### PR TITLE
fix up WriteJson for DAP error handling

### DIFF
--- a/src/JsonRpc/Serialization/DebugAdapterConverters/DapRpcErrorConverter.cs
+++ b/src/JsonRpc/Serialization/DebugAdapterConverters/DapRpcErrorConverter.cs
@@ -20,13 +20,17 @@ namespace OmniSharp.Extensions.JsonRpc.Serialization.DebugAdapterConverters
             writer.WriteStartObject();
             writer.WritePropertyName("seq");
             writer.WriteValue(_serializer.GetNextId());
+            writer.WritePropertyName("type");
+            writer.WriteValue("response");
             if (value.Id != null)
             {
                 writer.WritePropertyName("request_seq");
-                writer.WriteValue(value.Id);
+                writer.WriteValue(long.Parse((string) value.Id));
             }
+            writer.WritePropertyName("success");
+            writer.WriteValue(false);
             writer.WritePropertyName("message");
-            writer.WriteValue(value.Error.Message);
+            writer.WriteValue(value.Error.Data);
             writer.WriteEndObject();
         }
 


### PR DESCRIPTION
Now in my handler I can do:

```csharp
throw new RpcErrorException(0, "A positive integer must be specified for the processId field.");
```
and then I get:

![image](https://user-images.githubusercontent.com/2644648/65473344-3f185f80-de2c-11e9-9b94-3e1849c1df2c.png)

One thing that does concern me is that the [DAP spec says that `command` is required](https://microsoft.github.io/debug-adapter-protocol/specification#Base_Protocol_Response) in Response bodies, but this functionality works as I want so I'm going to just ignore that detail for now as it might actually be optional.
