### PR TITLE
Fix default compilation issues

### DIFF
--- a/src/JsonRpc/RequestRouterBase.cs
+++ b/src/JsonRpc/RequestRouterBase.cs
@@ -99,7 +99,7 @@ namespace OmniSharp.Extensions.JsonRpc
                     // TODO: Try / catch for Internal Error
                     try
                     {
-                        if (descriptor == default)
+                        if (descriptor == null || descriptor.Equals(default(TDescriptor)))
                         {
                             _logger.LogDebug("descriptor not found for Request ({Id}) {Method}", request.Id, request.Method);
                             return new MethodNotFound(request.Id, request.Method);

--- a/src/Protocol/Models/BooleanOr.cs
+++ b/src/Protocol/Models/BooleanOr.cs
@@ -15,7 +15,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
             _bool = value;
         }
 
-        public bool IsValue => this._value != default;
+        public bool IsValue => _value != null && !_value.Equals(default(T));
         public T Value
         {
             get { return this._value; }


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/csharp-language-server-protocol/issues/191.

I suspect a newer .NET version is finding new semantic errors, but I wasn't able to compile without making these changes.

Let me know if these aren't the right changes and I can address (for example by putting a new type constraint on the generic).