### PR TITLE
Skip dynamic registration of server capabilities if client does not support it

### DIFF
--- a/src/JsonRpc/JsonRpc.csproj
+++ b/src/JsonRpc/JsonRpc.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
         <PlatformTarget>AnyCPU</PlatformTarget>
+        <LangVersion>Latest</LangVersion>
         <!-- Needed for Microsoft.Composition -->
         <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dotnet5.4;portable-net45+win8</PackageTargetFallback>
         <PackageVersion Condition="'$(GitVersion_NuGetVersion)' != ''">$(GitVersion_NuGetVersion)</PackageVersion>

--- a/src/Lsp/LanguageServer.cs
+++ b/src/Lsp/LanguageServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -212,6 +212,9 @@ namespace Lsp
             {
                 registrations.Add(handler.Registration);
             }
+
+            if (registrations.Count == 0)
+                return; // No dynamic registrations supported by client.
 
             var @params = new RegistrationParams() { Registrations = registrations };
 


### PR DESCRIPTION
As noted by LSP protocol docs, clients do not have to support this:

https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#new-register-capability

And if the client does not support this, it currently causes LanguageServer.Initialize to hang (since the resulting exception is not handled correctly).