### PR TITLE
 Move payload deserialisation out of handlers

### DIFF
--- a/src/Client/Dispatcher/LspDispatcher.cs
+++ b/src/Client/Dispatcher/LspDispatcher.cs
@@ -105,7 +105,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Dispatcher
 
             if (_handlers.TryGetValue(method, out IHandler handler) && handler is IInvokeNotificationHandler notificationHandler)
             {
-                object notificationPayload = DeserializePayload(notificationHandler.BodyType, notification);
+                object notificationPayload = DeserializePayload(notificationHandler.PayloadType, notification);
 
                 await notificationHandler.Invoke(notificationPayload);
 
@@ -137,7 +137,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Dispatcher
 
             if (_handlers.TryGetValue(method, out IHandler handler) && handler is IInvokeRequestHandler requestHandler)
             {
-                object requestPayload = DeserializePayload(requestHandler.BodyType, request);
+                object requestPayload = DeserializePayload(requestHandler.PayloadType, request);
 
                 return requestHandler.Invoke(requestPayload, cancellationToken);
             }

--- a/src/Client/Handlers/DelegateEmptyNotificationHandler.cs
+++ b/src/Client/Handlers/DelegateEmptyNotificationHandler.cs
@@ -33,6 +33,11 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public NotificationHandler Handler { get; }
 
         /// <summary>
+        ///     The expected CLR type of the notification body (<c>null</c>, since the handler does not use the request body).
+        /// </summary>
+        public override Type BodyType => null;
+
+        /// <summary>
         ///     Invoke the handler.
         /// </summary>
         /// <returns>

--- a/src/Client/Handlers/DelegateEmptyNotificationHandler.cs
+++ b/src/Client/Handlers/DelegateEmptyNotificationHandler.cs
@@ -33,9 +33,9 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public NotificationHandler Handler { get; }
 
         /// <summary>
-        ///     The expected CLR type of the notification body (<c>null</c>, since the handler does not use the request body).
+        ///     The expected CLR type of the notification payload (<c>null</c>, since the handler does not use the request payload).
         /// </summary>
-        public override Type BodyType => null;
+        public override Type PayloadType => null;
 
         /// <summary>
         ///     Invoke the handler.

--- a/src/Client/Handlers/DelegateHandler.cs
+++ b/src/Client/Handlers/DelegateHandler.cs
@@ -26,5 +26,10 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         ///     The name of the method handled by the handler.
         /// </summary>
         public string Method { get; }
+
+        /// <summary>
+        ///     The expected CLR type of the request / notification body (if any; <c>null</c> if the handler does not use the request body).
+        /// </summary>
+        public abstract Type BodyType { get; }
     }
 }

--- a/src/Client/Handlers/DelegateHandler.cs
+++ b/src/Client/Handlers/DelegateHandler.cs
@@ -28,8 +28,8 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public string Method { get; }
 
         /// <summary>
-        ///     The expected CLR type of the request / notification body (if any; <c>null</c> if the handler does not use the request body).
+        ///     The expected CLR type of the request / notification payload (if any; <c>null</c> if the handler does not use the request payload).
         /// </summary>
-        public abstract Type BodyType { get; }
+        public abstract Type PayloadType { get; }
     }
 }

--- a/src/Client/Handlers/DelegateNotificationHandler.cs
+++ b/src/Client/Handlers/DelegateNotificationHandler.cs
@@ -39,9 +39,9 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public NotificationHandler<TNotification> Handler { get; }
 
         /// <summary>
-        ///     The expected CLR type of the notification body.
+        ///     The expected CLR type of the notification payload.
         /// </summary>
-        public override Type BodyType => typeof(TNotification);
+        public override Type PayloadType => typeof(TNotification);
 
         /// <summary>
         ///     Invoke the handler.

--- a/src/Client/Handlers/DelegateNotificationHandler.cs
+++ b/src/Client/Handlers/DelegateNotificationHandler.cs
@@ -39,6 +39,11 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public NotificationHandler<TNotification> Handler { get; }
 
         /// <summary>
+        ///     The expected CLR type of the notification body.
+        /// </summary>
+        public override Type BodyType => typeof(TNotification);
+
+        /// <summary>
         ///     Invoke the handler.
         /// </summary>
         /// <param name="notification">
@@ -47,12 +52,12 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         /// <returns>
         ///     A <see cref="Task"/> representing the operation.
         /// </returns>
-        public async Task Invoke(JObject notification)
+        public async Task Invoke(object notification)
         {
             await Task.Yield();
 
             Handler(
-                notification != null ? notification.ToObject<TNotification>(Serializer.Instance.JsonSerializer /* Fix me: this is ugly */) : default(TNotification)
+                (TNotification)notification
             );
         }
     }

--- a/src/Client/Handlers/DelegateRequestHandler.cs
+++ b/src/Client/Handlers/DelegateRequestHandler.cs
@@ -40,9 +40,9 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public RequestHandler<TRequest> Handler { get; }
 
         /// <summary>
-        ///     The expected CLR type of the request body.
+        ///     The expected CLR type of the request payload.
         /// </summary>
-        public override Type BodyType => typeof(TRequest);
+        public override Type PayloadType => typeof(TRequest);
 
         /// <summary>
         ///     Invoke the handler.

--- a/src/Client/Handlers/DelegateRequestHandler.cs
+++ b/src/Client/Handlers/DelegateRequestHandler.cs
@@ -40,6 +40,11 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public RequestHandler<TRequest> Handler { get; }
 
         /// <summary>
+        ///     The expected CLR type of the request body.
+        /// </summary>
+        public override Type BodyType => typeof(TRequest);
+
+        /// <summary>
         ///     Invoke the handler.
         /// </summary>
         /// <param name="request">
@@ -51,10 +56,10 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         /// <returns>
         ///     A <see cref="Task{TResult}"/> representing the operation.
         /// </returns>
-        public async Task<object> Invoke(JObject request, CancellationToken cancellationToken)
+        public async Task<object> Invoke(object request, CancellationToken cancellationToken)
         {
             await Handler(
-                request != null ? request.ToObject<TRequest>(Serializer.Instance.JsonSerializer /* Fix me: this is ugly */) : default(TRequest),
+                (TRequest)request,
                 cancellationToken
             );
 

--- a/src/Client/Handlers/DelegateRequestResponseHandler.cs
+++ b/src/Client/Handlers/DelegateRequestResponseHandler.cs
@@ -43,9 +43,9 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public RequestHandler<TRequest, TResponse> Handler { get; }
 
         /// <summary>
-        ///     The expected CLR type of the request body.
+        ///     The expected CLR type of the request payload.
         /// </summary>
-        public override Type BodyType => typeof(TRequest);
+        public override Type PayloadType => typeof(TRequest);
 
         /// <summary>
         ///     Invoke the handler.

--- a/src/Client/Handlers/DelegateRequestResponseHandler.cs
+++ b/src/Client/Handlers/DelegateRequestResponseHandler.cs
@@ -43,6 +43,11 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public RequestHandler<TRequest, TResponse> Handler { get; }
 
         /// <summary>
+        ///     The expected CLR type of the request body.
+        /// </summary>
+        public override Type BodyType => typeof(TRequest);
+
+        /// <summary>
         ///     Invoke the handler.
         /// </summary>
         /// <param name="request">
@@ -54,10 +59,10 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         /// <returns>
         ///     A <see cref="Task{TResult}"/> representing the operation.
         /// </returns>
-        public async Task<object> Invoke(JObject request, CancellationToken cancellationToken)
+        public async Task<object> Invoke(object request, CancellationToken cancellationToken)
         {
             return await Handler(
-                request != null ? request.ToObject<TRequest>(Serializer.Instance.JsonSerializer /* Fix me: this is ugly */) : default(TRequest),
+                (TRequest)request,
                 cancellationToken
             );
         }

--- a/src/Client/Handlers/DynamicRegistrationHandler.cs
+++ b/src/Client/Handlers/DynamicRegistrationHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -32,6 +33,11 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public string Method => "client/registerCapability";
 
         /// <summary>
+        ///     The expected CLR type of the request / notification body (if any; <c>null</c> if the handler does not use the request body).
+        /// </summary>
+        public Type BodyType => null;
+
+        /// <summary>
         ///     Invoke the handler.
         /// </summary>
         /// <param name="request">
@@ -43,7 +49,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         /// <returns>
         ///     A <see cref="Task{TResult}"/> representing the operation.
         /// </returns>
-        public Task<object> Invoke(JObject request, CancellationToken cancellationToken)
+        public Task<object> Invoke(object request, CancellationToken cancellationToken)
         {
             // For now, we don't really support dynamic registration but OmniSharp's implementation sends a request even when dynamic registrations are not supported.
 

--- a/src/Client/Handlers/DynamicRegistrationHandler.cs
+++ b/src/Client/Handlers/DynamicRegistrationHandler.cs
@@ -33,9 +33,9 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public string Method => "client/registerCapability";
 
         /// <summary>
-        ///     The expected CLR type of the request / notification body (if any; <c>null</c> if the handler does not use the request body).
+        ///     The expected CLR type of the request / notification payload (if any; <c>null</c> if the handler does not use the request payload).
         /// </summary>
-        public Type BodyType => null;
+        public Type PayloadType => null;
 
         /// <summary>
         ///     Invoke the handler.

--- a/src/Client/Handlers/IHandler.cs
+++ b/src/Client/Handlers/IHandler.cs
@@ -13,8 +13,8 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         string Method { get; }
 
         /// <summary>
-        ///     The expected CLR type of the request / notification body (if any; <c>null</c> if the handler does not use the request body).
+        ///     The expected CLR type of the request / notification payload (if any; <c>null</c> if the handler does not use the request body).
         /// </summary>
-        Type BodyType { get; }
+        Type PayloadType { get; }
     }
 }

--- a/src/Client/Handlers/IHandler.cs
+++ b/src/Client/Handlers/IHandler.cs
@@ -1,4 +1,6 @@
-﻿namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
+﻿using System;
+
+namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
 {
     /// <summary>
     ///     Represents a client-side message handler.
@@ -9,5 +11,10 @@
         ///     The name of the method handled by the handler.
         /// </summary>
         string Method { get; }
+
+        /// <summary>
+        ///     The expected CLR type of the request / notification body (if any; <c>null</c> if the handler does not use the request body).
+        /// </summary>
+        Type BodyType { get; }
     }
 }

--- a/src/Client/Handlers/IInvokeNotificationHandler.cs
+++ b/src/Client/Handlers/IInvokeNotificationHandler.cs
@@ -18,6 +18,6 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         /// <returns>
         ///     A <see cref="Task"/> representing the operation.
         /// </returns>
-        Task Invoke(JObject notification);
+        Task Invoke(object notification);
     }
 }

--- a/src/Client/Handlers/IInvokeRequestHandler.cs
+++ b/src/Client/Handlers/IInvokeRequestHandler.cs
@@ -22,6 +22,6 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         /// <returns>
         ///     A <see cref="Task{TResult}"/> representing the operation.
         /// </returns>
-        Task<object> Invoke(JObject request, CancellationToken cancellationToken);
+        Task<object> Invoke(object request, CancellationToken cancellationToken);
     }
 }

--- a/src/Client/Handlers/JsonRpcEmptyNotificationHandler.cs
+++ b/src/Client/Handlers/JsonRpcEmptyNotificationHandler.cs
@@ -34,6 +34,11 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public INotificationHandler Handler { get; }
 
         /// <summary>
+        ///     The expected CLR type of the notification body (<c>null</c>, since the handler does not use the request body).
+        /// </summary>
+        public override Type BodyType => null;
+
+        /// <summary>
         ///     Invoke the handler.
         /// </summary>
         /// <returns>

--- a/src/Client/Handlers/JsonRpcEmptyNotificationHandler.cs
+++ b/src/Client/Handlers/JsonRpcEmptyNotificationHandler.cs
@@ -34,9 +34,9 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public INotificationHandler Handler { get; }
 
         /// <summary>
-        ///     The expected CLR type of the notification body (<c>null</c>, since the handler does not use the request body).
+        ///     The expected CLR type of the notification payload (<c>null</c>, since the handler does not use the request payload).
         /// </summary>
-        public override Type BodyType => null;
+        public override Type PayloadType => null;
 
         /// <summary>
         ///     Invoke the handler.

--- a/src/Client/Handlers/JsonRpcHandler.cs
+++ b/src/Client/Handlers/JsonRpcHandler.cs
@@ -27,5 +27,10 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         ///     The name of the method handled by the handler.
         /// </summary>
         public string Method { get; }
+
+        /// <summary>
+        ///     The expected CLR type of the request / notification body (if any; <c>null</c> if the handler does not use the request body).
+        /// </summary>
+        public abstract Type BodyType { get; }
     }
 }

--- a/src/Client/Handlers/JsonRpcHandler.cs
+++ b/src/Client/Handlers/JsonRpcHandler.cs
@@ -29,8 +29,8 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public string Method { get; }
 
         /// <summary>
-        ///     The expected CLR type of the request / notification body (if any; <c>null</c> if the handler does not use the request body).
+        ///     The expected CLR type of the request / notification payload (if any; <c>null</c> if the handler does not use the request payload).
         /// </summary>
-        public abstract Type BodyType { get; }
+        public abstract Type PayloadType { get; }
     }
 }

--- a/src/Client/Handlers/JsonRpcNotificationHandler.cs
+++ b/src/Client/Handlers/JsonRpcNotificationHandler.cs
@@ -39,9 +39,9 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public INotificationHandler<TNotification> Handler { get; }
 
         /// <summary>
-        ///     The expected CLR type of the notification body.
+        ///     The expected CLR type of the notification payload.
         /// </summary>
-        public override Type BodyType => typeof(TNotification);
+        public override Type PayloadType => typeof(TNotification);
 
         /// <summary>
         ///     Invoke the handler.

--- a/src/Client/Handlers/JsonRpcNotificationHandler.cs
+++ b/src/Client/Handlers/JsonRpcNotificationHandler.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
@@ -40,6 +39,11 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         public INotificationHandler<TNotification> Handler { get; }
 
         /// <summary>
+        ///     The expected CLR type of the notification body.
+        /// </summary>
+        public override Type BodyType => typeof(TNotification);
+
+        /// <summary>
         ///     Invoke the handler.
         /// </summary>
         /// <param name="notification">
@@ -48,8 +52,8 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Handlers
         /// <returns>
         ///     A <see cref="Task"/> representing the operation.
         /// </returns>
-        public Task Invoke(JObject notification) => Handler.Handle(
-            notification != null ? notification.ToObject<TNotification>(Serializer.Instance.JsonSerializer /* Fix me: this is ugly */) : default(TNotification)
+        public Task Invoke(object notification) => Handler.Handle(
+            (TNotification)notification
         );
     }
 }

--- a/src/Client/LanguageClient.cs
+++ b/src/Client/LanguageClient.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Client.Clients;
 using OmniSharp.Extensions.LanguageServer.Client.Dispatcher;
 using OmniSharp.Extensions.LanguageServer.Client.Handlers;
@@ -10,6 +11,7 @@ using OmniSharp.Extensions.LanguageServer.Client.Processes;
 using OmniSharp.Extensions.LanguageServer.Client.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
 
 namespace OmniSharp.Extensions.LanguageServer.Client
@@ -24,9 +26,17 @@ namespace OmniSharp.Extensions.LanguageServer.Client
         : IDisposable
     {
         /// <summary>
+        ///     The serialiser for notification / request / response bodies.
+        /// </summary>
+        /// <remarks>
+        ///     TODO: Make this injectable. And what does client version do - do we have to negotiate this?
+        /// </remarks>
+        readonly ISerializer _serializer = new Serializer(ClientVersion.Lsp3);
+
+        /// <summary>
         ///     The dispatcher for incoming requests, notifications, and responses.
         /// </summary>
-        readonly LspDispatcher _dispatcher = new LspDispatcher();
+        readonly LspDispatcher _dispatcher;
 
         /// <summary>
         ///     The handler for dynamic registration of server capabilities.
@@ -101,6 +111,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client
             Window = new WindowClient(this);
             TextDocument = new TextDocumentClient(this);
 
+            _dispatcher = new LspDispatcher(_serializer);
             _dispatcher.RegisterHandler(_dynamicRegistrationHandler);
         }
 

--- a/src/Client/Protocol/LspConnection.cs
+++ b/src/Client/Protocol/LspConnection.cs
@@ -126,8 +126,6 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
         /// </summary>
         Task _dispatchLoop;
 
-        private readonly Serializer _serializer;
-
         /// <summary>
         ///     Create a new <see cref="LspConnection"/>.
         /// </summary>
@@ -160,8 +158,10 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
             Log = loggerFactory.CreateLogger<LspConnection>();
             _input = input;
             _output = output;
-            // What does client version do? Do we have to negotaite this?
-            _serializer = new Serializer(ClientVersion.Lsp3);
+
+            // What does client version do? Do we have to negotiate this?
+            // The connection may change its Serializer instance once connected; this can be propagated to other components as required.
+            Serializer = new Serializer(ClientVersion.Lsp3);
         }
 
         /// <summary>
@@ -188,6 +188,11 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
         ///     The connection's logger.
         /// </summary>
         ILogger Log { get; }
+
+        /// <summary>
+        ///     The JSON serializer used for notification, request, and response payloads.
+        /// </summary>
+        public Serializer Serializer { get; }
 
         /// <summary>
         ///     Is the connection open?
@@ -238,6 +243,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
             _cancellation = _cancellationSource.Token;
 
             _dispatcher = dispatcher;
+            _dispatcher.Serializer = Serializer;
             _sendLoop = SendLoop();
             _receiveLoop = ReceiveLoop();
             _dispatchLoop = DispatchLoop();
@@ -337,7 +343,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
             {
                 // No Id means it's a notification.
                 Method = method,
-                Params = JObject.FromObject(notification, _serializer.JsonSerializer)
+                Params = JObject.FromObject(notification, Serializer.JsonSerializer)
             });
         }
 
@@ -395,7 +401,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
             {
                 Id = requestId,
                 Method = method,
-                Params = request != null ? JObject.FromObject(request, _serializer.JsonSerializer) : null
+                Params = request != null ? JObject.FromObject(request, Serializer.JsonSerializer) : null
             });
 
             await responseCompletion.Task;
@@ -458,13 +464,13 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
             {
                 Id = requestId,
                 Method = method,
-                Params = request != null ? JObject.FromObject(request, _serializer.JsonSerializer) : null
+                Params = request != null ? JObject.FromObject(request, Serializer.JsonSerializer) : null
             });
 
             ServerMessage response = await responseCompletion.Task;
 
             if (response.Result != null)
-                return response.Result.ToObject<TResponse>(_serializer.JsonSerializer);
+                return response.Result.ToObject<TResponse>(Serializer.JsonSerializer);
             else
                 return default(TResponse);
         }
@@ -660,7 +666,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
             if (message == null)
                 throw new ArgumentNullException(nameof(message));
 
-            string payload = JsonConvert.SerializeObject(message, _serializer.Settings);
+            string payload = JsonConvert.SerializeObject(message, Serializer.Settings);
             byte[] payloadBuffer = PayloadEncoding.GetBytes(payload);
 
             byte[] headerBuffer = HeaderEncoding.GetBytes(
@@ -760,7 +766,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
             Log.LogDebug("Received entire payload ({ReceivedByteCount} bytes).", received);
 
             string responseBody = PayloadEncoding.GetString(requestBuffer);
-            ServerMessage message = JsonConvert.DeserializeObject<ServerMessage>(responseBody, _serializer.Settings);
+            ServerMessage message = JsonConvert.DeserializeObject<ServerMessage>(responseBody, Serializer.Settings);
 
             Log.LogDebug("Read response body {ResponseBody}.", responseBody);
 
@@ -893,7 +899,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
                     {
                         Id = requestMessage.Id,
                         Method = requestMessage.Method,
-                        Result = handlerTask.Result != null ? JObject.FromObject(handlerTask.Result, _serializer.JsonSerializer) : null
+                        Result = handlerTask.Result != null ? JObject.FromObject(handlerTask.Result, Serializer.JsonSerializer) : null
                     });
                 }
 

--- a/test/Client.Tests/ClientTests.cs
+++ b/test/Client.Tests/ClientTests.cs
@@ -13,6 +13,8 @@ using OmniSharp.Extensions.LanguageServer.Client.Utilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 
 namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
 {
@@ -46,7 +48,7 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
         /// <summary>
         ///     The server-side dispatcher.
         /// </summary>
-        LspDispatcher ServerDispatcher { get; } = new LspDispatcher();
+        LspDispatcher ServerDispatcher { get; } = new LspDispatcher(new Serializer(ClientVersion.Lsp3));
 
         /// <summary>
         ///     The server-side connection.

--- a/test/Client.Tests/ConnectionTests.cs
+++ b/test/Client.Tests/ConnectionTests.cs
@@ -4,6 +4,8 @@ using OmniSharp.Extensions.LanguageServer.Client.Dispatcher;
 using OmniSharp.Extensions.LanguageServer.Client.Protocol;
 using Xunit;
 using Xunit.Abstractions;
+using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 
 namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
 {
@@ -35,7 +37,7 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
             LspConnection clientConnection = await CreateClientConnection();
             LspConnection serverConnection = await CreateServerConnection();
 
-            var serverDispatcher = new LspDispatcher();
+            var serverDispatcher = CreateDispatcher();
             serverDispatcher.HandleEmptyNotification("test", () =>
             {
                 Log.LogInformation("Got notification.");
@@ -44,7 +46,7 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
             });
             serverConnection.Connect(serverDispatcher);
 
-            clientConnection.Connect(new LspDispatcher());
+            clientConnection.Connect(CreateDispatcher());
             clientConnection.SendEmptyNotification("test");
 
             await testCompletion.Task;
@@ -66,7 +68,7 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
             LspConnection clientConnection = await CreateClientConnection();
             LspConnection serverConnection = await CreateServerConnection();
 
-            var clientDispatcher = new LspDispatcher();
+            var clientDispatcher = CreateDispatcher();
             clientDispatcher.HandleEmptyNotification("test", () =>
             {
                 Log.LogInformation("Got notification.");
@@ -75,7 +77,7 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
             });
             clientConnection.Connect(clientDispatcher);
 
-            serverConnection.Connect(new LspDispatcher());
+            serverConnection.Connect(CreateDispatcher());
             serverConnection.SendEmptyNotification("test");
 
             await testCompletion.Task;
@@ -95,7 +97,7 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
             LspConnection clientConnection = await CreateClientConnection();
             LspConnection serverConnection = await CreateServerConnection();
 
-            var clientDispatcher = new LspDispatcher();
+            var clientDispatcher = CreateDispatcher();
             clientDispatcher.HandleRequest<TestRequest, TestResponse>("test", (request, cancellationToken) =>
             {
                 Log.LogInformation("Got request: {@Request}", request);
@@ -107,7 +109,7 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
             });
             clientConnection.Connect(clientDispatcher);
 
-            serverConnection.Connect(new LspDispatcher());
+            serverConnection.Connect(CreateDispatcher());
             TestResponse response = await serverConnection.SendRequest<TestResponse>("test", new TestRequest
             {
                 Value = 1234
@@ -132,7 +134,7 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
             LspConnection clientConnection = await CreateClientConnection();
             LspConnection serverConnection = await CreateServerConnection();
 
-            var serverDispatcher = new LspDispatcher();
+            var serverDispatcher = CreateDispatcher();
             serverDispatcher.HandleRequest<TestRequest, TestResponse>("test", (request, cancellationToken) =>
             {
                 Log.LogInformation("Got request: {@Request}", request);
@@ -144,7 +146,7 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
             });
             serverConnection.Connect(serverDispatcher);
 
-            clientConnection.Connect(new LspDispatcher());
+            clientConnection.Connect(CreateDispatcher());
             TestResponse response = await clientConnection.SendRequest<TestResponse>("test", new TestRequest
             {
                 Value = 1234
@@ -169,7 +171,7 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
             LspConnection clientConnection = await CreateClientConnection();
             LspConnection serverConnection = await CreateServerConnection();
 
-            var clientDispatcher = new LspDispatcher();
+            var clientDispatcher = CreateDispatcher();
             clientDispatcher.HandleRequest<TestRequest>("test", (request, cancellationToken) =>
             {
                 Log.LogInformation("Got request: {@Request}", request);
@@ -180,7 +182,7 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
             });
             clientConnection.Connect(clientDispatcher);
 
-            serverConnection.Connect(new LspDispatcher());
+            serverConnection.Connect(CreateDispatcher());
             await serverConnection.SendRequest("test", new TestRequest
             {
                 Value = 1234
@@ -201,7 +203,7 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
             LspConnection clientConnection = await CreateClientConnection();
             LspConnection serverConnection = await CreateServerConnection();
 
-            var serverDispatcher = new LspDispatcher();
+            var serverDispatcher = CreateDispatcher();
             serverDispatcher.HandleRequest<TestRequest>("test", (request, cancellationToken) =>
             {
                 Log.LogInformation("Got request: {@Request}", request);
@@ -212,7 +214,7 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
             });
             serverConnection.Connect(serverDispatcher);
 
-            clientConnection.Connect(new LspDispatcher());
+            clientConnection.Connect(CreateDispatcher());
             await clientConnection.SendRequest("test", new TestRequest
             {
                 Value = 1234
@@ -223,5 +225,13 @@ namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
 
             await Task.WhenAll(clientConnection.HasHasDisconnected, serverConnection.HasHasDisconnected);
         }
+
+        /// <summary>
+        ///     Create an <see cref="LspDispatcher"/> for use in tests.
+        /// </summary>
+        /// <returns>
+        ///     The <see cref="LspDispatcher"/>.
+        /// </returns>
+        LspDispatcher CreateDispatcher() => new LspDispatcher(new Serializer(ClientVersion.Lsp3));
     }
 }

--- a/test/Client.Tests/HandlerTests.cs
+++ b/test/Client.Tests/HandlerTests.cs
@@ -1,0 +1,97 @@
+using OmniSharp.Extensions.LanguageServer.Client.Handlers;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OmniSharp.Extensions.LanguageServerProtocol.Client.Tests
+{
+    /// <summary>
+    ///     Tests for <see cref="IHandler"/> and friends.
+    /// </summary>
+    public class HandlerTests
+        : TestBase
+    {
+        /// <summary>
+        ///     Create a new <see cref="IHandler"/> test suite.
+        /// </summary>
+        /// <param name="testOutput">
+        ///     Output for the current test.
+        /// </param>
+        public HandlerTests(ITestOutputHelper testOutput)
+            : base(testOutput)
+        {
+        }
+
+        /// <summary>
+        ///     Verify that <see cref="DelegateEmptyNotificationHandler"/> specifies the correct payload type.
+        /// </summary>
+        [Fact(DisplayName = "DelegateEmptyNotificationHandler specifies correct payload type")]
+        public void DelegateEmptyNotificationHandler_PayloadType()
+        {
+            IHandler handler = new DelegateEmptyNotificationHandler(
+                method: "test",
+                handler: () =>
+                {
+                    // Nothing to do.
+                }
+            );
+
+            Assert.Null(handler.PayloadType);
+        }
+
+        /// <summary>
+        ///     Verify that <see cref="DelegateNotificationHandler"/> specifies the correct payload type.
+        /// </summary>
+        [Fact(DisplayName = "DelegateNotificationHandler specifies correct payload type")]
+        public void DelegateNotificationHandler_PayloadType()
+        {
+            IHandler handler = new DelegateNotificationHandler<string>(
+                method: "test",
+                handler: notification =>
+                {
+                    // Nothing to do.
+                }
+            );
+
+            Assert.Equal(typeof(string), handler.PayloadType);
+        }
+
+        /// <summary>
+        ///     Verify that <see cref="DelegateRequestHandler{TRequest}"/> specifies the correct payload type (<c>null</c>).
+        /// </summary>
+        [Fact(DisplayName = "DelegateRequestHandler specifies correct payload type")]
+        public void DelegateRequestHandler_PayloadType()
+        {
+            IHandler handler = new DelegateRequestHandler<string>(
+                method: "test",
+                handler: (request, cancellationToken) =>
+                {
+                    // Nothing to do.
+
+                    return Task.CompletedTask;
+                }
+            );
+
+            Assert.Equal(typeof(string), handler.PayloadType);
+        }
+
+        /// <summary>
+        ///     Verify that <see cref="DelegateRequestResponseHandler{TRequest, TResponse}"/> specifies the correct payload type (<c>null</c>).
+        /// </summary>
+        [Fact(DisplayName = "DelegateRequestResponseHandler specifies correct payload type")]
+        public void DelegateRequestResponseHandler_PayloadType()
+        {
+            IHandler handler = new DelegateRequestResponseHandler<string, string>(
+                method: "test",
+                handler: (request, cancellationToken) =>
+                {
+                    // Nothing to do.
+
+                    return Task.FromResult<string>("hello");
+                }
+            );
+
+            Assert.Equal(typeof(string), handler.PayloadType);
+        }
+    }
+}


### PR DESCRIPTION
This moves the deserialisation of payloads out of handlers and into the calling code (`LspDispatcher`).