### PR TITLE
remove extra Reciever

### DIFF
--- a/src/JsonRpc/JsonRpcServer.cs
+++ b/src/JsonRpc/JsonRpcServer.cs
@@ -90,7 +90,6 @@ namespace OmniSharp.Extensions.JsonRpc
             services.AddJsonRpcMediatR(assemblies);
             services.AddSingleton<IJsonRpcServer>(this);
             services.AddSingleton<IRequestRouter<IHandlerDescriptor>, RequestRouter>();
-            services.AddSingleton<IReciever, Reciever>();
             services.AddSingleton<IResponseRouter, ResponseRouter>();
 
             var foundHandlers = services


### PR DESCRIPTION
The reciever is added a few lines up on line 87 so we don't want to replace that with a new instance of the `Receiver` class which wouldn't work for the debug adapter.




side note... isn't it spelled `receiver`? (`i` before `e` except after `c` 😄)