### PR TITLE
Log correct type for handler interface.

### DIFF
--- a/src/Server/Matchers/TextDocumentMatcher.cs
+++ b/src/Server/Matchers/TextDocumentMatcher.cs
@@ -82,7 +82,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Matchers
                 _logger.LogTrace("Document Selector {DocumentSelector}", registrationOptions.DocumentSelector.ToString());
                 if (registrationOptions.DocumentSelector == null || registrationOptions.DocumentSelector.IsMatch(attributes))
                 {
-                    _logger.LogTrace("Handler Selected: {Handler} via {DocumentSelector} (targeting {HandlerInterface})", handler.Handler.GetType().FullName, registrationOptions.DocumentSelector.ToString(), handler.HandlerType.GetType().FullName);
+                    _logger.LogTrace("Handler Selected: {Handler} via {DocumentSelector} (targeting {HandlerInterface})", handler.Handler.GetType().FullName, registrationOptions.DocumentSelector.ToString(), handler.HandlerType.FullName);
                     yield return handler;
                 }
             }


### PR DESCRIPTION
Removed call to `GetType()` on something that's already a `Type` :)

Fixes OmniSharp/csharp-language-server-protocol#54.