### PR TITLE
Flush after writing.

### DIFF
--- a/src/JsonRpc/OutputHandler.cs
+++ b/src/JsonRpc/OutputHandler.cs
@@ -65,6 +65,8 @@ namespace OmniSharp.Extensions.JsonRpc
                                 _output.Write(ms.ToArray(), 0, (int)ms.Position);
                             }
                         }
+
+                        _output.Flush();
                     }
                 }
             }


### PR DESCRIPTION
- Not all streams auto-flush after write. For instance creating a duplex JsonRpc stream to run the O# server in-proc results in the server never initializing because the flush result is not sent down to the client. For instance: https://github.com/dotnet/aspnetcore-tooling/blob/ed01e6b0d167f0dda61d9cdba226f8844fa1d96e/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs#L49