### PR TITLE
Added check to allow non spec compliant consumers to send us null for…

### DIFF
--- a/src/JsonRpc/Reciever.cs
+++ b/src/JsonRpc/Reciever.cs
@@ -79,9 +79,16 @@ namespace OmniSharp.Extensions.JsonRpc
             }
 
             var hasParams = request.TryGetValue("params", out var @params);
-            if (hasParams && @params?.Type != JTokenType.Array && @params?.Type != JTokenType.Object)
+            if (hasParams && @params?.Type != JTokenType.Array && @params?.Type != JTokenType.Object && @params?.Type != JTokenType.Null)
             {
                 return new InvalidRequest(requestId, "Invalid params");
+            }
+
+            // Special case params such that if we get a null value (from a non spec compliant system)
+            // that we don't fall over and throw an error.
+            if (@params?.Type == JTokenType.Null)
+            {
+                @params = null;
             }
 
             // id == request

--- a/src/Protocol/General/IShutdownHandler.cs
+++ b/src/Protocol/General/IShutdownHandler.cs
@@ -11,5 +11,5 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
     }
 
     [Serial, Method(Shutdown)]
-    public interface IShutdownHandler : INotificationHandler { }
+    public interface IShutdownHandler : IRequestHandler<object> { }
 }

--- a/src/Server/Handlers/ShutdownHandler.cs
+++ b/src/Server/Handlers/ShutdownHandler.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Server.Abstractions;
@@ -6,19 +7,18 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Handlers
 {
     public class ShutdownHandler : IShutdownHandler, IAwaitableTermination
     {
-        public Task Handle()
-        {
-            ShutdownRequested = true;
-            Shutdown?.Invoke(ShutdownRequested);
-            shutdownSource.SetResult(true); // after all event sinks were notified
-            return Task.CompletedTask;
-        }
-
         public event ShutdownEventHandler Shutdown;
 
         public bool ShutdownRequested { get; private set; }
 
-        private readonly TaskCompletionSource<bool> shutdownSource = new TaskCompletionSource<bool>(TaskContinuationOptions.LongRunning);
-        Task IAwaitableTermination.WasShutDown => shutdownSource.Task;
+        private readonly TaskCompletionSource<bool> _shutdownSource = new TaskCompletionSource<bool>(TaskContinuationOptions.LongRunning);
+        Task IAwaitableTermination.WasShutDown => _shutdownSource.Task;
+        public Task Handle(object request, CancellationToken token)
+        {
+            ShutdownRequested = true;
+            Shutdown?.Invoke(ShutdownRequested);
+            _shutdownSource.SetResult(true); // after all event sinks were notified
+            return Task.CompletedTask;
+        }
     }
 }

--- a/test/JsonRpc.Tests/Server/SpecifictionRecieverTests.cs
+++ b/test/JsonRpc.Tests/Server/SpecifictionRecieverTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -57,6 +57,24 @@ namespace JsonRpc.Tests.Server
                     });
 
                 yield return (
+                    @"{""jsonrpc"": ""2.0"", ""method"": ""subtract"", ""id"": 4}",
+                    new Renor[]
+                    {
+                        new Request(4, "subtract", null)
+                    });
+
+                // http://www.jsonrpc.org/specification says:
+                //      If present, parameters for the rpc call MUST be provided as a Structured value.
+                // Some clients may serialize params as null, instead of omitting it
+                // We're going to pretend we never got the null in the first place.
+                yield return (
+                    @"{""jsonrpc"": ""2.0"", ""method"": ""subtract"", ""params"": null, ""id"": 4}",
+                    new Renor[]
+                    {
+                        new Request(4, "subtract", null)
+                    });
+
+                yield return (
                     @"{""jsonrpc"": ""2.0"", ""method"": ""update"", ""params"": [1,2,3,4,5]}",
                     new Renor[]
                     {
@@ -65,6 +83,17 @@ namespace JsonRpc.Tests.Server
 
                 yield return (
                     @"{""jsonrpc"": ""2.0"", ""method"": ""foobar""}",
+                    new Renor[]
+                    {
+                        new Notification("foobar", null)
+                    });
+
+                // http://www.jsonrpc.org/specification says:
+                //      If present, parameters for the rpc call MUST be provided as a Structured value.
+                // Some clients may serialize params as null, instead of omitting it
+                // We're going to pretend we never got the null in the first place.
+                yield return (
+                    @"{""jsonrpc"": ""2.0"", ""method"": ""foobar"", ""params"": null}",
                     new Renor[]
                     {
                         new Notification("foobar", null)


### PR DESCRIPTION
… params.  When a null is given we won't error, instead we will just pretend we never got any params at all.

cc @tintoy 