### PR TITLE
Ensure shutdown handler runs asynchronously

### DIFF
--- a/src/Server/Handlers/ShutdownHandler.cs
+++ b/src/Server/Handlers/ShutdownHandler.cs
@@ -13,12 +13,19 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Handlers
 
         private readonly TaskCompletionSource<bool> _shutdownSource = new TaskCompletionSource<bool>(TaskContinuationOptions.LongRunning);
         public Task WasShutDown => _shutdownSource.Task;
-        public Task Handle(object request, CancellationToken token)
+        public async Task Handle(object request, CancellationToken token)
         {
+            await Task.Yield(); // Ensure shutdown handler runs asynchronously.
+
             ShutdownRequested = true;
-            Shutdown?.Invoke(ShutdownRequested);
-            _shutdownSource.SetResult(true); // after all event sinks were notified
-            return Task.CompletedTask;
+            try
+            {
+                Shutdown?.Invoke(ShutdownRequested);
+            }
+            finally
+            {
+                _shutdownSource.SetResult(true); // after all event sinks were notified
+            }
         }
     }
 }


### PR DESCRIPTION
The shutdown handler needs to run asynchronously because otherwise the server may deadlock on shutdown (server disposal disposes the `ProcessScheduler`, which attempts to join its own dispatcher thread; if we're not asynchronous, then the thread that's currently running is blocking that dispatcher thread).