### PR TITLE
Fix/init capabilities

### DIFF
--- a/src/Protocol/Models/BooleanOr.cs
+++ b/src/Protocol/Models/BooleanOr.cs
@@ -48,7 +48,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 
         public static implicit operator BooleanOr<T>(T value)
         {
-            return new BooleanOr<T>(value);
+            return value != null ? new BooleanOr<T>(value) : null;
         }
 
         public static implicit operator BooleanOr<T>(bool value)

--- a/src/Protocol/Models/BooleanOr.cs
+++ b/src/Protocol/Models/BooleanOr.cs
@@ -1,6 +1,6 @@
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
-    public struct BooleanOr<T>
+    public class BooleanOr<T>
     {
         private T _value;
         private bool? _bool;

--- a/src/Protocol/Serialization/Converters/BooleanOrConverter.cs
+++ b/src/Protocol/Serialization/Converters/BooleanOrConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -29,7 +29,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
                 return;
             }
 
-            if (value.IsBool && value.Bool)
+            if (value.IsBool)
             {
                 new JValue(value.Bool).WriteTo(writer);
                 return;
@@ -57,7 +57,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
                 return new BooleanOr<T>(JObject.Load(reader).ToObject<T>(serializer));
             }
 
-            return new BooleanOr<T>();
+            return new BooleanOr<T>(default(T));
         }
 
         public override bool CanRead => true;

--- a/test/Lsp.Tests/Capabilities/Server/ServerCapabilitiesTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/ServerCapabilitiesTests.cs
@@ -59,7 +59,24 @@ namespace Lsp.Tests.Capabilities.Server
                     WillSaveWaitUntil = true
                 }),
                 WorkspaceSymbolProvider = true,
+                ColorProvider = true,
+                FoldingRangeProvider = true,
+                ImplementationProvider = true,
+                TypeDefinitionProvider = true
             };
+            var result = Fixture.SerializeObject(model);
+
+            result.Should().Be(expected);
+
+            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ServerCapabilities>(expected);
+            deresult.Should().BeEquivalentTo(model);
+        }
+
+        [Theory, JsonFixture]
+        public void Optional(string expected)
+        {
+            var model = new ServerCapabilities();
+
             var result = Fixture.SerializeObject(model);
 
             result.Should().Be(expected);

--- a/test/Lsp.Tests/Capabilities/Server/ServerCapabilitiesTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/ServerCapabilitiesTests.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
 using Xunit;
@@ -75,7 +76,9 @@ namespace Lsp.Tests.Capabilities.Server
         [Theory, JsonFixture]
         public void Optional(string expected)
         {
-            var model = new ServerCapabilities();
+            var model = new ServerCapabilities {
+                ColorProvider = (ColorOptions)null
+            };
 
             var result = Fixture.SerializeObject(model);
 

--- a/test/Lsp.Tests/Capabilities/Server/ServerCapabilitiesTests_$Optional.json
+++ b/test/Lsp.Tests/Capabilities/Server/ServerCapabilitiesTests_$Optional.json
@@ -1,0 +1,11 @@
+{
+    "hoverProvider": false,
+    "definitionProvider": false,
+    "referencesProvider": false,
+    "documentHighlightProvider": false,
+    "documentSymbolProvider": false,
+    "workspaceSymbolProvider": false,
+    "documentFormattingProvider": false,
+    "documentRangeFormattingProvider": false,
+    "experimental": {}
+}

--- a/test/Lsp.Tests/Capabilities/Server/ServerCapabilitiesTests_$SimpleTest.json
+++ b/test/Lsp.Tests/Capabilities/Server/ServerCapabilitiesTests_$SimpleTest.json
@@ -54,8 +54,8 @@
     "experimental": {
         "abc": "123"
     },
-    "typeDefinitionProvider": null,
-    "implementationProvider": null,
-    "colorProvider": null,
-    "foldingRangeProvider": null
+    "typeDefinitionProvider": true,
+    "implementationProvider": true,
+    "colorProvider": true,
+    "foldingRangeProvider": true
 }

--- a/test/Lsp.Tests/Models/InitializeResultTests_$SimpleTest.json
+++ b/test/Lsp.Tests/Models/InitializeResultTests_$SimpleTest.json
@@ -54,10 +54,6 @@
         },
         "experimental": {
             "abc": "123"
-        },
-        "typeDefinitionProvider": null,
-        "implementationProvider": null,
-        "colorProvider": null,
-        "foldingRangeProvider": null
+        }
     }
 }


### PR DESCRIPTION
Tries to solve same issue as in #139 but in a different way. Problem is that `BooleanOr<T>` is a struct, hence the `[Optional]` attribute has no meaning (`null` will be serialized).

Honestly don't know if this is a good option or not.. //cc @david-driscoll 