### PR TITLE
Fix client-level handling of non-object params / results in server messages

### DIFF
--- a/src/Client/Dispatcher/LspDispatcher.cs
+++ b/src/Client/Dispatcher/LspDispatcher.cs
@@ -98,7 +98,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Dispatcher
         /// <returns>
         ///     <c>true</c>, if a notification handler was registered for specified method; otherwise, <c>false</c>.
         /// </returns>
-        public async Task<bool> TryHandleNotification(string method, JObject notification)
+        public async Task<bool> TryHandleNotification(string method, JToken notification)
         {
             if (string.IsNullOrWhiteSpace(method))
                 throw new ArgumentException($"Argument cannot be null, empty, or entirely composed of whitespace: {nameof(method)}.", nameof(method));
@@ -130,7 +130,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Dispatcher
         /// <returns>
         ///     If a registered handler was found, a <see cref="Task"/> representing the operation; otherwise, <c>null</c>.
         /// </returns>
-        public Task<object> TryHandleRequest(string method, JObject request, CancellationToken cancellationToken)
+        public Task<object> TryHandleRequest(string method, JToken request, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(method))
                 throw new ArgumentException($"Argument cannot be null, empty, or entirely composed of whitespace: {nameof(method)}.", nameof(method));
@@ -157,7 +157,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Dispatcher
         /// <returns>
         ///     The deserialised payload (if one is present and expected).
         /// </returns>
-        object DeserializePayload(Type payloadType, JObject payload)
+        object DeserializePayload(Type payloadType, JToken payload)
         {
             if (payloadType == null)
                 throw new ArgumentNullException(nameof(payloadType));

--- a/src/Client/Protocol/ServerMessage.cs
+++ b/src/Client/Protocol/ServerMessage.cs
@@ -31,13 +31,13 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
         ///     The request / notification message, if the message represents a request or a notification.
         /// </summary>
         [Optional]
-        public JObject Params { get; set; }
+        public JToken Params { get; set; }
 
         /// <summary>
         ///     The response message, if the message represents a response.
         /// </summary>
         [Optional]
-        public JObject Result { get; set; }
+        public JToken Result { get; set; }
 
         /// <summary>
         ///     The response error (if any).


### PR DESCRIPTION
Another place the client needs to be able to  handle params / responses that may be array (or other non-object) types.

Relates to OmniSharp/csharp-language-server-protocol#56.