### PR TITLE
GH159: Fixes BooleanOrConverter

### DIFF
--- a/src/Protocol/Serialization/Converters/BooleanOrConverter.cs
+++ b/src/Protocol/Serialization/Converters/BooleanOrConverter.cs
@@ -25,7 +25,15 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
         {
             if (value.IsValue)
             {
-                new JValue(value.Value).WriteTo(writer);
+                if (typeof(T).IsValueType)
+                {
+                    new JValue(value.Value).WriteTo(writer);
+                }
+                else
+                {
+                    serializer.Serialize(writer, value.Value);
+                }
+                
                 return;
             }
 

--- a/test/Lsp.Tests/Models/InitializeResultTests.cs
+++ b/test/Lsp.Tests/Models/InitializeResultTests.cs
@@ -70,5 +70,48 @@ namespace Lsp.Tests.Models
             var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<InitializeResult>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
+
+        [Theory, JsonFixture]
+        public void BooleanOrTest(string expected)
+        {
+            var model = new InitializeResult() {
+                Capabilities = new ServerCapabilities {
+                    CodeActionProvider = new CodeActionOptions {
+                        CodeActionKinds = new [] {
+                            CodeActionKind.QuickFix
+                        }
+                    },
+                    ColorProvider = new ColorOptions {
+                        DocumentSelector = DocumentSelector.ForPattern("**/*.foo"),
+                        Id = "foo"
+                    },
+                    DeclarationProvider = new DeclarationOptions {
+                        DocumentSelector = DocumentSelector.ForPattern("**/*.foo"),
+                        Id = "foo"
+                    },
+                    FoldingRangeProvider = new FoldingRangeOptions {
+                        DocumentSelector = DocumentSelector.ForPattern("**/*.foo"),
+                        Id = "foo"
+                    },
+                    ImplementationProvider = new ImplementationOptions {
+                        DocumentSelector = DocumentSelector.ForPattern("**/*.foo"),
+                        Id = "foo"
+                    },
+                    RenameProvider = new RenameOptions {
+                        PrepareProvider = true
+                    },
+                    TypeDefinitionProvider = new TypeDefinitionOptions {
+                        DocumentSelector = DocumentSelector.ForPattern("**/*.foo"),
+                        Id = "foo"
+                    }
+                }
+            };
+            var result = Fixture.SerializeObject(model);
+
+            result.Should().Be(expected);
+
+            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<InitializeResult>(expected);
+            deresult.Should().BeEquivalentTo(model);
+        }
     }
 }

--- a/test/Lsp.Tests/Models/InitializeResultTests_$BooleanOrTest.json
+++ b/test/Lsp.Tests/Models/InitializeResultTests_$BooleanOrTest.json
@@ -1,0 +1,61 @@
+{
+    "capabilities": {
+        "hoverProvider": false,
+        "definitionProvider": false,
+        "referencesProvider": false,
+        "documentHighlightProvider": false,
+        "documentSymbolProvider": false,
+        "workspaceSymbolProvider": false,
+        "codeActionProvider": {
+            "codeActionKinds": [
+                "quickfix"
+            ]
+        },
+        "documentFormattingProvider": false,
+        "documentRangeFormattingProvider": false,
+        "renameProvider": {
+            "prepareProvider": true
+        },
+        "experimental": {},
+        "typeDefinitionProvider": {
+            "id": "foo",
+            "documentSelector": [
+                {
+                    "pattern": "**/*.foo"
+                }
+            ]
+        },
+        "implementationProvider": {
+            "id": "foo",
+            "documentSelector": [
+                {
+                    "pattern": "**/*.foo"
+                }
+            ]
+        },
+        "colorProvider": {
+            "id": "foo",
+            "documentSelector": [
+                {
+                    "pattern": "**/*.foo"
+                }
+            ]
+        },
+        "foldingRangeProvider": {
+            "id": "foo",
+            "documentSelector": [
+                {
+                    "pattern": "**/*.foo"
+                }
+            ]
+        },
+        "declarationProvider": {
+            "id": "foo",
+            "documentSelector": [
+                {
+                    "pattern": "**/*.foo"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
- Serialize object type correctly
- Fixes #159

With #156 and #148 we will now see `BooleanOr<T>` serializing `T` as class, which bubbled up a bug in the converter. We where trying to feed a `JValue` with the object directly, which made JSON.NET throw an exception. Best is to probably have the serializer serialize it directly into the writer.