### PR TITLE
Fix failing test

### DIFF
--- a/src/JsonRpc/OutputHandler.cs
+++ b/src/JsonRpc/OutputHandler.cs
@@ -19,7 +19,8 @@ namespace JsonRpc
             _output = output;
             _queue = new BlockingCollection<object>();
             _cancel = new CancellationTokenSource();
-            _thread = new Thread(ProcessOutputQueue) {
+            _thread = new Thread(ProcessOutputQueue)
+            {
                 IsBackground = true
             };
         }
@@ -37,11 +38,11 @@ namespace JsonRpc
         private void ProcessOutputQueue()
         {
             var token = _cancel.Token;
-            while (true)
+            try
             {
-                if (_thread == null) return;
-                try
+                while (true)
                 {
+                    if (_thread == null) return;
                     if (_queue.TryTake(out var value, Timeout.Infinite, token))
                     {
                         var content = JsonConvert.SerializeObject(value);
@@ -55,8 +56,14 @@ namespace JsonRpc
                         _output.Write(sb.ToString());
                     }
                 }
-                catch (OperationCanceledException) { }
             }
+            catch (OperationCanceledException ex)
+            {
+                if (ex.CancellationToken != token)
+                    throw;
+                // else ignore. Exceptions: OperationCanceledException - The CancellationToken has been canceled.
+            }
+            finally { _cancel.Dispose(); }
         }
 
         public void Dispose()

--- a/src/JsonRpc/OutputHandler.cs
+++ b/src/JsonRpc/OutputHandler.cs
@@ -19,8 +19,7 @@ namespace JsonRpc
             _output = output;
             _queue = new BlockingCollection<object>();
             _cancel = new CancellationTokenSource();
-            _thread = new Thread(ProcessOutputQueue)
-            {
+            _thread = new Thread(ProcessOutputQueue) {
                 IsBackground = true
             };
         }


### PR DESCRIPTION
Sorry for the trouble. I noticed not only until today, that my VS2017 only ran the Lsp.Tests but not the JsonRpc ones. I overlooked (1) that cancelling the token causes an ex when canceled and (2) that the CancellationTokenSource needs to be Disposed as well.

Martin