### PR TITLE
Adds ILoggingBuilder extension for LanguageServer logging.

### DIFF
--- a/sample/SampleServer/Program.cs
+++ b/sample/SampleServer/Program.cs
@@ -19,7 +19,7 @@ namespace SampleServer
 
         static async Task MainAsync(string[] args)
         {
-            Debugger.Launch();
+            //Debugger.Launch();
             //while (!System.Diagnostics.Debugger.IsAttached)
             //{
             //    await Task.Delay(100);
@@ -38,8 +38,8 @@ namespace SampleServer
                     .WithOutput(Console.OpenStandardOutput())
                     .ConfigureLogging(x => x
                         .AddSerilog()
-                        .AddLanguageServer(LogLevel.Critical)
-                        .SetMinimumLevel(LogLevel.Trace))
+                        .AddLanguageServer(LogLevel.Error)
+                        .SetMinimumLevel(LogLevel.Error))
                     .WithHandler<TextDocumentHandler>()
                     .WithHandler<DidChangeWatchedFilesHandler>()
                     .WithHandler<FoldingRangeHandler>()

--- a/sample/SampleServer/Program.cs
+++ b/sample/SampleServer/Program.cs
@@ -19,10 +19,11 @@ namespace SampleServer
 
         static async Task MainAsync(string[] args)
         {
-            // while (!System.Diagnostics.Debugger.IsAttached)
-            // {
+            Debugger.Launch();
+            //while (!System.Diagnostics.Debugger.IsAttached)
+            //{
             //    await Task.Delay(100);
-            // }
+            //}
 
             Log.Logger = new LoggerConfiguration()
               .Enrich.FromLogContext()
@@ -35,8 +36,10 @@ namespace SampleServer
                 options
                     .WithInput(Console.OpenStandardInput())
                     .WithOutput(Console.OpenStandardOutput())
-                    .ConfigureLogging(x => x.AddSerilog())
-                    .AddDefaultLoggingProvider()
+                    .ConfigureLogging(x => x
+                        .AddSerilog()
+                        .AddLanguageServer(LogLevel.Critical)
+                        .SetMinimumLevel(LogLevel.Trace))
                     .WithHandler<TextDocumentHandler>()
                     .WithHandler<DidChangeWatchedFilesHandler>()
                     .WithHandler<FoldingRangeHandler>()

--- a/sample/SampleServer/TextDocumentHandler.cs
+++ b/sample/SampleServer/TextDocumentHandler.cs
@@ -36,6 +36,9 @@ namespace SampleServer
 
         public Task<Unit> Handle(DidChangeTextDocumentParams notification, CancellationToken token)
         {
+            _logger.LogCritical("Critical");
+            _logger.LogDebug("Debug");
+            _logger.LogTrace("Trace");
             _logger.LogInformation("Hello world!");
             return Unit.Task;
         }

--- a/src/Server/LanguageServer.cs
+++ b/src/Server/LanguageServer.cs
@@ -27,6 +27,7 @@ using OmniSharp.Extensions.LanguageServer.Server.Pipelines;
 using ISerializer = OmniSharp.Extensions.LanguageServer.Protocol.Serialization.ISerializer;
 using System.Reactive.Disposables;
 using Microsoft.Extensions.Options;
+using OmniSharp.Extensions.LanguageServer.Server.Logging;
 
 namespace OmniSharp.Extensions.LanguageServer.Server
 {
@@ -132,6 +133,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             var outputHandler = new OutputHandler(output, serializer);
 
             services.AddLogging(builder => loggingBuilderAction(builder));
+            services.AddSingleton<IOptionsMonitor<LoggerFilterOptions>, LanguageServerLoggerFilterOptions>();
 
             _reciever = reciever;
             _serializer = serializer;
@@ -347,9 +349,17 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             {
                 var loggerSettings = _serviceProvider.GetService<LanguageServerLoggerSettings>();
 
-                if (loggerSettings?.MinimumLogLevel >= LogLevel.Information)
+                if (loggerSettings?.MinimumLogLevel <= LogLevel.Information)
                 {
                     loggerSettings.MinimumLogLevel = LogLevel.Trace;
+                }
+
+                var optionsMonitor = _serviceProvider.GetService<IOptionsMonitor<LoggerFilterOptions>>() as LanguageServerLoggerFilterOptions;
+
+                if (optionsMonitor?.CurrentValue.MinLevel <= LogLevel.Information)
+                {
+                    optionsMonitor.CurrentValue.MinLevel = LogLevel.Trace;
+                    optionsMonitor.Set(optionsMonitor.CurrentValue);
                 }
             }
 

--- a/src/Server/LanguageServerOptions.cs
+++ b/src/Server/LanguageServerOptions.cs
@@ -33,7 +33,6 @@ namespace OmniSharp.Extensions.LanguageServer.Server
         internal List<Type> HandlerTypes { get; set; } = new List<Type>();
         internal List<Type> TextDocumentIdentifierTypes { get; set; } = new List<Type>();
         internal List<Assembly> HandlerAssemblies { get; set; } = new List<Assembly>();
-        internal bool AddDefaultLoggingProvider { get; set; }
         internal Action<ILoggingBuilder> LoggingBuilderAction { get; set; } = new Action<ILoggingBuilder>(_ => { });
 
         internal readonly List<InitializeDelegate> InitializeDelegates = new List<InitializeDelegate>();

--- a/src/Server/LanguageServerOptionsExtensions.cs
+++ b/src/Server/LanguageServerOptionsExtensions.cs
@@ -78,13 +78,6 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             return options;
         }
 
-        public static LanguageServerOptions AddDefaultLoggingProvider(this LanguageServerOptions options)
-        {
-            options.AddDefaultLoggingProvider = true;
-            return options;
-        }
-
-
         public static LanguageServerOptions OnInitialize(this LanguageServerOptions options, InitializeDelegate @delegate)
         {
             options.InitializeDelegates.Add(@delegate);

--- a/src/Server/Logging/LanguageServerLogger.cs
+++ b/src/Server/Logging/LanguageServerLogger.cs
@@ -1,7 +1,5 @@
 using System;
 using Microsoft.Extensions.Logging;
-using OmniSharp.Extensions.JsonRpc;
-using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
@@ -9,10 +7,10 @@ namespace OmniSharp.Extensions.LanguageServer.Server
 {
     class LanguageServerLogger : ILogger
     {
-        private readonly LanguageServer _responseRouter;
+        private readonly ILanguageServer _responseRouter;
         private readonly Func<LogLevel> _logLevelGetter;
 
-        public LanguageServerLogger(LanguageServer responseRouter, Func<LogLevel> logLevelGetter)
+        public LanguageServerLogger(ILanguageServer responseRouter, Func<LogLevel> logLevelGetter)
         {
             _logLevelGetter = logLevelGetter;
             _responseRouter = responseRouter;

--- a/src/Server/Logging/LanguageServerLoggerExtensions.cs
+++ b/src/Server/Logging/LanguageServerLoggerExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace OmniSharp.Extensions.LanguageServer.Server
+{
+    public static class LanguageServerLoggerExtensions
+    {
+        public static ILoggingBuilder AddLanguageServer(this ILoggingBuilder builder, LogLevel minLevel = LogLevel.Information)
+        {
+            builder.Services.AddSingleton<LanguageServerLoggerSettings>(_ => new LanguageServerLoggerSettings { MinimumLogLevel = minLevel });
+            builder.Services.AddSingleton<ILoggerProvider, LanguageServerLoggerProvider>();
+
+            return builder;
+        }
+    }
+}

--- a/src/Server/Logging/LanguageServerLoggerFilterOptions.cs
+++ b/src/Server/Logging/LanguageServerLoggerFilterOptions.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace OmniSharp.Extensions.LanguageServer.Server.Logging
+{
+    internal class LanguageServerLoggerFilterOptions : IOptionsMonitor<LoggerFilterOptions>, IDisposable
+    {
+        private readonly List<IDisposable> _registrations = new List<IDisposable>();
+        private event Action<LoggerFilterOptions, string> _onChange;
+
+        public LanguageServerLoggerFilterOptions(IOptions<LoggerFilterOptions> options)
+        {
+            CurrentValue = options.Value;
+        }
+
+        public LoggerFilterOptions CurrentValue { get; private set; }
+
+        public LoggerFilterOptions Get(string _) => CurrentValue;
+
+        public IDisposable OnChange(Action<LoggerFilterOptions, string> listener)
+        {
+            var disposable = new ChangeTrackerDisposable(this, listener);
+            _onChange += disposable.OnChange;
+            return disposable;
+        }
+
+        public void Dispose()
+        {
+            foreach (var registration in _registrations)
+            {
+                registration.Dispose();
+            }
+
+            _registrations.Clear();
+        }
+
+        internal void Set(LoggerFilterOptions options)
+        {
+            CurrentValue = options;
+            _onChange?.Invoke(options, Options.DefaultName);
+        }
+
+        private class ChangeTrackerDisposable : IDisposable
+        {
+            private readonly Action<LoggerFilterOptions, string> _listener;
+            private readonly LanguageServerLoggerFilterOptions _monitor;
+
+            public ChangeTrackerDisposable(LanguageServerLoggerFilterOptions monitor, Action<LoggerFilterOptions, string> listener)
+            {
+                _listener = listener;
+                _monitor = monitor;
+            }
+
+            public void OnChange(LoggerFilterOptions options, string name) => _listener.Invoke(options, name);
+
+            public void Dispose() => _monitor._onChange -= OnChange;
+        }
+    }
+}

--- a/src/Server/Logging/LanguageServerLoggerProvider.cs
+++ b/src/Server/Logging/LanguageServerLoggerProvider.cs
@@ -5,16 +5,18 @@ namespace OmniSharp.Extensions.LanguageServer.Server
 {
     class LanguageServerLoggerProvider : ILoggerProvider
     {
-        private readonly LanguageServer _languageServer;
+        private readonly ILanguageServer _languageServer;
+        private readonly LanguageServerLoggerSettings _settings;
 
-        public LanguageServerLoggerProvider(LanguageServer languageServer)
+        public LanguageServerLoggerProvider(ILanguageServer languageServer, LanguageServerLoggerSettings settings)
         {
             _languageServer = languageServer;
+            _settings = settings;
         }
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new LanguageServerLogger(_languageServer, () => _languageServer.MinimumLogLevel);
+            return new LanguageServerLogger(_languageServer, () => _settings.MinimumLogLevel);
         }
 
         public void Dispose()

--- a/src/Server/Logging/LanguageServerLoggerSettings.cs
+++ b/src/Server/Logging/LanguageServerLoggerSettings.cs
@@ -1,0 +1,9 @@
+using Microsoft.Extensions.Logging;
+
+namespace OmniSharp.Extensions.LanguageServer.Server
+{
+    internal class LanguageServerLoggerSettings
+    {
+        public LogLevel MinimumLogLevel { get; set; }
+    }
+}


### PR DESCRIPTION
replaces `AddDefaultLoggingProvider()` with `.AddLanguageServer()`.

Allows you to pass in a `LogLevel` into `.AddLanguageServer()` (default is Information)