### PR TITLE
Changes for #175 to return a Location object for diagnostic related information

### DIFF
--- a/src/Protocol/Models/DiagnosticRelatedInformation.cs
+++ b/src/Protocol/Models/DiagnosticRelatedInformation.cs
@@ -10,7 +10,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
         /// <summary>
         /// The location of this related diagnostic information.
         /// </summary>
-        public string Location { get; set; }
+        public Location Location { get; set; }
 
         /// <summary>
         /// The message of this related diagnostic information.

--- a/test/Lsp.Tests/Models/DiagnosticTests.cs
+++ b/test/Lsp.Tests/Models/DiagnosticTests.cs
@@ -30,6 +30,41 @@ namespace Lsp.Tests.Models
         }
 
         [Theory, JsonFixture]
+        public void RelatedInformationTest(string expected)
+        {
+            var model = new Diagnostic() {
+                Code = new DiagnosticCode("abcd"),
+                Message = "message",
+                Range = new Range(new Position(1, 1), new Position(2, 2)),
+                Severity = DiagnosticSeverity.Error,
+                Source = "csharp",
+                RelatedInformation = new Container<DiagnosticRelatedInformation>(
+                    new DiagnosticRelatedInformation {
+                        Location = new Location {
+                            Uri = new Uri("file:///abc/def.cs"),
+                            Range = new Range(new Position(1, 2), new Position(3, 4))
+                        },
+                        Message = "related message 1"
+                    },
+                    new DiagnosticRelatedInformation {
+                        Location = new Location {
+                            Uri = new Uri("file:///def/ghi.cs"),
+                            Range = new Range(new Position(5, 6), new Position(7, 8))
+                        },
+                        Message = "related message 2"
+                    }
+                )
+            };
+
+            var result = Fixture.SerializeObject(model);
+
+            result.Should().Be(expected);
+
+            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<Diagnostic>(expected);
+            deresult.Should().BeEquivalentTo(model);
+        }
+
+        [Theory, JsonFixture]
         public void OptionalTest(string expected)
         {
             var model = new Diagnostic();

--- a/test/Lsp.Tests/Models/DiagnosticTests_$RelatedInformationTest.json
+++ b/test/Lsp.Tests/Models/DiagnosticTests_$RelatedInformationTest.json
@@ -1,0 +1,50 @@
+{
+    "range": {
+        "start": {
+            "line": 1,
+            "character": 1
+        },
+        "end": {
+            "line": 2,
+            "character": 2
+        }
+    },
+    "severity": 1,
+    "code": "abcd",
+    "source": "csharp",
+    "message": "message",
+    "relatedInformation": [
+        {
+            "location": {
+                "uri": "file:///abc/def.cs",
+                "range": {
+                    "start": {
+                        "line": 1,
+                        "character": 2
+                    },
+                    "end": {
+                        "line": 3,
+                        "character": 4
+                    }
+                }
+            },
+            "message": "related message 1"
+        },
+        {
+            "location": {
+                "uri": "file:///def/ghi.cs",
+                "range": {
+                    "start": {
+                        "line": 5,
+                        "character": 6
+                    },
+                    "end": {
+                        "line": 7,
+                        "character": 8
+                    }
+                }
+            },
+            "message": "related message 2"
+        }
+    ]
+}


### PR DESCRIPTION
This will change the return of the DiagnosticRelatedInformation.Location property from string to Location.