### PR TITLE
Enable handling of requests with no parameters.

### DIFF
--- a/src/Server/LspRequestRouter.cs
+++ b/src/Server/LspRequestRouter.cs
@@ -121,10 +121,12 @@ namespace OmniSharp.Extensions.LanguageServer.Server
                     object @params;
                     try
                     {
-                        @params = request.Params.ToObject(descriptor.Params, _serializer.JsonSerializer);
+                        @params = request.Params?.ToObject(descriptor.Params, _serializer.JsonSerializer);
                     }
-                    catch
+                    catch (Exception cannotDeserializeRequestParams)
                     {
+                        _logger.LogError(new EventId(-32602), cannotDeserializeRequestParams, "Failed to deserialise request parameters.");
+
                         return new InvalidParams(request.Id);
                     }
 


### PR DESCRIPTION
An example of this is the "shutdown" request. It has no parameters (parameter type is void), and so this was failing with a swallowed exception.

Also, log the exception so if there turn out to be any other edge cases they'll be easier to diagnose.