### PR TITLE
TextDocumentItem inheritance

### DIFF
--- a/src/Lsp/Models/TextDocumentItem.cs
+++ b/src/Lsp/Models/TextDocumentItem.cs
@@ -5,13 +5,8 @@ using Newtonsoft.Json.Serialization;
 namespace Lsp.Models
 {
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-    public class TextDocumentItem
+    public class TextDocumentItem : TextDocumentIdentifier
     {
-        /// <summary>
-        /// The text document's URI.
-        /// </summary>
-        public Uri Uri { get; set; }
-
         /// <summary>
         /// The text document's language identifier.
         /// </summary>

--- a/test/Lsp.Tests/Models/DidOpenTextDocumentParamsTests_$SimpleTest.json
+++ b/test/Lsp.Tests/Models/DidOpenTextDocumentParamsTests_$SimpleTest.json
@@ -1,8 +1,8 @@
 ﻿{
     "textDocument": {
-        "uri": "file:///abc/def.cs",
         "languageId": "csharp",
         "version": 1,
-        "text": "content"
+        "text": "content",
+        "uri": "file:///abc/def.cs"
     }
 }

--- a/test/Lsp.Tests/Models/TextDocumentItemTests_$SimpleTest.json
+++ b/test/Lsp.Tests/Models/TextDocumentItemTests_$SimpleTest.json
@@ -1,6 +1,6 @@
 ﻿{
-    "uri": "file:///abc/def.cs",
     "languageId": "csharp",
     "version": 1,
-    "text": "content"
+    "text": "content",
+    "uri": "file:///abc/def.cs"
 }


### PR DESCRIPTION
TextDocumentItem inherits it's Uri from TextDocumentIdentifier now, just as several other classes with an Uri.  Tests had to be adapted, b/c the results are only JSON-functional equivalent to the original ones. I guess, that's acceptable.

It would be even better to have an Interface for things that have a read-only Uri instead of a base class: `IHaveAUri`.