### PR TITLE
Modified ExecuteCommandHandler parsing on the LSPRequestRouter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ buildlog
 # Build folder
 tools/*/
 /tools/packages.config.md5sum
+
+.idea

--- a/src/Lsp/Abstractions/IHanderMatcherCollection.cs
+++ b/src/Lsp/Abstractions/IHanderMatcherCollection.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace OmniSharp.Extensions.LanguageServer.Abstractions
+{
+    public interface IHandlerMatcherCollection : IEnumerable<IHandlerMatcher>
+    {
+        IDisposable Add(IHandlerMatcher handler);
+    }
+}

--- a/src/Lsp/Abstractions/IHandlerMatch.cs
+++ b/src/Lsp/Abstractions/IHandlerMatch.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using OmniSharp.Extensions.JsonRpc.Server;
+
+namespace OmniSharp.Extensions.LanguageServer.Abstractions
+{
+    public interface IHandlerMatcher
+    {
+        /// <summary>
+        /// Finds the first handler that matches the parameters.
+        /// </summary>
+        /// <param name="parameters">The parameters.</param>
+        /// <param name="descriptors">The descriptors.</param>
+        /// <returns></returns>
+        IEnumerable<ILspHandlerDescriptor> FindHandler(object parameters, IEnumerable<ILspHandlerDescriptor> descriptors);
+    }
+}

--- a/src/Lsp/Capabilities/Server/ExecuteCommandOptions.cs
+++ b/src/Lsp/Capabilities/Server/ExecuteCommandOptions.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using OmniSharp.Extensions.LanguageServer.Models;
 
@@ -15,9 +17,9 @@ namespace OmniSharp.Extensions.LanguageServer.Capabilities.Server
         /// </summary>
         public Container<string> Commands { get; set; }
 
-        public static ExecuteCommandOptions Of(IExecuteCommandOptions options)
+        public static ExecuteCommandOptions Of(IEnumerable<IExecuteCommandOptions> options)
         {
-            return new ExecuteCommandOptions() { Commands = options.Commands };
+            return new ExecuteCommandOptions() { Commands = options.SelectMany(x => x.Commands).ToArray() };
         }
     }
 }

--- a/src/Lsp/HandlerMatcherCollection.cs
+++ b/src/Lsp/HandlerMatcherCollection.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OmniSharp.Extensions.LanguageServer.Abstractions;
+
+namespace OmniSharp.Extensions.LanguageServer
+{
+    public class HandlerMatcherCollection : IHandlerMatcherCollection
+    {
+        internal readonly HashSet<IHandlerMatcher> _handlers = new HashSet<IHandlerMatcher>();
+
+        public IEnumerator<IHandlerMatcher> GetEnumerator()
+        {
+            return _handlers.GetEnumerator();
+        }
+
+        public IDisposable Add(IHandlerMatcher handler)
+        {
+            _handlers.Add(handler);
+            return new Disposable(() => _handlers.Remove(handler));
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Lsp/Lsp.csproj
+++ b/src/Lsp/Lsp.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <AssemblyName>OmniSharp.Extensions.LanguageServerProtocol</AssemblyName>
-        <RootNamespace>OmniSharp.Extensions.LanguageServer</RootNamespace>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-        <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-        <ProjectReference Include="..\JsonRpc\JsonRpc.csproj" />
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <AssemblyName>OmniSharp.Extensions.LanguageServerProtocol</AssemblyName>
+    <RootNamespace>OmniSharp.Extensions.LanguageServer</RootNamespace>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <ProjectReference Include="..\JsonRpc\JsonRpc.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Lsp/Matchers/ExecuteCommandMatcher.cs
+++ b/src/Lsp/Matchers/ExecuteCommandMatcher.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.LanguageServer.Abstractions;
+using OmniSharp.Extensions.LanguageServer.Models;
+
+namespace OmniSharp.Extensions.LanguageServer.Matchers
+{
+    public class ExecuteCommandMatcher : IHandlerMatcher
+    {
+        private readonly ILogger _logger;
+
+        public ExecuteCommandMatcher(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Finds the first handler that matches the parameters.
+        /// </summary>
+        /// <param name="parameters">The parameters.</param>
+        /// <param name="descriptors">The descriptors.</param>
+        /// <returns></returns>
+        public IEnumerable<ILspHandlerDescriptor> FindHandler(object parameters, IEnumerable<ILspHandlerDescriptor> descriptors)
+        {
+            if (parameters is ExecuteCommandParams executeCommandParams)
+            {
+                _logger.LogTrace("Registration options {OptionsName}", executeCommandParams.GetType().FullName);
+                foreach (var descriptor in descriptors)
+                {
+                    if (descriptor.Registration.RegisterOptions is ExecuteCommandRegistrationOptions registrationOptions && registrationOptions.Commands.Any(x => x == executeCommandParams.Command))
+                    {
+                        _logger.LogTrace("Checking handler {Method}:{Handler}",
+                            executeCommandParams.Command,
+                            executeCommandParams.GetType().FullName);
+                        yield return descriptor;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Lsp/Matchers/TextDocumentMatcher.cs
+++ b/src/Lsp/Matchers/TextDocumentMatcher.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.LanguageServer.Abstractions;
+using OmniSharp.Extensions.LanguageServer.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+
+namespace OmniSharp.Extensions.LanguageServer.Matchers
+{
+    public class TextDocumentMatcher : IHandlerMatcher
+    {
+        private readonly ILogger _logger;
+
+        public TextDocumentMatcher(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public IEnumerable<ILspHandlerDescriptor> FindHandler(object parameters, IEnumerable<ILspHandlerDescriptor> descriptors)
+        {
+            switch (parameters)
+            {
+                case ITextDocumentIdentifierParams textDocumentIdentifierParams:
+                    {
+                        var attributes = GetTextDocumentAttributes(descriptors, textDocumentIdentifierParams.TextDocument.Uri);
+
+                        _logger.LogTrace("Found attributes {Count}, {Attributes}", attributes.Count, attributes.Select(x => $"{x.LanguageId}:{x.Scheme}:{x.Uri}"));
+
+                        return GetHandler(descriptors, attributes);
+                    }
+                case DidOpenTextDocumentParams openTextDocumentParams:
+                    {
+                        var attributes = new TextDocumentAttributes(openTextDocumentParams.TextDocument.Uri, openTextDocumentParams.TextDocument.LanguageId);
+
+                        _logger.LogTrace("Created attribute {Attribute}", $"{attributes.LanguageId}:{attributes.Scheme}:{attributes.Uri}");
+
+                        return GetHandler(descriptors, attributes);
+                    }
+                case DidChangeTextDocumentParams didChangeDocumentParams:
+                    {
+                        // TODO: Do something with document version here?
+                        var attributes = GetTextDocumentAttributes(descriptors, didChangeDocumentParams.TextDocument.Uri);
+
+                        _logger.LogTrace("Found attributes {Count}, {Attributes}", attributes.Count, attributes.Select(x => $"{x.LanguageId}:{x.Scheme}:{x.Uri}"));
+
+                        return GetHandler(descriptors, attributes);
+                    }
+            }
+
+            return Enumerable.Empty<ILspHandlerDescriptor>();
+        }
+
+        private List<TextDocumentAttributes> GetTextDocumentAttributes(IEnumerable<ILspHandlerDescriptor> method, Uri uri)
+        {
+            var textDocumentSyncHandlers = method
+                .Select(x => x.Handler is ITextDocumentSyncHandler r ? r : null)
+                .Where(x => x != null)
+                .Distinct();
+            return textDocumentSyncHandlers
+                .Select(x => x.GetTextDocumentAttributes(uri))
+                .Where(x => x != null)
+                .Distinct()
+                .ToList();
+        }
+
+        private IEnumerable<ILspHandlerDescriptor> GetHandler(IEnumerable<ILspHandlerDescriptor> method, IEnumerable<TextDocumentAttributes> attributes)
+        {
+            return attributes
+                .SelectMany(x => GetHandler(method, x));
+        }
+
+        private IEnumerable<ILspHandlerDescriptor> GetHandler(IEnumerable<ILspHandlerDescriptor> method, TextDocumentAttributes attributes)
+        {
+            _logger.LogTrace("Looking for handler for method {Method}", method);
+            foreach (var handler in method)
+            {
+                _logger.LogTrace("Checking handler {Method}:{Handler}", method, handler.Handler.GetType().FullName);
+                var registrationOptions = handler.Registration.RegisterOptions as TextDocumentRegistrationOptions;
+
+                _logger.LogTrace("Registration options {OptionsName}", registrationOptions.GetType().FullName);
+                _logger.LogTrace("Document Selector {DocumentSelector}", registrationOptions.DocumentSelector.ToString());
+                if (registrationOptions.DocumentSelector == null || registrationOptions.DocumentSelector.IsMatch(attributes))
+                {
+                    _logger.LogTrace("Handler Selected: {Handler} via {DocumentSelector} (targeting {HandlerInterface})", handler.Handler.GetType().FullName, registrationOptions.DocumentSelector.ToString(), handler.HandlerType.GetType().FullName);
+                    yield return handler;
+                }
+            }
+        }
+    }
+}

--- a/src/Lsp/Models/Command.cs
+++ b/src/Lsp/Models/Command.cs
@@ -1,9 +1,9 @@
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Models
 {
-
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class Command
     {
@@ -22,6 +22,7 @@ namespace OmniSharp.Extensions.LanguageServer.Models
         /// Arguments that the command handler should be
         /// invoked with.
         /// </summary>
-        public ObjectContainer Arguments { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public JArray Arguments { get; set; }
     }
 }

--- a/src/Lsp/Models/DidChangeTextDocumentParams.cs
+++ b/src/Lsp/Models/DidChangeTextDocumentParams.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.LanguageServer.Abstractions;
 
 namespace OmniSharp.Extensions.LanguageServer.Models
 {

--- a/src/Lsp/Models/DidOpenTextDocumentParams.cs
+++ b/src/Lsp/Models/DidOpenTextDocumentParams.cs
@@ -1,5 +1,6 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.LanguageServer.Abstractions;
 
 namespace OmniSharp.Extensions.LanguageServer.Models
 {

--- a/src/Lsp/Models/ExecuteCommandParams.cs
+++ b/src/Lsp/Models/ExecuteCommandParams.cs
@@ -1,20 +1,22 @@
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.LanguageServer.Abstractions;
 
 namespace OmniSharp.Extensions.LanguageServer.Models
 {
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class ExecuteCommandParams
     {
-
         /// <summary>
         /// The identifier of the actual command handler.
         /// </summary>
         public string Command { get; set; }
+
         /// <summary>
         /// Arguments that the command should be invoked with.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public ObjectContainer Arguments { get; set; }
+        public JArray Arguments { get; set; }
     }
 }

--- a/test/Lsp.Tests/ExecuteCommandSyncHandlerExtensions.cs
+++ b/test/Lsp.Tests/ExecuteCommandSyncHandlerExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using OmniSharp.Extensions.LanguageServer.Abstractions;
+using OmniSharp.Extensions.LanguageServer.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+
+namespace Lsp.Tests
+{
+    internal static class ExecuteCommandSyncHandlerExtensions
+    {
+        public static IExecuteCommandHandler With(Container<string> commands)
+        {
+            return Substitute.For<IExecuteCommandHandler>().With(commands);
+        }
+
+        public static IExecuteCommandHandler With(this IExecuteCommandHandler handler, Container<string> commands)
+        {
+            ((IExecuteCommandHandler)handler).GetRegistrationOptions().Returns(new ExecuteCommandRegistrationOptions { Commands = commands });
+
+            handler.Handle(Arg.Any<ExecuteCommandParams>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+
+            return handler;
+        }
+    }
+}

--- a/test/Lsp.Tests/Lsp.Tests.csproj
+++ b/test/Lsp.Tests/Lsp.Tests.csproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
-        <WarningsAsErrors>true</WarningsAsErrors>
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    </PropertyGroup>
-    <ItemGroup>
-        <None Remove="**\*.json" />
-        <EmbeddedResource Include="**\*.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Lsp\Lsp.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="4.19.4" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-        <PackageReference Include="NSubstitute" Version="2.0.3" />
-        <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
-        <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.4" />
-        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <WarningsAsErrors>true</WarningsAsErrors>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Remove="**\*.json" />
+    <EmbeddedResource Include="**\*.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Lsp\Lsp.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
+    <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.4" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
+  </ItemGroup>
 </Project>

--- a/test/Lsp.Tests/LspRequestRouterTests.cs
+++ b/test/Lsp.Tests/LspRequestRouterTests.cs
@@ -4,11 +4,14 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
 using OmniSharp.Extensions.JsonRpc.Server;
 using OmniSharp.Extensions.LanguageServer;
+using OmniSharp.Extensions.LanguageServer.Abstractions;
+using OmniSharp.Extensions.LanguageServer.Matchers;
 using OmniSharp.Extensions.LanguageServer.Messages;
 using OmniSharp.Extensions.LanguageServer.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol;
@@ -23,10 +26,17 @@ namespace Lsp.Tests
     public class LspRequestRouterTests
     {
         private readonly TestLoggerFactory _testLoggerFactory;
+        private readonly IHandlerMatcherCollection _handlerMatcherCollection = new HandlerMatcherCollection();
 
         public LspRequestRouterTests(ITestOutputHelper testOutputHelper)
         {
             _testLoggerFactory = new TestLoggerFactory(testOutputHelper);
+            var logger = Substitute.For<ILogger>();
+            var matcher = Substitute.For<IHandlerMatcher>();
+            matcher.FindHandler(Arg.Any<object>(), Arg.Any<IEnumerable<ILspHandlerDescriptor>>())
+                .Returns(new List<HandlerDescriptor>());
+
+            _handlerMatcherCollection.Add(matcher);
         }
 
         [Fact]
@@ -36,7 +46,7 @@ namespace Lsp.Tests
             textDocumentSyncHandler.Handle(Arg.Any<DidSaveTextDocumentParams>()).Returns(Task.CompletedTask);
 
             var collection = new HandlerCollection { textDocumentSyncHandler };
-            var mediator = new LspRequestRouter(collection, _testLoggerFactory);
+            var mediator = new LspRequestRouter(collection, _testLoggerFactory, _handlerMatcherCollection);
 
             var @params = new DidSaveTextDocumentParams() {
                 TextDocument = new TextDocumentIdentifier(new Uri("file:///c:/test/123.cs"))
@@ -58,7 +68,7 @@ namespace Lsp.Tests
             textDocumentSyncHandler2.Handle(Arg.Any<DidSaveTextDocumentParams>()).Returns(Task.CompletedTask);
 
             var collection = new HandlerCollection { textDocumentSyncHandler, textDocumentSyncHandler2 };
-            var mediator = new LspRequestRouter(collection, _testLoggerFactory);
+            var mediator = new LspRequestRouter(collection, _testLoggerFactory, _handlerMatcherCollection);
 
             var @params = new DidSaveTextDocumentParams() {
                 TextDocument = new TextDocumentIdentifier(new Uri("file:///c:/test/123.cake"))
@@ -68,8 +78,8 @@ namespace Lsp.Tests
 
             await mediator.RouteNotification(mediator.GetDescriptor(request), request);
 
-            await textDocumentSyncHandler.Received(0).Handle(Arg.Any<DidSaveTextDocumentParams>());
-            await textDocumentSyncHandler2.Received(1).Handle(Arg.Any<DidSaveTextDocumentParams>());
+            await textDocumentSyncHandler.Received(1).Handle(Arg.Any<DidSaveTextDocumentParams>());
+            await textDocumentSyncHandler2.Received(0).Handle(Arg.Any<DidSaveTextDocumentParams>());
         }
 
         [Fact]
@@ -85,7 +95,7 @@ namespace Lsp.Tests
                 .Returns(new CommandContainer());
 
             var collection = new HandlerCollection { textDocumentSyncHandler, codeActionHandler };
-            var mediator = new LspRequestRouter(collection, _testLoggerFactory);
+            var mediator = new LspRequestRouter(collection, _testLoggerFactory, _handlerMatcherCollection);
 
             var id = Guid.NewGuid().ToString();
             var @params = new DidSaveTextDocumentParams() {
@@ -120,7 +130,7 @@ namespace Lsp.Tests
                 .Returns(new CommandContainer());
 
             var collection = new HandlerCollection { textDocumentSyncHandler, textDocumentSyncHandler2, codeActionHandler, codeActionHandler2 };
-            var mediator = new LspRequestRouter(collection, _testLoggerFactory);
+            var mediator = new LspRequestRouter(collection, _testLoggerFactory, _handlerMatcherCollection);
 
             var id = Guid.NewGuid().ToString();
             var @params = new DidSaveTextDocumentParams() {
@@ -131,8 +141,8 @@ namespace Lsp.Tests
 
             await mediator.RouteRequest(mediator.GetDescriptor(request), request);
 
-            await codeActionHandler.Received(0).Handle(Arg.Any<CodeActionParams>(), Arg.Any<CancellationToken>());
-            await codeActionHandler2.Received(1).Handle(Arg.Any<CodeActionParams>(), Arg.Any<CancellationToken>());
+            await codeActionHandler.Received(1).Handle(Arg.Any<CodeActionParams>(), Arg.Any<CancellationToken>());
+            await codeActionHandler2.Received(0).Handle(Arg.Any<CodeActionParams>(), Arg.Any<CancellationToken>());
         }
     }
 }

--- a/test/Lsp.Tests/Matchers/ExecuteCommandHandlerMatcherTests.cs
+++ b/test/Lsp.Tests/Matchers/ExecuteCommandHandlerMatcherTests.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using OmniSharp.Extensions.LanguageServer;
+using OmniSharp.Extensions.LanguageServer.Abstractions;
+using OmniSharp.Extensions.LanguageServer.Capabilities.Client;
+using OmniSharp.Extensions.LanguageServer.Matchers;
+using OmniSharp.Extensions.LanguageServer.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using Xunit;
+
+namespace Lsp.Tests.Matchers
+{
+    public class ExecuteCommandHandlerMatcherTests
+    {
+        private readonly ILogger _logger;
+
+        public ExecuteCommandHandlerMatcherTests()
+        {
+            _logger = Substitute.For<ILogger>();
+        }
+
+        [Fact]
+        public void Should_Not_Return_Null()
+        {
+            // Given
+            var handlerDescriptors = Enumerable.Empty<ILspHandlerDescriptor>();
+            var handlerMatcher = new ExecuteCommandMatcher(_logger);
+
+            // When
+            var result = handlerMatcher.FindHandler(1, handlerDescriptors);
+
+            // Then
+            result.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Should_Return_Empty_Descriptor()
+        {
+            // Given
+            var handlerDescriptors = Enumerable.Empty<ILspHandlerDescriptor>();
+            var handlerMatcher = new ExecuteCommandMatcher(_logger);
+
+            // When
+            var result = handlerMatcher.FindHandler(1, handlerDescriptors);
+
+            // Then
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Should_Return_Handler_Descriptor()
+        {
+            // Given
+            var handlerMatcher = new ExecuteCommandMatcher(_logger);
+            var executeCommandHandler = Substitute.For<IExecuteCommandHandler>().With(new Container<string>("Command"));
+
+            // When
+            var result = handlerMatcher.FindHandler(new ExecuteCommandParams { Command = "Command" },
+                new List<HandlerDescriptor> {
+                    new HandlerDescriptor("workspace/executeCommand",
+                        "Key",
+                        executeCommandHandler,
+                        executeCommandHandler.GetType(),
+                        typeof(ExecuteCommandParams),
+                        typeof(ExecuteCommandRegistrationOptions),
+                        typeof(ExecuteCommandCapability),
+                        () => { })
+                });
+
+            // Then
+            result.Should().NotBeNullOrEmpty();
+            result.Should().Contain(x => x.Method == "workspace/executeCommand");
+        }
+    }
+}

--- a/test/Lsp.Tests/Matchers/TextDocumentMatcherTests.cs
+++ b/test/Lsp.Tests/Matchers/TextDocumentMatcherTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using OmniSharp.Extensions.LanguageServer;
+using OmniSharp.Extensions.LanguageServer.Abstractions;
+using OmniSharp.Extensions.LanguageServer.Capabilities.Client;
+using OmniSharp.Extensions.LanguageServer.Matchers;
+using OmniSharp.Extensions.LanguageServer.Models;
+using Xunit;
+
+namespace Lsp.Tests.Matchers
+{
+    public class TextDocumentMatcherTests
+    {
+        private readonly ILogger _logger;
+
+        public TextDocumentMatcherTests()
+        {
+            _logger = Substitute.For<ILogger>();
+        }
+
+        [Fact]
+        public void Should_Not_Return_Null()
+        {
+            // Given
+            var handlerDescriptors = Enumerable.Empty<ILspHandlerDescriptor>();
+            var handlerMatcher = new TextDocumentMatcher(_logger);
+
+            // When
+            var result = handlerMatcher.FindHandler(1, handlerDescriptors);
+
+            // Then
+            result.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Should_Return_Empty_Descriptor()
+        {
+            // Given
+            var handlerDescriptors = Enumerable.Empty<ILspHandlerDescriptor>();
+
+            var handlerMatcher = new TextDocumentMatcher(_logger);
+
+            // When
+            var result = handlerMatcher.FindHandler(1, handlerDescriptors);
+
+            // Then
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Should_Return_Did_Open_Text_Document_Handler_Descriptor()
+        {
+            // Given
+            var handlerMatcher = new TextDocumentMatcher(_logger);
+            var textDocumentSyncHandler =
+                TextDocumentSyncHandlerExtensions.With(DocumentSelector.ForPattern("**/*.cs"));
+
+            // When
+            var result = handlerMatcher.FindHandler(new DidOpenTextDocumentParams() {
+                TextDocument = new TextDocumentItem {
+                    Uri = new Uri("file:///abc/123/d.cs")
+                }
+            },
+                new List<HandlerDescriptor>() {
+                    new HandlerDescriptor("textDocument/didOpen",
+                        "Key",
+                        textDocumentSyncHandler,
+                        textDocumentSyncHandler.GetType(),
+                        typeof(DidOpenTextDocumentParams),
+                        typeof(TextDocumentRegistrationOptions),
+                        typeof(TextDocumentClientCapabilities),
+                        () => { })
+                });
+
+            // Then
+            result.Should().NotBeNullOrEmpty();
+            result.Should().Contain(x => x.Method == "textDocument/didOpen");
+        }
+
+        [Fact]
+        public void Should_Return_Did_Change_Text_Document_Descriptor()
+        {
+            // Given
+            var handlerMatcher = new TextDocumentMatcher(_logger);
+            var textDocumentSyncHandler =
+                TextDocumentSyncHandlerExtensions.With(DocumentSelector.ForPattern("**/*.cs"));
+
+            // When
+            var result = handlerMatcher.FindHandler(new DidChangeTextDocumentParams() {
+                TextDocument = new VersionedTextDocumentIdentifier { Uri = new Uri("file:///abc/123/d.cs"), Version = 1 }
+            },
+                new List<HandlerDescriptor>() {
+                    new HandlerDescriptor("textDocument/didChange",
+                        "Key",
+                        textDocumentSyncHandler,
+                        textDocumentSyncHandler.GetType(),
+                        typeof(DidOpenTextDocumentParams),
+                        typeof(TextDocumentRegistrationOptions),
+                        typeof(TextDocumentClientCapabilities),
+                        () => { })
+                });
+
+            // Then
+            result.Should().NotBeNullOrEmpty();
+            result.Should().Contain(x => x.Method == "textDocument/didChange");
+        }
+
+        [Fact]
+        public void Should_Return_Did_Save_Text_Document_Descriptor()
+        {
+            // Given
+            var handlerMatcher = new TextDocumentMatcher(_logger);
+            var textDocumentSyncHandler =
+                TextDocumentSyncHandlerExtensions.With(DocumentSelector.ForPattern("**/*.cs"));
+
+            // When
+            var result = handlerMatcher.FindHandler(new DidChangeTextDocumentParams() {
+                TextDocument = new VersionedTextDocumentIdentifier { Uri = new Uri("file:///abc/123/d.cs"), Version = 1 }
+            },
+                new List<HandlerDescriptor>() {
+                    new HandlerDescriptor("textDocument/didSave",
+                        "Key",
+                        textDocumentSyncHandler,
+                        textDocumentSyncHandler.GetType(),
+                        typeof(DidOpenTextDocumentParams),
+                        typeof(TextDocumentRegistrationOptions),
+                        typeof(TextDocumentClientCapabilities),
+                        () => { })
+                });
+
+            // Then
+            result.Should().NotBeNullOrEmpty();
+            result.Should().Contain(x => x.Method == "textDocument/didSave");
+        }
+
+        [Fact]
+        public void Should_Return_Did_Close_Text_Document_Descriptor()
+        {
+            // Given
+            var handlerMatcher = new TextDocumentMatcher(_logger);
+            var textDocumentSyncHandler =
+                TextDocumentSyncHandlerExtensions.With(DocumentSelector.ForPattern("**/*.cs"));
+
+            // When
+            var result = handlerMatcher.FindHandler(new DidCloseTextDocumentParams() {
+                TextDocument = new VersionedTextDocumentIdentifier { Uri = new Uri("file:///abc/123/d.cs"), Version = 1 }
+            },
+                new List<HandlerDescriptor>() {
+                    new HandlerDescriptor("textDocument/didClose",
+                        "Key",
+                        textDocumentSyncHandler,
+                        textDocumentSyncHandler.GetType(),
+                        typeof(DidOpenTextDocumentParams),
+                        typeof(TextDocumentRegistrationOptions),
+                        typeof(TextDocumentClientCapabilities),
+                        () => { })
+                });
+
+            // Then
+            result.Should().NotBeNullOrEmpty();
+            result.Should().Contain(x => x.Method == "textDocument/didClose");
+        }
+    }
+}

--- a/test/Lsp.Tests/MediatorTestsRequestHandlerOfTRequest.cs
+++ b/test/Lsp.Tests/MediatorTestsRequestHandlerOfTRequest.cs
@@ -17,12 +17,14 @@ using Xunit.Abstractions;
 using Xunit.Sdk;
 using HandlerCollection = OmniSharp.Extensions.LanguageServer.HandlerCollection;
 using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Abstractions;
 
 namespace Lsp.Tests
 {
     public class MediatorTestsRequestHandlerOfTRequest
     {
         private readonly TestLoggerFactory _testLoggerFactory;
+        private readonly IHandlerMatcherCollection _handlerMatcherCollection = new HandlerMatcherCollection();
 
         public MediatorTestsRequestHandlerOfTRequest(ITestOutputHelper testOutputHelper)
         {
@@ -41,7 +43,7 @@ namespace Lsp.Tests
                 });
 
             var collection = new HandlerCollection { executeCommandHandler };
-            var mediator = new LspRequestRouter(collection, _testLoggerFactory);
+            var mediator = new LspRequestRouter(collection, _testLoggerFactory, _handlerMatcherCollection);
 
             var id = Guid.NewGuid().ToString();
             var @params = new ExecuteCommandParams() { Command = "123" };
@@ -54,6 +56,5 @@ namespace Lsp.Tests
             result.IsError.Should().BeTrue();
             result.Error.ShouldBeEquivalentTo(new RequestCancelled());
         }
-
     }
 }

--- a/test/Lsp.Tests/MediatorTestsRequestHandlerOfTRequestTResponse.cs
+++ b/test/Lsp.Tests/MediatorTestsRequestHandlerOfTRequestTResponse.cs
@@ -19,12 +19,14 @@ using Xunit.Abstractions;
 using Xunit.Sdk;
 using HandlerCollection = OmniSharp.Extensions.LanguageServer.HandlerCollection;
 using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Abstractions;
 
 namespace Lsp.Tests
 {
     public class MediatorTestsRequestHandlerOfTRequestTResponse
     {
         private readonly TestLoggerFactory _testLoggerFactory;
+        private readonly IHandlerMatcherCollection _handlerMatcherCollection = new HandlerMatcherCollection();
 
         public MediatorTestsRequestHandlerOfTRequestTResponse(ITestOutputHelper testOutputHelper)
         {
@@ -48,7 +50,7 @@ namespace Lsp.Tests
                 });
 
             var collection = new HandlerCollection { textDocumentSyncHandler, codeActionHandler };
-            var mediator = new LspRequestRouter(collection, _testLoggerFactory);
+            var mediator = new LspRequestRouter(collection, _testLoggerFactory, _handlerMatcherCollection);
 
             var id = Guid.NewGuid().ToString();
             var @params = new CodeActionParams() {
@@ -68,6 +70,5 @@ namespace Lsp.Tests
             result.IsError.Should().BeTrue();
             result.Error.ShouldBeEquivalentTo(new RequestCancelled());
         }
-
     }
 }

--- a/test/Lsp.Tests/Models/CodeLensTests.cs
+++ b/test/Lsp.Tests/Models/CodeLensTests.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Models;
 using Xunit;
 
@@ -14,7 +15,7 @@ namespace Lsp.Tests.Models
         {
             var model = new CodeLens() {
                 Command = new Command() {
-                    Arguments = new object[] { 1, "2", true },
+                    Arguments = new JArray { 1, "2", true },
                     Name = "abc",
                     Title = "Cool story bro"
                 },

--- a/test/Lsp.Tests/Models/CommandTests.cs
+++ b/test/Lsp.Tests/Models/CommandTests.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using FluentAssertions;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Models;
 using Xunit;
 
@@ -12,7 +13,7 @@ namespace Lsp.Tests.Models
         public void SimpleTest(string expected)
         {
             var model = new Command() {
-                Arguments = new object[] { 1, "2", true },
+                Arguments = new JArray { 1, "2", true },
                 Name = "abc",
                 Title = "Cool story bro"
             };

--- a/test/Lsp.Tests/Models/ExecuteCommandParamsTests.cs
+++ b/test/Lsp.Tests/Models/ExecuteCommandParamsTests.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using FluentAssertions;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Models;
 using Xunit;
 
@@ -12,7 +13,7 @@ namespace Lsp.Tests.Models
         public void SimpleTest(string expected)
         {
             var model = new ExecuteCommandParams() {
-                Arguments = new ObjectContainer(1, "2"),
+                Arguments = new JArray(1, "2"),
                 Command = "command"
             };
             var result = Fixture.SerializeObject(model);


### PR DESCRIPTION
Added Reduce method to execute at single action from a collection
Changed Command Arguments to JArray
Changed ExecuteCommandParams to JArray
Added GetExecuteCommand in LSPRequestRouter
Added ClientCapabilityProviderFixture
Added IHandlerMatcher to match handlers to parameters
Added Tests