### PR TITLE
switch null to new JObject so it can still be parsed into the right type

### DIFF
--- a/src/JsonRpc/DapReciever.cs
+++ b/src/JsonRpc/DapReciever.cs
@@ -57,7 +57,7 @@ namespace OmniSharp.Extensions.JsonRpc
                 {
                     return new InvalidRequest(null, "No command given");
                 }
-                return new Request(sequence, command.Value<string>(), request.TryGetValue("arguments", out var body) ? body : null);
+                return new Request(sequence, command.Value<string>(), request.TryGetValue("arguments", out var body) ? body : new JObject());
             }
             if (messageType == "response")
             {


### PR DESCRIPTION
This was needed for the `configurationDone` message which is a Client->Server request that has no params.

It was failing to cast an EmptyResponse to the ConfigurationDone request. 