### PR TITLE
Bug/gh #98

### DIFF
--- a/src/Client/Protocol/ServerMessage.cs
+++ b/src/Client/Protocol/ServerMessage.cs
@@ -14,6 +14,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
         /// <summary>
         ///     The JSON-RPC protocol version.
         /// </summary>
+        [JsonProperty("jsonrpc")]
         public string ProtocolVersion { get; set; } = "2.0";
 
         /// <summary>

--- a/src/JsonRpc/Client/Notification.cs
+++ b/src/JsonRpc/Client/Notification.cs
@@ -6,6 +6,7 @@ namespace OmniSharp.Extensions.JsonRpc.Client
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class Notification
     {
+        [JsonProperty("jsonrpc")]
         public string ProtocolVersion { get; } = "2.0";
 
         public string Method { get; set; }

--- a/src/JsonRpc/Client/Request.cs
+++ b/src/JsonRpc/Client/Request.cs
@@ -8,6 +8,7 @@ namespace OmniSharp.Extensions.JsonRpc.Client
     {
         public object Id { get; set; }
 
+        [JsonProperty("jsonrpc")]
         public string ProtocolVersion { get; } = "2.0";
 
         public string Method { get; set; }

--- a/src/JsonRpc/Client/Response.cs
+++ b/src/JsonRpc/Client/Response.cs
@@ -17,6 +17,7 @@ namespace OmniSharp.Extensions.JsonRpc.Client
             Result = result;
         }
 
+        [JsonProperty("jsonrpc")]
         public string ProtocolVersion { get; set; } = "2.0";
 
         public object Id { get; set; }

--- a/src/JsonRpc/RpcError.cs
+++ b/src/JsonRpc/RpcError.cs
@@ -20,6 +20,7 @@ namespace OmniSharp.Extensions.JsonRpc
             ProtocolVersion = protocolVersion;
         }
 
+        [JsonProperty("jsonrpc")]
         public string ProtocolVersion { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/src/JsonRpc/RpcErrorConverter.cs
+++ b/src/JsonRpc/RpcErrorConverter.cs
@@ -36,7 +36,7 @@ namespace OmniSharp.Extensions.JsonRpc
                 data = dataToken.ToObject(errorMessageType, serializer);
             }
 
-            return Activator.CreateInstance(objectType, requestId, data, obj["protocolVersion"].ToString());
+            return Activator.CreateInstance(objectType, requestId, data, obj["jsonrpc"].ToString());
         }
 
         public override bool CanConvert(Type objectType)

--- a/src/JsonRpc/Server/Notification.cs
+++ b/src/JsonRpc/Server/Notification.cs
@@ -18,6 +18,7 @@ namespace OmniSharp.Extensions.JsonRpc.Server
 
         internal Notification(string method, JToken @params) : this(method, @params, "2.0") { }
 
+        [JsonProperty("jsonrpc")]
         public string ProtocolVersion { get; }
 
         public string Method { get; }

--- a/src/JsonRpc/Server/Request.cs
+++ b/src/JsonRpc/Server/Request.cs
@@ -22,6 +22,7 @@ namespace OmniSharp.Extensions.JsonRpc.Server
 
         public object Id { get; }
 
+        [JsonProperty("jsonrpc")]
         public string ProtocolVersion { get; }
 
         public string Method { get; }

--- a/src/JsonRpc/Server/ResponseBase.cs
+++ b/src/JsonRpc/Server/ResponseBase.cs
@@ -1,3 +1,7 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+
 namespace OmniSharp.Extensions.JsonRpc.Server
 {
     public class ResponseBase
@@ -7,6 +11,7 @@ namespace OmniSharp.Extensions.JsonRpc.Server
             Id = id;
         }
 
+        [JsonProperty("jsonrpc")]
         public string ProtocolVersion { get; set; } = "2.0";
 
         public object Id { get; set; }

--- a/test/JsonRpc.Tests/OutputHandlerTests.cs
+++ b/test/JsonRpc.Tests/OutputHandlerTests.cs
@@ -50,7 +50,7 @@ namespace JsonRpc.Tests
 
                 handler.Send(value);
                 await wait();
-                const string send = "Content-Length: 43\r\n\r\n{\"protocolVersion\":\"2.0\",\"id\":1,\"result\":1}";
+                const string send = "Content-Length: 35\r\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":1}";
                 received.Should().Be(send);
                 var b = System.Text.Encoding.UTF8.GetBytes(send);
                 w.Received().Write(Arg.Any<byte[]>(), 0, b.Length); // can't compare b here, because it is only value-equal and this test tests reference equality

--- a/test/Lsp.Tests/Messages/ServerErrorEndTests_$SimpleTest.json
+++ b/test/Lsp.Tests/Messages/ServerErrorEndTests_$SimpleTest.json
@@ -1,5 +1,5 @@
 {
-    "protocolVersion": "2.0",
+    "jsonrpc": "2.0",
     "error": {
         "code": -32000,
         "message": "Server Error End"

--- a/test/Lsp.Tests/Messages/ServerErrorStartTests_$SimpleTest.json
+++ b/test/Lsp.Tests/Messages/ServerErrorStartTests_$SimpleTest.json
@@ -1,5 +1,5 @@
 {
-    "protocolVersion": "2.0",
+    "jsonrpc": "2.0",
     "error": {
         "code": -32099,
         "message": "Server Error Start",

--- a/test/Lsp.Tests/Messages/ServerNotInitializedTests_$SimpleTest.json
+++ b/test/Lsp.Tests/Messages/ServerNotInitializedTests_$SimpleTest.json
@@ -1,5 +1,5 @@
 {
-    "protocolVersion": "2.0",
+    "jsonrpc": "2.0",
     "error": {
         "code": -32002,
         "message": "Server Not Initialized"

--- a/test/Lsp.Tests/Messages/UnknownErrorCodeTests_$SimpleTest.json
+++ b/test/Lsp.Tests/Messages/UnknownErrorCodeTests_$SimpleTest.json
@@ -1,5 +1,5 @@
 {
-    "protocolVersion": "2.0",
+    "jsonrpc": "2.0",
     "error": {
         "code": -32602,
         "message": "Unknown Error Code"


### PR DESCRIPTION
Fixes #98 

Instead of serializing out `{"jsonrpc": "2.0", "result": 19, "id": 1}` as per https://www.jsonrpc.org/specification we've been serializing `{"protcolVersion": "2.0", "result": 19, "id": 1}`.  Talk about a WTF moment...

![image](https://user-images.githubusercontent.com/1269157/44699957-9cd54f00-aa54-11e8-848c-41947363ccff.png)
