### PR TITLE
Fix TextDocument synchronization for LSP3

### DIFF
--- a/src/Server/LanguageServer.cs
+++ b/src/Server/LanguageServer.cs
@@ -458,7 +458,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
                 {
                     serverCapabilities.TextDocumentSync = new TextDocumentSyncOptions()
                     {
-                        Change = TextDocumentSyncKind.None,
+                        Change = textDocumentSyncKind,
                         OpenClose = _collection.ContainsHandler(typeof(IDidOpenTextDocumentHandler)) || _collection.ContainsHandler(typeof(IDidCloseTextDocumentHandler)),
                         Save = _collection.ContainsHandler(typeof(IDidSaveTextDocumentHandler)) ?
                             new SaveOptions() { IncludeText = true /* TODO: Make configurable */ } :


### PR DESCRIPTION
- For LSP3 clients the TextDocumentSynchronization kind is always set to none without this. For the VS LSP client this results in language servers never getting any text document synchronization events.