### PR TITLE
Expose service provider through ILanguageServer interface also.

### DIFF
--- a/src/Server/ILanguageServer.cs
+++ b/src/Server/ILanguageServer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -18,6 +19,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
 
         InitializeParams ClientSettings { get; }
         InitializeResult ServerSettings { get; }
+        IServiceProvider Services { get; }
 
         IObservable<bool> Shutdown { get; }
         IObservable<int> Exit { get; }


### PR DESCRIPTION
@david-driscoll you recently exposed services on `LanguageServer`, I think it would be wise to also expose it through the interface in order to avoid unnecessary casts.