### PR TITLE
Correctly handle CommandOrCodeAction with missing "command" property

### DIFF
--- a/src/Protocol/Serialization/Converters/CommandOrCodeActionConverter.cs
+++ b/src/Protocol/Serialization/Converters/CommandOrCodeActionConverter.cs
@@ -28,7 +28,8 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
             var result = JObject.Load(reader);
 
             // Commands have a name, CodeActions do not
-            if (result["command"].Type == JTokenType.String)
+            JToken command = result["command"];
+            if (command?.Type == JTokenType.String)
             {
                 return new CommandOrCodeAction(result.ToObject<Command>());
             }


### PR DESCRIPTION
Fixes OmniSharp/csharp-language-server-protocol#210