### PR TITLE
Add missing FailureHandlingKind enum member.

### DIFF
--- a/src/Protocol/Models/FailureHandlingKind.cs
+++ b/src/Protocol/Models/FailureHandlingKind.cs
@@ -24,5 +24,12 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
         /// </summary>
         [EnumMember(Value = "delete")]
         Delete,
+        /// <summary>
+        /// If the workspace edit contains only textual file changes they are executed transactional.
+        /// If resource changes (create, rename or delete file) are part of the change the failure
+        /// handling strategy is abort.
+        /// </summary>
+        [EnumMember(Value = "textOnlyTransactional")]
+        TextOnlyTransactional,
     }
 }


### PR DESCRIPTION
This adds the missing TextOnlyTransactional enum value to FailureHandlingKind.cs.
Without this value, my LSP would crash with the 1.33.0 vscode insiders version.

cc @david-driscoll 