### PR TITLE
Fixes FailureHandlingKind after LSP spec update

### DIFF
--- a/src/Protocol/Models/FailureHandlingKind.cs
+++ b/src/Protocol/Models/FailureHandlingKind.cs
@@ -8,8 +8,8 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
     public enum FailureHandlingKind
     {
         /// <summary>
-        /// All operations are executed transactional. That means they either all
-        /// succeed or no changes at all are applied to the workspace.
+        /// Applying the workspace change is simply aborted if one of the changes provided
+        /// fails. All operations executed before the failing operation stay executed.
         /// </summary>
         [EnumMember(Value = "abort")]
         Abort,
@@ -20,9 +20,17 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
         [EnumMember(Value = "transactional")]
         Transactional,
         /// <summary>
-        ///Supports deleting existing files and folders.
+        /// If the workspace edit contains only textual file changes they are executed transactional.
+        /// If resource changes (create, rename or delete file) are part of the change the failure
+        /// handling strategy is abort.
         /// </summary>
-        [EnumMember(Value = "delete")]
-        Delete,
+        [EnumMember(Value = "textOnlyTransactional")]
+        TextOnlyTransactional,
+        /// <summary>
+        /// The client tries to undo the operations already executed. But there is no
+        /// guarantee that this is succeeding.
+        /// </summary>
+        [EnumMember(Value = "undo")]
+        Undo,
     }
 }


### PR DESCRIPTION
Tried out the betas with an updated LSP client and got this exception:
```
Unhandled Exception: Newtonsoft.Json.JsonSerializationException: Error converting value "textOnlyTransactional" to type 'System.Nullable`1[OmniSharp.Extensions.LanguageServer.Protocol.Models.FailureHandlingKind]'. Path 'params.capabilities.workspace.workspaceEdit.failureHandling', line 1, position 349. ---> System.ArgumentException: Requested value 'textOnlyTransactional' was not found.
```