### PR TITLE
Avoid NullReferenceException if "params" property is null.

### DIFF
--- a/src/JsonRpc/Client/Request.cs
+++ b/src/JsonRpc/Client/Request.cs
@@ -12,6 +12,7 @@ namespace OmniSharp.Extensions.JsonRpc.Client
 
         public string Method { get; set; }
 
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public object Params { get; set; }
     }
 }

--- a/src/JsonRpc/Reciever.cs
+++ b/src/JsonRpc/Reciever.cs
@@ -54,7 +54,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
             object requestId = null;
             bool hasRequestId;
-            if (hasRequestId = request.TryGetValue("id", out var id) && requestId != null)
+            if (hasRequestId = request.TryGetValue("id", out var id))
             {
                 var idString = id.Type == JTokenType.String ? (string)id : null;
                 var idLong = id.Type == JTokenType.Integer ? (long?)id : null;
@@ -77,8 +77,8 @@ namespace OmniSharp.Extensions.JsonRpc
                 return new InvalidRequest(requestId, "Method not set");
             }
 
-            var hasParams = request.TryGetValue("params", out var @params) && @params != null;
-            if (hasParams && @params.Type != JTokenType.Array && @params.Type != JTokenType.Object)
+            var hasParams = request.TryGetValue("params", out var @params);
+            if (hasParams && @params?.Type != JTokenType.Array && @params?.Type != JTokenType.Object)
             {
                 return new InvalidRequest(requestId, "Invalid params");
             }

--- a/src/JsonRpc/Reciever.cs
+++ b/src/JsonRpc/Reciever.cs
@@ -54,7 +54,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
             object requestId = null;
             bool hasRequestId;
-            if (hasRequestId = request.TryGetValue("id", out var id))
+            if (hasRequestId = request.TryGetValue("id", out var id) && requestId != null)
             {
                 var idString = id.Type == JTokenType.String ? (string)id : null;
                 var idLong = id.Type == JTokenType.Integer ? (long?)id : null;
@@ -77,7 +77,7 @@ namespace OmniSharp.Extensions.JsonRpc
                 return new InvalidRequest(requestId, "Method not set");
             }
 
-            var hasParams = request.TryGetValue("params", out var @params);
+            var hasParams = request.TryGetValue("params", out var @params) && @params != null;
             if (hasParams && @params.Type != JTokenType.Array && @params.Type != JTokenType.Object)
             {
                 return new InvalidRequest(requestId, "Invalid params");


### PR DESCRIPTION
Specific fix for OmniSharp/csharp-language-server-protocol#24 (a more general fix will be offered as a separate PR).