### PR TITLE
Initial handling of errors

### DIFF
--- a/src/JsonRpc/HandledErrorException.cs
+++ b/src/JsonRpc/HandledErrorException.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace OmniSharp.Extensions.JsonRpc
+{
+    public class HandledErrorException : Exception {}
+}

--- a/src/JsonRpc/RequestRouterBase.cs
+++ b/src/JsonRpc/RequestRouterBase.cs
@@ -148,6 +148,11 @@ namespace OmniSharp.Extensions.JsonRpc
 
                         return new JsonRpc.Client.Response(request.Id, responseValue, request);
                     }
+                    catch (HandledErrorException e)
+                    {
+                        _logger.LogDebug("Request {id} had a handled error", id);
+                        return new RpcError(id, request.Method, new ErrorMessage(0, e.Message));
+                    }
                     catch (TaskCanceledException e)
                     {
                         _logger.LogDebug("Request {Id} was cancelled", id);

--- a/src/JsonRpc/RpcError.cs
+++ b/src/JsonRpc/RpcError.cs
@@ -13,7 +13,15 @@ namespace OmniSharp.Extensions.JsonRpc
             Error = message;
         }
 
+        public RpcError(object id, string command, ErrorMessage message)
+        {
+            Id = id;
+            Command = command;
+            Error = message;
+        }
+
         public object Id { get; }
         public ErrorMessage Error { get; }
+        public string Command { get; }
     }
 }

--- a/src/JsonRpc/Serialization/DebugAdapterConverters/DapRpcErrorConverter.cs
+++ b/src/JsonRpc/Serialization/DebugAdapterConverters/DapRpcErrorConverter.cs
@@ -20,11 +20,17 @@ namespace OmniSharp.Extensions.JsonRpc.Serialization.DebugAdapterConverters
             writer.WriteStartObject();
             writer.WritePropertyName("seq");
             writer.WriteValue(_serializer.GetNextId());
+            writer.WritePropertyName("type");
+            writer.WriteValue("response");
             if (value.Id != null)
             {
                 writer.WritePropertyName("request_seq");
-                writer.WriteValue(value.Id);
+                writer.WriteValue(long.Parse((string) value.Id));
             }
+            writer.WritePropertyName("command");
+            writer.WriteValue(value.Command);
+            writer.WritePropertyName("success");
+            writer.WriteValue(false);
             writer.WritePropertyName("message");
             writer.WriteValue(value.Error.Message);
             writer.WriteEndObject();
@@ -49,6 +55,11 @@ namespace OmniSharp.Extensions.JsonRpc.Serialization.DebugAdapterConverters
             {
                 var errorMessageType = typeof(ErrorMessage);
                 data = dataToken.ToObject<ErrorMessage>(serializer);
+            }
+
+            if (obj.TryGetValue("command", out var command))
+            {
+                return new RpcError(requestId, (string) command, data);
             }
 
             return new RpcError(requestId, data);


### PR DESCRIPTION
This PR includes the initial ability to handle errors via throwing a `HandledErrorException`.

It also fixes up the `DapRpcErrorConverter` to have the right schema.