### PR TITLE
Refactor logging  +semver:minor

### DIFF
--- a/sample/SampleServer/Program.cs
+++ b/sample/SampleServer/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Server;
+using Serilog;
 
 namespace SampleServer
 {
@@ -22,13 +23,17 @@ namespace SampleServer
             //    await Task.Delay(100);
             // }
 
+            Log.Logger = new LoggerConfiguration()
+              .Enrich.FromLogContext()
+              .WriteTo.File("log.txt", rollingInterval: RollingInterval.Day)
+              .CreateLogger();
+
             var server = await LanguageServer.From(options =>
                 options
                     .WithInput(Console.OpenStandardInput())
                     .WithOutput(Console.OpenStandardOutput())
-                    .WithLoggerFactory(new LoggerFactory())
+                    .ConfigureLogging(x => x.AddSerilog())
                     .AddDefaultLoggingProvider()
-                    .WithMinimumLogLevel(LogLevel.Trace)
                     .WithHandler<TextDocumentHandler>()
                     .WithHandler<DidChangeWatchedFilesHandler>()
                     .WithHandler<FoldingRangeHandler>()

--- a/sample/SampleServer/Program.cs
+++ b/sample/SampleServer/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
@@ -28,6 +29,8 @@ namespace SampleServer
               .WriteTo.File("log.txt", rollingInterval: RollingInterval.Day)
               .CreateLogger();
 
+            Log.Logger.Information("This only goes file...");
+
             var server = await LanguageServer.From(options =>
                 options
                     .WithInput(Console.OpenStandardInput())
@@ -37,9 +40,28 @@ namespace SampleServer
                     .WithHandler<TextDocumentHandler>()
                     .WithHandler<DidChangeWatchedFilesHandler>()
                     .WithHandler<FoldingRangeHandler>()
+                    .WithServices(services => {
+                        services.AddSingleton<Foo>(provider => {
+                            var loggerFactory = provider.GetService<ILoggerFactory>();
+                            var logger = loggerFactory.CreateLogger<Foo>();
+
+                            logger.LogInformation("Configuring");
+
+                            return new Foo();
+                        });
+                    }).OnInitialize((s, request) => {
+                        var serviceProvider = s.Services;
+                        var foo = serviceProvider.GetService<Foo>();
+
+                        return Task.CompletedTask;
+                    })
                 );
 
             await server.WaitForExit;
         }
+    }
+
+    internal class Foo
+    {
     }
 }

--- a/sample/SampleServer/Program.cs
+++ b/sample/SampleServer/Program.cs
@@ -47,7 +47,7 @@ namespace SampleServer
 
                             logger.LogInformation("Configuring");
 
-                            return new Foo();
+                            return new Foo(logger);
                         });
                     }).OnInitialize((s, request) => {
                         var serviceProvider = s.Services;
@@ -63,5 +63,17 @@ namespace SampleServer
 
     internal class Foo
     {
+        private readonly ILogger<Foo> _logger;
+
+        public Foo(ILogger<Foo> logger)
+        {
+            logger.LogInformation("inside ctor");
+            _logger = logger;
+        }
+
+        public void SayFoo()
+        {
+            _logger.LogInformation("Fooooo!");
+        }
     }
 }

--- a/sample/SampleServer/SampleServer.csproj
+++ b/sample/SampleServer/SampleServer.csproj
@@ -3,13 +3,15 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="../../src/Server/Server.csproj" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+        <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+        <PackageReference Include="Serilog.Sinks.File" Version="4.1.0-dev-00850" />
     </ItemGroup>
 
 </Project>

--- a/sample/SampleServer/TextDocumentHandler.cs
+++ b/sample/SampleServer/TextDocumentHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.Embedded.MediatR;
 using OmniSharp.Extensions.LanguageServer;
 using OmniSharp.Extensions.LanguageServer.Protocol;
@@ -15,7 +16,7 @@ namespace SampleServer
 {
     class TextDocumentHandler : ITextDocumentSyncHandler
     {
-        private readonly OmniSharp.Extensions.LanguageServer.Protocol.Server.ILanguageServer _router;
+        private readonly ILogger<TextDocumentHandler> _logger;
 
         private readonly DocumentSelector _documentSelector = new DocumentSelector(
             new DocumentFilter() {
@@ -25,19 +26,16 @@ namespace SampleServer
 
         private SynchronizationCapability _capability;
 
-        public TextDocumentHandler(OmniSharp.Extensions.LanguageServer.Protocol.Server.ILanguageServer router)
+        public TextDocumentHandler(ILogger<TextDocumentHandler> logger)
         {
-            _router = router;
+            _logger = logger;
         }
 
         public TextDocumentSyncKind Change { get; } = TextDocumentSyncKind.Full;
 
         public Task<Unit> Handle(DidChangeTextDocumentParams notification, CancellationToken token)
         {
-            _router.Window.LogMessage(new LogMessageParams() {
-                Type = MessageType.Log,
-                Message = "Hello World!!!!"
-            });
+            _logger.LogInformation("Hello world!");
             return Unit.Task;
         }
 
@@ -57,10 +55,7 @@ namespace SampleServer
         public async Task<Unit> Handle(DidOpenTextDocumentParams notification, CancellationToken token)
         {
             await Task.Yield();
-            _router.Window.LogMessage(new LogMessageParams() {
-                Type = MessageType.Log,
-                Message = "Hello World!!!!"
-            });
+            _logger.LogInformation("Hello world!");
             return Unit.Value;
         }
 

--- a/sample/SampleServer/TextDocumentHandler.cs
+++ b/sample/SampleServer/TextDocumentHandler.cs
@@ -26,9 +26,10 @@ namespace SampleServer
 
         private SynchronizationCapability _capability;
 
-        public TextDocumentHandler(ILogger<TextDocumentHandler> logger)
+        public TextDocumentHandler(ILogger<TextDocumentHandler> logger, Foo foo)
         {
             _logger = logger;
+            foo.SayFoo();
         }
 
         public TextDocumentSyncKind Change { get; } = TextDocumentSyncKind.Full;

--- a/src/JsonRpc/RequestRouterBase.cs
+++ b/src/JsonRpc/RequestRouterBase.cs
@@ -148,7 +148,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
                         return new JsonRpc.Client.Response(request.Id, responseValue, request);
                     }
-                    catch (TaskCanceledException e)
+                    catch (TaskCanceledException)
                     {
                         _logger.LogDebug("Request {Id} was cancelled", id);
                         return new RequestCancelled();

--- a/src/Server/LanguageServer.cs
+++ b/src/Server/LanguageServer.cs
@@ -215,6 +215,12 @@ namespace OmniSharp.Extensions.LanguageServer.Server
 
             _exitHandler = new ServerExitHandler(_shutdownHandler);
 
+            // We need to at least create Window here in case any handler does loggin in their constructor
+            Document = new LanguageServerDocument(_responseRouter);
+            Client = new LanguageServerClient(_responseRouter);
+            Window = new LanguageServerWindow(_responseRouter);
+            Workspace = new LanguageServerWorkspace(_responseRouter);
+
             _disposable.Add(
                 AddHandlers(this, _shutdownHandler, _exitHandler, new CancelRequestHandler<ILspHandlerDescriptor>(_requestRouter))
             );
@@ -232,12 +238,6 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             {
                 _disposable.Add(_collection.Add(name, handlerFunc(_serviceProvider)));
             }
-
-
-            Document = new LanguageServerDocument(_responseRouter);
-            Client = new LanguageServerClient(_responseRouter);
-            Window = new LanguageServerWindow(_responseRouter);
-            Workspace = new LanguageServerWorkspace(_responseRouter);
         }
 
         public ILanguageServerDocument Document { get; }

--- a/src/Server/LanguageServerOptions.cs
+++ b/src/Server/LanguageServerOptions.cs
@@ -22,8 +22,6 @@ namespace OmniSharp.Extensions.LanguageServer.Server
 
         public Stream Input { get; set; }
         public Stream Output { get; set; }
-        public LogLevel MinimumLogLevel { get; set; } = LogLevel.Information;
-        public ILoggerFactory LoggerFactory { get; set; } = new LoggerFactory();
         public ISerializer Serializer { get; set; } = Protocol.Serialization.Serializer.Instance;
         public IRequestProcessIdentifier RequestProcessIdentifier { get; set; } = new RequestProcessIdentifier();
         public ILspReciever Reciever { get; set; } = new LspReciever();
@@ -36,6 +34,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
         internal List<Type> TextDocumentIdentifierTypes { get; set; } = new List<Type>();
         internal List<Assembly> HandlerAssemblies { get; set; } = new List<Assembly>();
         internal bool AddDefaultLoggingProvider { get; set; }
+        internal Action<ILoggingBuilder> LoggingBuilderAction { get; set; } = new Action<ILoggingBuilder>(_ => { });
 
         internal readonly List<InitializeDelegate> InitializeDelegates = new List<InitializeDelegate>();
         internal readonly List<InitializedDelegate> InitializedDelegates = new List<InitializedDelegate>();

--- a/src/Server/LanguageServerOptionsExtensions.cs
+++ b/src/Server/LanguageServerOptionsExtensions.cs
@@ -22,18 +22,6 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             return options;
         }
 
-        public static LanguageServerOptions WithMinimumLogLevel(this LanguageServerOptions options, LogLevel logLevel)
-        {
-            options.MinimumLogLevel = logLevel;
-            return options;
-        }
-
-        public static LanguageServerOptions WithLoggerFactory(this LanguageServerOptions options, ILoggerFactory loggerFactory)
-        {
-            options.LoggerFactory = loggerFactory;
-            return options;
-        }
-
         public static LanguageServerOptions WithRequestProcessIdentifier(this LanguageServerOptions options, IRequestProcessIdentifier requestProcessIdentifier)
         {
             options.RequestProcessIdentifier = requestProcessIdentifier;
@@ -107,6 +95,12 @@ namespace OmniSharp.Extensions.LanguageServer.Server
         public static LanguageServerOptions OnInitialized(this LanguageServerOptions options, InitializedDelegate @delegate)
         {
             options.InitializedDelegates.Add(@delegate);
+            return options;
+        }
+
+        public static LanguageServerOptions ConfigureLogging(this LanguageServerOptions options, Action<ILoggingBuilder> builderAction)
+        {
+            options.LoggingBuilderAction = builderAction;
             return options;
         }
     }

--- a/test/Lsp.Tests/LanguageServerTests.cs
+++ b/test/Lsp.Tests/LanguageServerTests.cs
@@ -37,10 +37,10 @@ namespace Lsp.Tests
             var serverStart = LanguageServer.From(x => x
                 //.WithHandler(handler)
                 .WithInput(process.ClientOutputStream)
-                .WithOutput(process.ClientInputStream)
-                .WithLoggerFactory(LoggerFactory)
-                .AddDefaultLoggingProvider()
-                .WithMinimumLogLevel(LogLevel.Trace),
+                .WithOutput(process.ClientInputStream),
+                //.WithLoggerFactory(LoggerFactory)
+                //.AddDefaultLoggingProvider()
+                //.WithMinimumLogLevel(LogLevel.Trace),
                 cts.Token
             );
 
@@ -63,9 +63,9 @@ namespace Lsp.Tests
             var server = LanguageServer.PreInit(x => x
                 .WithInput(process.ClientOutputStream)
                 .WithOutput(process.ClientInputStream)
-                .WithLoggerFactory(LoggerFactory)
-                .AddDefaultLoggingProvider()
-                .WithMinimumLogLevel(LogLevel.Trace)
+                //.WithLoggerFactory(LoggerFactory)
+                //.AddDefaultLoggingProvider()
+                //.WithMinimumLogLevel(LogLevel.Trace)
                 .AddHandlers(TextDocumentSyncHandlerExtensions.With(DocumentSelector.ForPattern("**/*.cs"), "csharp"))
             ) as IRequestHandler<InitializeParams, InitializeResult>;
 

--- a/vscode-testextension/.vscode/tasks.json
+++ b/vscode-testextension/.vscode/tasks.json
@@ -8,23 +8,14 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-	"version": "0.1.0",
-
-	// we want to run npm
-	"command": "npm",
-
-	// the command is a shell script
-	"isShellCommand": true,
-
-	// show the output window only if unrecognized errors occur.
-	"showOutput": "silent",
-
-	// we run the custom script "compile" as defined in package.json
-	"args": ["run", "compile", "--loglevel", "silent"],
-
-	// The tsc compiler is started in watching mode
-	"isWatching": true,
-
-	// use the standard tsc in watch mode problem matcher to find compile problems in the output.
-	"problemMatcher": "$tsc-watch"
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "npm",
+            "command": "npm",
+            "args": ["run", "compile", "--loglevel", "silent"],
+            "type": "shell",
+            "problemMatcher": "$tsc-watch"
+        }
+    ]
 }

--- a/vscode-testextension/src/extension.ts
+++ b/vscode-testextension/src/extension.ts
@@ -31,9 +31,9 @@ export function activate(context: ExtensionContext) {
     // Otherwise the run options are used
     let serverOptions: ServerOptions = {
         // run: { command: serverExe, args: ['-lsp', '-d'] },
-        run: { command: serverExe, args: ["C:/src/gh/csharp-language-server-protocol/sample/SampleServer/bin/Debug/netcoreapp2.1/win7-x64/SampleServer.dll"] },
+        run: { command: serverExe, args: ["C:/src/gh/csharp-language-server-protocol/sample/SampleServer/bin/Release/netcoreapp2.1/win7-x64/SampleServer.dll"] },
         // debug: { command: serverExe, args: ['-lsp', '-d'] }
-        debug: { command: serverExe, args: ["C:/src/gh/csharp-language-server-protocol/sample/SampleServer/bin/Debug/netcoreapp2.1/win7-x64/SampleServer.dll"] }
+        debug: { command: serverExe, args: ["C:/src/gh/csharp-language-server-protocol/sample/SampleServer/bin/Release/netcoreapp2.1/win7-x64/SampleServer.dll"] }
     };
 
     // Options to control the language client

--- a/vscode-testextension/src/extension.ts
+++ b/vscode-testextension/src/extension.ts
@@ -31,9 +31,9 @@ export function activate(context: ExtensionContext) {
     // Otherwise the run options are used
     let serverOptions: ServerOptions = {
         // run: { command: serverExe, args: ['-lsp', '-d'] },
-        run: { command: serverExe, args: ["C:/src/gh/csharp-language-server-protocol/sample/SampleServer/bin/Release/netcoreapp2.1/win7-x64/SampleServer.dll"] },
+        run: { command: serverExe, args: ["C:/src/gh/csharp-language-server-protocol/sample/SampleServer/bin/Debug/netcoreapp2.1/win7-x64/SampleServer.dll"] },
         // debug: { command: serverExe, args: ['-lsp', '-d'] }
-        debug: { command: serverExe, args: ["C:/src/gh/csharp-language-server-protocol/sample/SampleServer/bin/Release/netcoreapp2.1/win7-x64/SampleServer.dll"] }
+        debug: { command: serverExe, args: ["C:/src/gh/csharp-language-server-protocol/sample/SampleServer/bin/Debug/netcoreapp2.1/win7-x64/SampleServer.dll"] }
     };
 
     // Options to control the language client

--- a/vscode-testextension/src/extension.ts
+++ b/vscode-testextension/src/extension.ts
@@ -20,11 +20,10 @@ import { Trace } from "vscode-jsonrpc";
 
 export function activate(context: ExtensionContext) {
     // The server is implemented in node
-    // let serverExe = 'dotnet';
+    let serverExe = 'dotnet';
 
     // let serverExe = 'D:\\Development\\Omnisharp\\csharp-language-server-protocol\\sample\\SampleServer\\bin\\Debug\\netcoreapp2.0\\win7-x64\\SampleServer.exe';
-    let serverExe =
-        "D:/Development/Omnisharp/omnisharp-roslyn/artifacts/publish/OmniSharp.Stdio.Driver/win7-x64/OmniSharp.exe";
+    // let serverExe = "D:/Development/Omnisharp/omnisharp-roslyn/artifacts/publish/OmniSharp.Stdio.Driver/win7-x64/OmniSharp.exe";
     // The debug options for the server
     // let debugOptions = { execArgv: ['-lsp', '-d' };5
 
@@ -32,9 +31,9 @@ export function activate(context: ExtensionContext) {
     // Otherwise the run options are used
     let serverOptions: ServerOptions = {
         // run: { command: serverExe, args: ['-lsp', '-d'] },
-        run: { command: serverExe, args: ["-lsp"] },
+        run: { command: serverExe, args: ["C:/src/gh/csharp-language-server-protocol/sample/SampleServer/bin/Debug/netcoreapp2.1/win7-x64/SampleServer.dll"] },
         // debug: { command: serverExe, args: ['-lsp', '-d'] }
-        debug: { command: serverExe, args: ["-lsp"] }
+        debug: { command: serverExe, args: ["C:/src/gh/csharp-language-server-protocol/sample/SampleServer/bin/Debug/netcoreapp2.1/win7-x64/SampleServer.dll"] }
     };
 
     // Options to control the language client
@@ -65,7 +64,7 @@ export function activate(context: ExtensionContext) {
         serverOptions,
         clientOptions
     );
-    // client.trace = Trace.Verbose;
+    client.trace = Trace.Verbose;
     client.clientOptions.errorHandler;
     let disposable = client.start();
 


### PR DESCRIPTION
- Expose ILoggingBuilder instead of accepting a ILoggerFactory

Some open questions. How to maintain backwards compatibility, or should we?