### PR TITLE
BugFix: content-length is counted in bytes

### DIFF
--- a/sample/SampleServer/Program.cs
+++ b/sample/SampleServer/Program.cs
@@ -24,7 +24,7 @@ namespace SampleServer
             //    await Task.Delay(100);
             //}
 
-            var server = new LanguageServer(Console.In, Console.Out);
+            var server = new LanguageServer(Console.OpenStandardInput(), Console.OpenStandardOutput());
 
             server.AddHandler(new TextDocumentHandler(server));
 

--- a/src/JsonRpc/Connection.cs
+++ b/src/JsonRpc/Connection.cs
@@ -18,7 +18,7 @@ namespace JsonRpc
         private readonly IRequestRouter _requestRouter;
 
         public Connection(
-            TextReader input,
+            Stream input,
             IOutputHandler outputHandler,
             IReciever reciever,
             IRequestProcessIdentifier requestProcessIdentifier,

--- a/src/JsonRpc/InputHandler.cs
+++ b/src/JsonRpc/InputHandler.cs
@@ -21,7 +21,7 @@ namespace JsonRpc
         public static char[] HeaderKeys = { CR, LF, ':' };
         public const short MinBuffer = 21; // Minimum size of the buffer "Content-Length: X\r\n\r\n"
 
-        private readonly TextReader _input;
+        private readonly Stream _input;
         private readonly IOutputHandler _outputHandler;
         private readonly IReciever _reciever;
         private readonly IRequestProcessIdentifier _requestProcessIdentifier;
@@ -32,7 +32,7 @@ namespace JsonRpc
         private Thread _queueThread;
 
         public InputHandler(
-            TextReader input,
+            Stream input,
             IOutputHandler outputHandler,
             IReciever reciever,
             IRequestProcessIdentifier requestProcessIdentifier,
@@ -40,6 +40,7 @@ namespace JsonRpc
             IResponseRouter responseRouter
             )
         {
+            if (!input.CanRead) throw new ArgumentException($"must provide a readable stream for {nameof(input)}", nameof(input));
             _input = input;
             _outputHandler = outputHandler;
             _reciever = reciever;
@@ -54,7 +55,7 @@ namespace JsonRpc
         }
 
         internal InputHandler(
-            TextReader input,
+            Stream input,
             IOutputHandler outputHandler,
             IReciever reciever,
             IRequestProcessIdentifier requestProcessIdentifier,
@@ -75,19 +76,23 @@ namespace JsonRpc
 
         private async void ProcessInputStream()
         {
+            // header is encoded in ASCII
+            // "Content-Length: 0" counts bytes for the following content
+            // content is encoded in UTF-8
             while (true)
             {
                 if (_inputThread == null) return;
 
-                var buffer = new char[300];
-                var current = await _input.ReadBlockAsync(buffer, 0, MinBuffer);
-                while (current < MinBuffer || buffer[current - 4] != CR || buffer[current - 3] != LF ||
+                var buffer = new byte[300];
+                var current = await _input.ReadAsync(buffer, 0, MinBuffer);
+                while (current < MinBuffer || 
+                       buffer[current - 4] != CR || buffer[current - 3] != LF ||
                        buffer[current - 2] != CR || buffer[current - 1] != LF)
                 {
-                    current += await _input.ReadBlockAsync(buffer, current, 1);
+                    current += await _input.ReadAsync(buffer, current, 1);
                 }
 
-                var headersContent = new string(buffer, 0, current);
+                var headersContent = System.Text.Encoding.ASCII.GetString(buffer, 0, current);
                 var headers = headersContent.Split(HeaderKeys, StringSplitOptions.RemoveEmptyEntries);
                 long length = 0;
                 for (var i = 0; i < headers.Length; i += 2)
@@ -100,11 +105,11 @@ namespace JsonRpc
                     }
                 }
 
-                var requestBuffer = new char[length];
+                var requestBuffer = new byte[length];
 
-                await _input.ReadBlockAsync(requestBuffer, 0, requestBuffer.Length);
+                await _input.ReadAsync(requestBuffer, 0, requestBuffer.Length);
 
-                var payload = new string(requestBuffer);
+                var payload = System.Text.Encoding.UTF8.GetString(requestBuffer);
 
                 HandleRequest(payload);
             }

--- a/src/JsonRpc/OutputHandler.cs
+++ b/src/JsonRpc/OutputHandler.cs
@@ -9,13 +9,14 @@ namespace JsonRpc
 {
     public class OutputHandler : IOutputHandler
     {
-        private readonly TextWriter _output;
+        private readonly Stream _output;
         private Thread _thread;
         private readonly BlockingCollection<object> _queue;
         private readonly CancellationTokenSource _cancel;
 
-        public OutputHandler(TextWriter output)
+        public OutputHandler(Stream output)
         {
+            if (!output.CanWrite) throw new ArgumentException($"must provide a writable stream for {nameof(output)}", nameof(output));
             _output = output;
             _queue = new BlockingCollection<object>();
             _cancel = new CancellationTokenSource();
@@ -45,14 +46,21 @@ namespace JsonRpc
                     if (_queue.TryTake(out var value, Timeout.Infinite, token))
                     {
                         var content = JsonConvert.SerializeObject(value);
+                        var contentBytes = System.Text.Encoding.UTF8.GetBytes(content);
 
                         // TODO: Is this lsp specific??
                         var sb = new StringBuilder();
-                        sb.Append($"Content-Length: {content.Length}\r\n");
+                        sb.Append($"Content-Length: {contentBytes.Length}\r\n");
                         sb.Append($"\r\n");
-                        sb.Append(content);
+                        var headerBytes = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
 
-                        _output.Write(sb.ToString());
+                        // only one write to _output
+                        using (var ms = new MemoryStream(headerBytes.Length + contentBytes.Length))
+                        {
+                            ms.Write(headerBytes, 0, headerBytes.Length);
+                            ms.Write(contentBytes, 0, contentBytes.Length);
+                            _output.Write(ms.ToArray(), 0, (int)ms.Position);
+                        }
                     }
                 }
                 catch (OperationCanceledException) { }

--- a/src/Lsp/LanguageServer.cs
+++ b/src/Lsp/LanguageServer.cs
@@ -29,13 +29,13 @@ namespace Lsp
         private readonly TaskCompletionSource<InitializeResult> _initializeComplete = new TaskCompletionSource<InitializeResult>();
         private readonly CompositeDisposable _disposable = new CompositeDisposable();
 
-        public LanguageServer(TextReader input, TextWriter output)
+        public LanguageServer(Stream input, Stream output)
             : this(input, new OutputHandler(output), new LspReciever(), new RequestProcessIdentifier())
         {
         }
 
         internal LanguageServer(
-            TextReader input,
+            Stream input,
             IOutputHandler output,
             LspReciever reciever,
             IRequestProcessIdentifier requestProcessIdentifier

--- a/test/JsonRpc.Tests/OutputHandlerTests.cs
+++ b/test/JsonRpc.Tests/OutputHandlerTests.cs
@@ -3,20 +3,21 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using NSubstitute;
+using FluentAssertions;
 using Xunit;
 
 namespace JsonRpc.Tests
 {
     public class OutputHandlerTests
     {
-        private static (OutputHandler handler, Func<Task> wait) NewHandler(TextWriter textWriter,Action<CancellationTokenSource> action)
+        private static (OutputHandler handler, Func<Task> wait) NewHandler(Stream Writer,Action<CancellationTokenSource> action)
         {
             var cts = new CancellationTokenSource();
             if (!System.Diagnostics.Debugger.IsAttached)
                 cts.CancelAfter(TimeSpan.FromSeconds(120));
             action(cts);
 
-            var handler = new OutputHandler(textWriter);
+            var handler = new OutputHandler(Writer);
             handler.Start();
             return (handler, () => {
                 cts.Wait();
@@ -27,11 +28,16 @@ namespace JsonRpc.Tests
         [Fact]
         public async Task ShouldSerializeValues()
         {
-            var tw = Substitute.For<TextWriter>();
+            var w = Substitute.For<Stream>();
+            var received = "";
+            w.CanWrite.Returns(true);
 
-            var (handler, wait) = NewHandler(tw, cts => {
-                tw.When(x => x.Write(Arg.Any<string>()))
-                    .Do(c => cts.Cancel());
+            var (handler, wait) = NewHandler(w, cts => {
+                w.When(x => x.Write(Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<int>()))
+                    .Do(c => {
+                        received = System.Text.Encoding.UTF8.GetString(c.ArgAt<byte[]>(0), 0, c.ArgAt<int>(2));
+                        cts.Cancel();
+                    });
             });
             var value = new JsonRpc.Client.Response(1);
 
@@ -40,8 +46,10 @@ namespace JsonRpc.Tests
 
                 handler.Send(value);
                 await wait();
-
-                tw.Received().Write("Content-Length: 46\r\n\r\n{\"protocolVersion\":\"2.0\",\"id\":1,\"result\":null}");
+                const string send = "Content-Length: 46\r\n\r\n{\"protocolVersion\":\"2.0\",\"id\":1,\"result\":null}";
+                received.Should().Be(send);
+                var b = System.Text.Encoding.UTF8.GetBytes(send);
+                w.Received().Write(Arg.Any<byte[]>(), 0, b.Length); // can't compare b here, because it is only value-equal and this test tests reference equality
             }
         }
     }


### PR DESCRIPTION
Hence we can't use TextReaders and TextWriters in In/OutputHandlers, because otherwise reading chars when there is only a bytes count would be really hard. So I converted everything to streams plus UTF8 Encoding methods plus some test enhancements.

This change is _important_, because otherwise there is _no_ parsing of text containing non-ASCII characters, which is quite common outside of the US ;-) With it, I can now parse a real Coco/R grammar with a real example :-)

Note: This fix is based on the _current_ OmniSharp/master. As it is some fixes behind, I expect some manual merging.

Martin