### PR TITLE
Remove duplicate code

### DIFF
--- a/src/Server/LanguageServer.cs
+++ b/src/Server/LanguageServer.cs
@@ -74,29 +74,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
 
         public static async Task<ILanguageServer> From(LanguageServerOptions options, CancellationToken token)
         {
-            var server = new LanguageServer(
-                options.Input,
-                options.Output,
-                options.Reciever,
-                options.RequestProcessIdentifier,
-                options.LoggerFactory,
-                options.Serializer,
-                options.Services,
-                options.HandlerTypes.Select(x => x.Assembly)
-                    .Distinct().Concat(options.HandlerAssemblies),
-                options.Handlers,
-                options.HandlerTypes,
-                options.NamedHandlers,
-                options.NamedServiceHandlers,
-                options.TextDocumentIdentifiers,
-                options.TextDocumentIdentifierTypes,
-                options.InitializeDelegates,
-                options.InitializedDelegates
-            );
-
-            if (options.AddDefaultLoggingProvider)
-                options.LoggerFactory.AddProvider(new LanguageServerLoggerProvider(server));
-
+            var server = (LanguageServer)PreInit(options);
             await server.Initialize(token);
 
             return server;


### PR DESCRIPTION
Noticed we had duplicate code in `PreInit` and `From`. Let's use ´PreInit` in `From` in order to avoid divergence in the future between these two methods.