### PR TITLE
Awaiting the Shutdown of a LanguageServer

### DIFF
--- a/sample/SampleServer/Program.cs
+++ b/sample/SampleServer/Program.cs
@@ -29,8 +29,7 @@ namespace SampleServer
             server.AddHandler(new TextDocumentHandler(server));
 
             await server.Initialize();
-
-            await new TaskCompletionSource<object>().Task;
+            await server.WasShutDown;
         }
     }
 

--- a/src/Lsp/Abstractions/IAwaitableTermination.cs
+++ b/src/Lsp/Abstractions/IAwaitableTermination.cs
@@ -1,0 +1,7 @@
+﻿namespace Lsp
+{
+    public interface IAwaitableTermination
+    {
+        System.Threading.Tasks.Task WasShutDown { get; }
+    }
+}

--- a/src/Lsp/Handlers/ShutdownHandler.cs
+++ b/src/Lsp/Handlers/ShutdownHandler.cs
@@ -1,19 +1,24 @@
+﻿using System;
 using System.Threading.Tasks;
 using Lsp.Protocol;
 
 namespace Lsp.Handlers
 {
-    public class ShutdownHandler : IShutdownHandler
+    public class ShutdownHandler : IShutdownHandler, IAwaitableTermination
     {
         public Task Handle()
         {
             ShutdownRequested = true;
             Shutdown?.Invoke(ShutdownRequested);
+            shutdownSource.SetResult(true); // after all event sinks were notified
             return Task.CompletedTask;
         }
 
         public event ShutdownEventHandler Shutdown;
 
         public bool ShutdownRequested { get; private set; }
+
+        private TaskCompletionSource<bool> shutdownSource = new TaskCompletionSource<bool>(TaskContinuationOptions.LongRunning);
+        Task IAwaitableTermination.WasShutDown => shutdownSource.Task;
     }
 }

--- a/src/Lsp/LanguageServer.cs
+++ b/src/Lsp/LanguageServer.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Lsp
 {
-    public class LanguageServer : ILanguageServer, IInitializeHandler, IInitializedHandler, IDisposable
+    public class LanguageServer : ILanguageServer, IInitializeHandler, IInitializedHandler, IDisposable, IAwaitableTermination
     {
         private readonly Connection _connection;
         private readonly LspRequestRouter _requestRouter;
@@ -249,6 +249,8 @@ namespace Lsp
         {
             return _responseRouter.GetRequest(id);
         }
+
+        public Task WasShutDown => ((IAwaitableTermination)_shutdownHandler).WasShutDown;
 
         public void Dispose()
         {


### PR DESCRIPTION
The objective was to replace the never ending `await new TaskCompletionSource<object>().Task;` with an awaitable Task that would complete eventually: `await server.WasShutDown;` (I'd prefer `await server.Shutdown;` but that name was already taken by the event).

So I moved the `TaskCompletionSource` down to the `IShutdownHandler` that knows when a shutdown happens. Sorry, no test for that b/c I didn't find any test for `LanguageServer`.

Martin
