### PR TITLE
Do not embed MediatR

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "submodules/MediatR.Extensions.Microsoft.DependencyInjection"]
-	path = submodules/MediatR.Extensions.Microsoft.DependencyInjection
-	url = https://github.com/jbogard/MediatR.Extensions.Microsoft.DependencyInjection.git
-[submodule "submodules/MediatR"]
-	path = submodules/MediatR
-	url = https://github.com/jbogard/MediatR.git

--- a/Common.Build.props
+++ b/Common.Build.props
@@ -12,6 +12,7 @@
         <PackageTags>lsp;language server;language server protocol;language client;language server client</PackageTags>
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\lsp.snk</AssemblyOriginatorKeyFile>
         <Logging_Extensions_Version>2.0.0</Logging_Extensions_Version>
+        <MediatR_Version>7.0.0</MediatR_Version>
     </PropertyGroup>
     <PropertyGroup>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Common.Build.targets
+++ b/Common.Build.targets
@@ -22,5 +22,7 @@
         <PackageReference Update="XunitXml.TestLogger" Version="2.1.26" />
         <PackageReference Update="coverlet.msbuild" Version="2.5.1" />
         <PackageReference Update="System.Reactive" Version="4.1.2" />
+        <PackageReference Update="MediatR" Version="$(MediatR_Version)" />
+        <PackageReference Update="MediatR.Extensions.Microsoft.DependencyInjection" Version="$(MediatR_Version)" />
     </ItemGroup>
 </Project>

--- a/build.cake
+++ b/build.cake
@@ -1,28 +1,6 @@
 #load "nuget:?package=Rocket.Surgery.Cake.Library&version=0.9.3";
 
-Task("Submodules")
-    .Does(() => {
-        StartProcess("git", "submodule update --init --recursive");
-    });
-
-Task("Embed MediatR")
-    .Does(() => {
-        foreach (var file in GetFiles("submodules/**/*.cs"))
-        {
-            var content = System.IO.File.ReadAllText(file.FullPath);
-            if (content.IndexOf("namespace MediatR") > -1 || content.IndexOf("using MediatR") > -1)
-            {
-                System.IO.File.WriteAllText(file.FullPath, content
-                    .Replace("namespace MediatR", "namespace OmniSharp.Extensions.Embedded.MediatR")
-                    .Replace("using MediatR", "using OmniShqarp.Extensions.Embedded.MediatR")
-                );
-            }
-        }
-    });
-
 Task("Default")
-    .IsDependentOn("Submodules")
-    .IsDependentOn("Embed MediatR")
     .IsDependentOn("dotnetcore");
 
 RunTarget(Target);

--- a/sample/SampleServer/TextDocumentHandler.cs
+++ b/sample/SampleServer/TextDocumentHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.LanguageServer;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;

--- a/src/Client/Handlers/JsonRpcNotificationHandler.cs
+++ b/src/Client/Handlers/JsonRpcNotificationHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;

--- a/src/Client/LanguageRegistration.cs
+++ b/src/Client/LanguageRegistration.cs
@@ -1,5 +1,5 @@
 using System;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Client.Handlers;
 

--- a/src/Dap.Protocol/Events/BreakpointEvent.cs
+++ b/src/Dap.Protocol/Events/BreakpointEvent.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events
 {

--- a/src/Dap.Protocol/Events/BreakpointExtensions.cs
+++ b/src/Dap.Protocol/Events/BreakpointExtensions.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events

--- a/src/Dap.Protocol/Events/CapabilitiesEvent.cs
+++ b/src/Dap.Protocol/Events/CapabilitiesEvent.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events
 {

--- a/src/Dap.Protocol/Events/CapabilitiesExtensions.cs
+++ b/src/Dap.Protocol/Events/CapabilitiesExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events

--- a/src/Dap.Protocol/Events/ContinuedEvent.cs
+++ b/src/Dap.Protocol/Events/ContinuedEvent.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events
 {

--- a/src/Dap.Protocol/Events/ContinuedExtensions.cs
+++ b/src/Dap.Protocol/Events/ContinuedExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events

--- a/src/Dap.Protocol/Events/ExitedEvent.cs
+++ b/src/Dap.Protocol/Events/ExitedEvent.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events
 {

--- a/src/Dap.Protocol/Events/ExitedExtensions.cs
+++ b/src/Dap.Protocol/Events/ExitedExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events

--- a/src/Dap.Protocol/Events/InitializedEvent.cs
+++ b/src/Dap.Protocol/Events/InitializedEvent.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events
 {

--- a/src/Dap.Protocol/Events/InitializedExtensions.cs
+++ b/src/Dap.Protocol/Events/InitializedExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events

--- a/src/Dap.Protocol/Events/LoadedSourceEvent.cs
+++ b/src/Dap.Protocol/Events/LoadedSourceEvent.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events
 {

--- a/src/Dap.Protocol/Events/LoadedSourceExtensions.cs
+++ b/src/Dap.Protocol/Events/LoadedSourceExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events

--- a/src/Dap.Protocol/Events/ModuleEvent.cs
+++ b/src/Dap.Protocol/Events/ModuleEvent.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events
 {

--- a/src/Dap.Protocol/Events/ModuleExtensions.cs
+++ b/src/Dap.Protocol/Events/ModuleExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events

--- a/src/Dap.Protocol/Events/OutputEvent.cs
+++ b/src/Dap.Protocol/Events/OutputEvent.cs
@@ -1,7 +1,7 @@
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events
 {

--- a/src/Dap.Protocol/Events/OutputExtensions.cs
+++ b/src/Dap.Protocol/Events/OutputExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events

--- a/src/Dap.Protocol/Events/ProcessEvent.cs
+++ b/src/Dap.Protocol/Events/ProcessEvent.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events
 {

--- a/src/Dap.Protocol/Events/ProcessExtensions.cs
+++ b/src/Dap.Protocol/Events/ProcessExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events

--- a/src/Dap.Protocol/Events/StoppedEvent.cs
+++ b/src/Dap.Protocol/Events/StoppedEvent.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events
 {

--- a/src/Dap.Protocol/Events/StoppedExtensions.cs
+++ b/src/Dap.Protocol/Events/StoppedExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events

--- a/src/Dap.Protocol/Events/TerminatedEvent.cs
+++ b/src/Dap.Protocol/Events/TerminatedEvent.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events
 {

--- a/src/Dap.Protocol/Events/TerminatedExtensions.cs
+++ b/src/Dap.Protocol/Events/TerminatedExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events

--- a/src/Dap.Protocol/Events/ThreadEvent.cs
+++ b/src/Dap.Protocol/Events/ThreadEvent.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events
 {

--- a/src/Dap.Protocol/Events/ThreadExtensions.cs
+++ b/src/Dap.Protocol/Events/ThreadExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Events

--- a/src/Dap.Protocol/Requests/AttachRequestArguments.cs
+++ b/src/Dap.Protocol/Requests/AttachRequestArguments.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/CompletionsArguments.cs
+++ b/src/Dap.Protocol/Requests/CompletionsArguments.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/ConfigurationDoneArguments.cs
+++ b/src/Dap.Protocol/Requests/ConfigurationDoneArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/ContinueArguments.cs
+++ b/src/Dap.Protocol/Requests/ContinueArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/DataBreakpointInfoArguments.cs
+++ b/src/Dap.Protocol/Requests/DataBreakpointInfoArguments.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/DisassembleArguments.cs
+++ b/src/Dap.Protocol/Requests/DisassembleArguments.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/DisconnectArguments.cs
+++ b/src/Dap.Protocol/Requests/DisconnectArguments.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/EvaluateArguments.cs
+++ b/src/Dap.Protocol/Requests/EvaluateArguments.cs
@@ -1,6 +1,6 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/ExceptionInfoArguments.cs
+++ b/src/Dap.Protocol/Requests/ExceptionInfoArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/GotoArguments.cs
+++ b/src/Dap.Protocol/Requests/GotoArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/GotoTargetsArguments.cs
+++ b/src/Dap.Protocol/Requests/GotoTargetsArguments.cs
@@ -1,6 +1,6 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/InitializeRequestArguments.cs
+++ b/src/Dap.Protocol/Requests/InitializeRequestArguments.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/LaunchRequestArguments.cs
+++ b/src/Dap.Protocol/Requests/LaunchRequestArguments.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/LoadedSourcesArguments.cs
+++ b/src/Dap.Protocol/Requests/LoadedSourcesArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/ModulesArguments.cs
+++ b/src/Dap.Protocol/Requests/ModulesArguments.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/NextArguments.cs
+++ b/src/Dap.Protocol/Requests/NextArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/PauseArguments.cs
+++ b/src/Dap.Protocol/Requests/PauseArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/ReadMemoryArguments.cs
+++ b/src/Dap.Protocol/Requests/ReadMemoryArguments.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/RestartArguments.cs
+++ b/src/Dap.Protocol/Requests/RestartArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/RestartFrameArguments.cs
+++ b/src/Dap.Protocol/Requests/RestartFrameArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/ReverseContinueArguments.cs
+++ b/src/Dap.Protocol/Requests/ReverseContinueArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/RunInTerminalArguments.cs
+++ b/src/Dap.Protocol/Requests/RunInTerminalArguments.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/ScopesArguments.cs
+++ b/src/Dap.Protocol/Requests/ScopesArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/SetBreakpointsArguments.cs
+++ b/src/Dap.Protocol/Requests/SetBreakpointsArguments.cs
@@ -1,7 +1,7 @@
 using System;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/SetDataBreakpointsArguments.cs
+++ b/src/Dap.Protocol/Requests/SetDataBreakpointsArguments.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/SetExceptionBreakpointsArguments.cs
+++ b/src/Dap.Protocol/Requests/SetExceptionBreakpointsArguments.cs
@@ -1,6 +1,6 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/SetExpressionArguments.cs
+++ b/src/Dap.Protocol/Requests/SetExpressionArguments.cs
@@ -1,6 +1,6 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/SetFunctionBreakpointsArguments.cs
+++ b/src/Dap.Protocol/Requests/SetFunctionBreakpointsArguments.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/SetVariableArguments.cs
+++ b/src/Dap.Protocol/Requests/SetVariableArguments.cs
@@ -1,6 +1,6 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/SourceArguments.cs
+++ b/src/Dap.Protocol/Requests/SourceArguments.cs
@@ -1,6 +1,6 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/StackTraceArguments.cs
+++ b/src/Dap.Protocol/Requests/StackTraceArguments.cs
@@ -1,6 +1,6 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/StepBackArguments.cs
+++ b/src/Dap.Protocol/Requests/StepBackArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/StepInArguments.cs
+++ b/src/Dap.Protocol/Requests/StepInArguments.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/StepInTargetsArguments.cs
+++ b/src/Dap.Protocol/Requests/StepInTargetsArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/StepOutArguments.cs
+++ b/src/Dap.Protocol/Requests/StepOutArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/TerminateArguments.cs
+++ b/src/Dap.Protocol/Requests/TerminateArguments.cs
@@ -1,5 +1,5 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/TerminateThreadsArguments.cs
+++ b/src/Dap.Protocol/Requests/TerminateThreadsArguments.cs
@@ -1,6 +1,6 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/ThreadsArguments.cs
+++ b/src/Dap.Protocol/Requests/ThreadsArguments.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/Dap.Protocol/Requests/VariablesArguments.cs
+++ b/src/Dap.Protocol/Requests/VariablesArguments.cs
@@ -1,6 +1,6 @@
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {

--- a/src/JsonRpc/CancelParams.cs
+++ b/src/JsonRpc/CancelParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/JsonRpc/CancelRequestHandler.cs
+++ b/src/JsonRpc/CancelRequestHandler.cs
@@ -1,6 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.JsonRpc

--- a/src/JsonRpc/DelegatingNotification.cs
+++ b/src/JsonRpc/DelegatingNotification.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.JsonRpc
 {

--- a/src/JsonRpc/DelegatingNotificationHandler.cs
+++ b/src/JsonRpc/DelegatingNotificationHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.JsonRpc
 {

--- a/src/JsonRpc/DelegatingRequest.cs
+++ b/src/JsonRpc/DelegatingRequest.cs
@@ -1,5 +1,5 @@
 using Newtonsoft.Json.Linq;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.JsonRpc
 {

--- a/src/JsonRpc/EmptyRequest.cs
+++ b/src/JsonRpc/EmptyRequest.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.JsonRpc
 {

--- a/src/JsonRpc/HandlerCollection.cs
+++ b/src/JsonRpc/HandlerCollection.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Reflection;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.JsonRpc
 {

--- a/src/JsonRpc/ICancelRequestHandler.cs
+++ b/src/JsonRpc/ICancelRequestHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 // ReSharper disable CheckNamespace

--- a/src/JsonRpc/IJsonRpcHandler.cs
+++ b/src/JsonRpc/IJsonRpcHandler.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.JsonRpc
 {

--- a/src/JsonRpc/IJsonRpcNotificationHandler.cs
+++ b/src/JsonRpc/IJsonRpcNotificationHandler.cs
@@ -1,5 +1,5 @@
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.JsonRpc
 {

--- a/src/JsonRpc/IJsonRpcRequestHandler.cs
+++ b/src/JsonRpc/IJsonRpcRequestHandler.cs
@@ -1,6 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.JsonRpc
 {

--- a/src/JsonRpc/JsonRpc.csproj
+++ b/src/JsonRpc/JsonRpc.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Newtonsoft.Json" />
-        <Compile Include="../../submodules/MediatR/src/MediatR/**/*.cs" Exclude="**/*AssemblyInfo.cs" Visible="false" />
-        <Compile Include="../../submodules/MediatR.Extensions.Microsoft.DependencyInjection/src/MediatR.Extensions.Microsoft.DependencyInjection/**/*.cs" Exclude="**/*AssemblyInfo.cs" Visible="false" />
+        <PackageReference Include="MediatR" />
+        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" />
     </ItemGroup>
 </Project>

--- a/src/JsonRpc/JsonRpcServer.cs
+++ b/src/JsonRpc/JsonRpcServer.cs
@@ -8,7 +8,7 @@ using System.Reactive.Threading.Tasks;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;

--- a/src/JsonRpc/RequestRouterBase.cs
+++ b/src/JsonRpc/RequestRouterBase.cs
@@ -2,7 +2,7 @@ using System;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using OmniSharp.Extensions.JsonRpc.Server;
 using OmniSharp.Extensions.JsonRpc.Server.Messages;

--- a/src/JsonRpc/ServiceCollectionExtensions.cs
+++ b/src/JsonRpc/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using MediatR;
+using MediatR.Registration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -12,7 +13,8 @@ namespace OmniSharp.Extensions.JsonRpc
     {
         public static IServiceCollection AddJsonRpcMediatR(this IServiceCollection services, IEnumerable<Assembly> assemblies)
         {
-            services.AddMediatR(assemblies, configuration: null);
+            ServiceRegistrar.AddRequiredServices(services, new MediatRServiceConfiguration());
+            ServiceRegistrar.AddMediatRClasses(services, assemblies);
             services.AddScoped<IRequestContext, RequestContext>();
             services.RemoveAll<ServiceFactory>();
             services.AddScoped<ServiceFactory>(

--- a/src/JsonRpc/ServiceCollectionExtensions.cs
+++ b/src/JsonRpc/ServiceCollectionExtensions.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -11,7 +12,7 @@ namespace OmniSharp.Extensions.JsonRpc
     {
         public static IServiceCollection AddJsonRpcMediatR(this IServiceCollection services, IEnumerable<Assembly> assemblies)
         {
-            services.AddMediatR(assemblies);
+            services.AddMediatR(assemblies, configuration: null);
             services.AddScoped<IRequestContext, RequestContext>();
             services.RemoveAll<ServiceFactory>();
             services.AddScoped<ServiceFactory>(

--- a/src/Protocol/Client/Client/IRegisterCapabilityHandler.cs
+++ b/src/Protocol/Client/Client/IRegisterCapabilityHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 

--- a/src/Protocol/Client/Client/IUnregisterCapabilityHandler.cs
+++ b/src/Protocol/Client/Client/IUnregisterCapabilityHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 

--- a/src/Protocol/Document/Client/IPublishDiagnosticsHandler.cs
+++ b/src/Protocol/Document/Client/IPublishDiagnosticsHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 

--- a/src/Protocol/Document/Server/ICodeActionHandler.cs
+++ b/src/Protocol/Document/Server/ICodeActionHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/src/Protocol/Document/Server/IDidChangeTextDocumentHandler.cs
+++ b/src/Protocol/Document/Server/IDidChangeTextDocumentHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/src/Protocol/Document/Server/IDidCloseTextDocumentHandler.cs
+++ b/src/Protocol/Document/Server/IDidCloseTextDocumentHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/src/Protocol/Document/Server/IDidOpenTextDocumentHandler.cs
+++ b/src/Protocol/Document/Server/IDidOpenTextDocumentHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/src/Protocol/Document/Server/IDidSaveTextDocumentHandler.cs
+++ b/src/Protocol/Document/Server/IDidSaveTextDocumentHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/src/Protocol/Document/Server/ITextDocumentSyncHandler.cs
+++ b/src/Protocol/Document/Server/ITextDocumentSyncHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;

--- a/src/Protocol/Document/Server/IWillSaveTextDocumentHandler.cs
+++ b/src/Protocol/Document/Server/IWillSaveTextDocumentHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/src/Protocol/Document/Server/IWillSaveWaitUntilTextDocumentHandler.cs
+++ b/src/Protocol/Document/Server/IWillSaveWaitUntilTextDocumentHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/src/Protocol/General/Client/ShutdownExtensions.cs
+++ b/src/Protocol/General/Client/ShutdownExtensions.cs
@@ -1,5 +1,5 @@
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client;
 
 // ReSharper disable CheckNamespace

--- a/src/Protocol/General/Server/IExitHandler.cs
+++ b/src/Protocol/General/Server/IExitHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 

--- a/src/Protocol/General/Server/IInitializeHandler.cs
+++ b/src/Protocol/General/Server/IInitializeHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 

--- a/src/Protocol/General/Server/IInitializedHandler.cs
+++ b/src/Protocol/General/Server/IInitializedHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 // ReSharper disable CheckNamespace

--- a/src/Protocol/General/Server/IShutdownHandler.cs
+++ b/src/Protocol/General/Server/IShutdownHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 

--- a/src/Protocol/Models/ApplyWorkspaceEditParams.cs
+++ b/src/Protocol/Models/ApplyWorkspaceEditParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;

--- a/src/Protocol/Models/CodeActionParams.cs
+++ b/src/Protocol/Models/CodeActionParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/CodeLens.cs
+++ b/src/Protocol/Models/CodeLens.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;

--- a/src/Protocol/Models/CodeLensParams.cs
+++ b/src/Protocol/Models/CodeLensParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/ColorPresentationParams.cs
+++ b/src/Protocol/Models/ColorPresentationParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/CompletionItem.cs
+++ b/src/Protocol/Models/CompletionItem.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;

--- a/src/Protocol/Models/CompletionParams.cs
+++ b/src/Protocol/Models/CompletionParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;

--- a/src/Protocol/Models/ConfigurationParams.cs
+++ b/src/Protocol/Models/ConfigurationParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json.Linq;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models

--- a/src/Protocol/Models/DeclarationParams.cs
+++ b/src/Protocol/Models/DeclarationParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/DefinitionParams.cs
+++ b/src/Protocol/Models/DefinitionParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/DidChangeConfigurationParams.cs
+++ b/src/Protocol/Models/DidChangeConfigurationParams.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Newtonsoft.Json.Linq;

--- a/src/Protocol/Models/DidChangeTextDocumentParams.cs
+++ b/src/Protocol/Models/DidChangeTextDocumentParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/DidChangeWatchedFilesParams.cs
+++ b/src/Protocol/Models/DidChangeWatchedFilesParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/DidChangeWorkspaceFoldersParams.cs
+++ b/src/Protocol/Models/DidChangeWorkspaceFoldersParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/DidCloseTextDocumentParams.cs
+++ b/src/Protocol/Models/DidCloseTextDocumentParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/DidOpenTextDocumentParams.cs
+++ b/src/Protocol/Models/DidOpenTextDocumentParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/DidSaveTextDocumentParams.cs
+++ b/src/Protocol/Models/DidSaveTextDocumentParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;

--- a/src/Protocol/Models/DocumentColorParams.cs
+++ b/src/Protocol/Models/DocumentColorParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/DocumentFormattingParams.cs
+++ b/src/Protocol/Models/DocumentFormattingParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/DocumentHighlightParams.cs
+++ b/src/Protocol/Models/DocumentHighlightParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/DocumentLink.cs
+++ b/src/Protocol/Models/DocumentLink.cs
@@ -1,5 +1,5 @@
 using System;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;

--- a/src/Protocol/Models/DocumentLinkParams.cs
+++ b/src/Protocol/Models/DocumentLinkParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/DocumentOnTypeFormattingParams.cs
+++ b/src/Protocol/Models/DocumentOnTypeFormattingParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/DocumentRangeFormattingParams.cs
+++ b/src/Protocol/Models/DocumentRangeFormattingParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/DocumentSymbolParams.cs
+++ b/src/Protocol/Models/DocumentSymbolParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/ExecuteCommandParams.cs
+++ b/src/Protocol/Models/ExecuteCommandParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;

--- a/src/Protocol/Models/FoldingRangeRequestParam.cs
+++ b/src/Protocol/Models/FoldingRangeRequestParam.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/HoverParams.cs
+++ b/src/Protocol/Models/HoverParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/ICanBeResolvedHandler.cs
+++ b/src/Protocol/Models/ICanBeResolvedHandler.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models

--- a/src/Protocol/Models/ImplementationParams.cs
+++ b/src/Protocol/Models/ImplementationParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/InitializeParams.cs
+++ b/src/Protocol/Models/InitializeParams.cs
@@ -1,5 +1,5 @@
 using System;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;

--- a/src/Protocol/Models/InitializedParams.cs
+++ b/src/Protocol/Models/InitializedParams.cs
@@ -1,5 +1,5 @@
 using System;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;

--- a/src/Protocol/Models/LogMessageParams.cs
+++ b/src/Protocol/Models/LogMessageParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/PrepareRenameParams.cs
+++ b/src/Protocol/Models/PrepareRenameParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/PublishDiagnosticsParams.cs
+++ b/src/Protocol/Models/PublishDiagnosticsParams.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters;

--- a/src/Protocol/Models/ReferenceParams.cs
+++ b/src/Protocol/Models/ReferenceParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/RegistrationParams.cs
+++ b/src/Protocol/Models/RegistrationParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/RenameParams.cs
+++ b/src/Protocol/Models/RenameParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/ShowMessageParams.cs
+++ b/src/Protocol/Models/ShowMessageParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/ShowMessageRequestParams.cs
+++ b/src/Protocol/Models/ShowMessageRequestParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;

--- a/src/Protocol/Models/ShutdownParams.cs
+++ b/src/Protocol/Models/ShutdownParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/SignatureHelpParams.cs
+++ b/src/Protocol/Models/SignatureHelpParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/TypeDefinitionParams.cs
+++ b/src/Protocol/Models/TypeDefinitionParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/UnregistrationParams.cs
+++ b/src/Protocol/Models/UnregistrationParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/WillSaveTextDocumentParams.cs
+++ b/src/Protocol/Models/WillSaveTextDocumentParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Models/WillSaveWaitUntilTextDocumentParams.cs
+++ b/src/Protocol/Models/WillSaveWaitUntilTextDocumentParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/WorkspaceFolderParams.cs
+++ b/src/Protocol/Models/WorkspaceFolderParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {

--- a/src/Protocol/Models/WorkspaceSymbolParams.cs
+++ b/src/Protocol/Models/WorkspaceSymbolParams.cs
@@ -1,4 +1,4 @@
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Protocol/Window/Client/TelemetryEventParams.cs
+++ b/src/Protocol/Window/Client/TelemetryEventParams.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Protocol/Workspace/Server/IDidChangeConfigurationHandler.cs
+++ b/src/Protocol/Workspace/Server/IDidChangeConfigurationHandler.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/src/Protocol/Workspace/Server/IDidChangeWatchedFilesHandler.cs
+++ b/src/Protocol/Workspace/Server/IDidChangeWatchedFilesHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/src/Protocol/Workspace/Server/IDidChangeWorkspaceFoldersHandler.cs
+++ b/src/Protocol/Workspace/Server/IDidChangeWorkspaceFoldersHandler.cs
@@ -2,7 +2,7 @@ using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using System.Threading;
 using System;
 

--- a/src/Protocol/Workspace/Server/IExecuteCommandHandler.cs
+++ b/src/Protocol/Workspace/Server/IExecuteCommandHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/src/Server/HandlerDescriptor.cs
+++ b/src/Server/HandlerDescriptor.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;

--- a/src/Server/Handlers/ExitHandler.cs
+++ b/src/Server/Handlers/ExitHandler.cs
@@ -3,7 +3,7 @@ using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;

--- a/src/Server/Handlers/ShutdownHandler.cs
+++ b/src/Server/Handlers/ShutdownHandler.cs
@@ -4,7 +4,7 @@ using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;

--- a/src/Server/LanguageServer.cs
+++ b/src/Server/LanguageServer.cs
@@ -8,7 +8,7 @@ using System.Reactive.Threading.Tasks;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;

--- a/src/Server/LspRequestRouter.cs
+++ b/src/Server/LspRequestRouter.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;

--- a/src/Server/Matchers/ResolveCommandMatcher.cs
+++ b/src/Server/Matchers/ResolveCommandMatcher.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;

--- a/src/Server/Pipelines/ResolveCommandPipeline.cs
+++ b/src/Server/Pipelines/ResolveCommandPipeline.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.JsonRpc;

--- a/test/JsonRpc.Tests/AutoNSubstitute/NSubstituteRegistrationHandler.cs
+++ b/test/JsonRpc.Tests/AutoNSubstitute/NSubstituteRegistrationHandler.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Autofac;
 using Autofac.Builder;
 using Autofac.Core;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 // ReSharper disable once CheckNamespace
 namespace NSubstitute

--- a/test/JsonRpc.Tests/HandlerResolverTests.cs
+++ b/test/JsonRpc.Tests/HandlerResolverTests.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Common;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using NSubstitute;
 using OmniSharp.Extensions.JsonRpc;
 using Xunit;

--- a/test/JsonRpc.Tests/MediatorTestsNotificationHandler.cs
+++ b/test/JsonRpc.Tests/MediatorTestsNotificationHandler.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using OmniSharp.Extensions.JsonRpc;

--- a/test/JsonRpc.Tests/MediatorTestsNotificationHandlerOfT.cs
+++ b/test/JsonRpc.Tests/MediatorTestsNotificationHandlerOfT.cs
@@ -2,7 +2,7 @@ using System;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/test/JsonRpc.Tests/MediatorTestsRequestHandlerOfTRequest.cs
+++ b/test/JsonRpc.Tests/MediatorTestsRequestHandlerOfTRequest.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/test/JsonRpc.Tests/MediatorTestsRequestHandlerOfTRequestTResponse.cs
+++ b/test/JsonRpc.Tests/MediatorTestsRequestHandlerOfTRequestTResponse.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/test/JsonRpc.Tests/RequestRouterTests.cs
+++ b/test/JsonRpc.Tests/RequestRouterTests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;

--- a/test/Lsp.Tests/ExecuteCommandSyncHandlerExtensions.cs
+++ b/test/Lsp.Tests/ExecuteCommandSyncHandlerExtensions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using NSubstitute;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/test/Lsp.Tests/HandlerResolverTests.cs
+++ b/test/Lsp.Tests/HandlerResolverTests.cs
@@ -12,7 +12,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 using HandlerCollection = OmniSharp.Extensions.LanguageServer.Server.HandlerCollection;
 using System.Collections.Generic;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Server;
 

--- a/test/Lsp.Tests/LanguageServerTests.cs
+++ b/test/Lsp.Tests/LanguageServerTests.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.LanguageServer.Client;
 using OmniSharp.Extensions.LanguageServer.Client.Processes;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;

--- a/test/Lsp.Tests/LspRequestRouterTests.cs
+++ b/test/Lsp.Tests/LspRequestRouterTests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;

--- a/test/Lsp.Tests/MediatorTestsRequestHandlerOfTRequest.cs
+++ b/test/Lsp.Tests/MediatorTestsRequestHandlerOfTRequest.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using Newtonsoft.Json;

--- a/test/Lsp.Tests/MediatorTestsRequestHandlerOfTRequestTResponse.cs
+++ b/test/Lsp.Tests/MediatorTestsRequestHandlerOfTRequestTResponse.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using Newtonsoft.Json;


### PR DESCRIPTION
MediatR is strong-name signed nowadays, no need to embed and strong-name signed anymore.

// cc @NTaylorMullen and @TylerLeonhardt would this break for any of you? It's basically a couple of more DLLs to ship with the extension, but nothing more.