### PR TITLE
Enable client to handle array-type responses

### DIFF
--- a/src/Client/Protocol/ClientMessage.cs
+++ b/src/Client/Protocol/ClientMessage.cs
@@ -32,7 +32,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
         ///     The request / notification message, if the message represents a request or a notification.
         /// </summary>
         [Optional]
-        public JObject Params { get; set; }
+        public JToken Params { get; set; }
 
         /// <summary>
         ///     The response message, if the message represents a response.

--- a/src/Client/Protocol/ClientMessage.cs
+++ b/src/Client/Protocol/ClientMessage.cs
@@ -37,7 +37,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
         /// <summary>
         ///     The response message, if the message represents a response.
         /// </summary>
-        [Optional]
-        public JObject Result { get; set; }
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate, NullValueHandling = NullValueHandling.Ignore)]
+        public JToken Result { get; set; }
     }
 }

--- a/src/Client/Protocol/LspConnection.cs
+++ b/src/Client/Protocol/LspConnection.cs
@@ -899,7 +899,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
                     {
                         Id = requestMessage.Id,
                         Method = requestMessage.Method,
-                        Result = handlerTask.Result != null ? JToken.FromObject(handlerTask.Result) : null
+                        Result = handlerTask.Result != null ? JToken.FromObject(handlerTask.Result, Serializer.JsonSerializer) : null
                     });
                 }
 

--- a/src/Client/Protocol/LspConnection.cs
+++ b/src/Client/Protocol/LspConnection.cs
@@ -343,7 +343,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
             {
                 // No Id means it's a notification.
                 Method = method,
-                Params = JObject.FromObject(notification, Serializer.JsonSerializer)
+                Params = JToken.FromObject(notification, Serializer.JsonSerializer)
             });
         }
 
@@ -401,7 +401,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
             {
                 Id = requestId,
                 Method = method,
-                Params = request != null ? JObject.FromObject(request, Serializer.JsonSerializer) : null
+                Params = request != null ? JToken.FromObject(request, Serializer.JsonSerializer) : null
             });
 
             await responseCompletion.Task;
@@ -464,7 +464,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
             {
                 Id = requestId,
                 Method = method,
-                Params = request != null ? JObject.FromObject(request, Serializer.JsonSerializer) : null
+                Params = request != null ? JToken.FromObject(request, Serializer.JsonSerializer) : null
             });
 
             ServerMessage response = await responseCompletion.Task;

--- a/src/Client/Protocol/LspConnection.cs
+++ b/src/Client/Protocol/LspConnection.cs
@@ -899,7 +899,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
                     {
                         Id = requestMessage.Id,
                         Method = requestMessage.Method,
-                        Result = handlerTask.Result != null ? JObject.FromObject(handlerTask.Result, Serializer.JsonSerializer) : null
+                        Result = handlerTask.Result != null ? JToken.FromObject(handlerTask.Result) : null
                     });
                 }
 


### PR DESCRIPTION
This is necessary for "container" return types that contain multiple values because they will be serialised as arrays instead of objects.

OmniSharp/csharp-language-server-protocol#56