### PR TITLE
Fixes #214 by returning LSP conform JSON for prepare rename request

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-hacker

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-hacker

--- a/src/Protocol/Serialization/Converters/RangeOrPlaceholderRangeConverter.cs
+++ b/src/Protocol/Serialization/Converters/RangeOrPlaceholderRangeConverter.cs
@@ -1,0 +1,29 @@
+using System;
+using Newtonsoft.Json;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
+{
+    class RangeOrPlaceholderRangeConverter : JsonConverter<RangeOrPlaceholderRange>
+    {
+        public override void WriteJson(JsonWriter writer, RangeOrPlaceholderRange value, JsonSerializer serializer)
+        {
+            if (value.IsRange)
+            {
+                serializer.Serialize(writer, value.Range);
+            }
+            else
+            {
+                serializer.Serialize(writer, value.PlaceholderRange);
+            }
+        }
+
+        public override RangeOrPlaceholderRange ReadJson(JsonReader reader, Type objectType, RangeOrPlaceholderRange existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            return new RangeOrPlaceholderRange((Range) null);
+        }
+
+        public override bool CanRead => false;
+    }
+}

--- a/src/Protocol/Serialization/Serializer.cs
+++ b/src/Protocol/Serialization/Serializer.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Newtonsoft.Json;
-using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Serialization;
-using OmniSharp.Extensions.JsonRpc.Serialization.Converters;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters;
@@ -76,6 +73,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization
             ReplaceConverter(converters, new WorkspaceEditDocumentChangeConverter());
             ReplaceConverter(converters, new ParameterInformationLabelConverter());
             ReplaceConverter(converters, new ValueTupleContractResolver<long, long>());
+            ReplaceConverter(converters, new RangeOrPlaceholderRangeConverter());
             base.AddOrReplaceConverters(converters);
         }
 

--- a/test/Lsp.Tests/Capabilities/Server/PrepareRenameTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/PrepareRenameTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+
+namespace Lsp.Tests.Capabilities.Server
+{
+    public class PrepareRenameTests
+    {
+        [Theory, JsonFixture]
+        public void Range(string expected)
+        {
+            var range = new Range(
+                new Position(1, 2),
+                new Position(3, 4)
+            );
+
+            var model = new RangeOrPlaceholderRange(range);
+
+            var result = Fixture.SerializeObject(model);
+
+            result.Should().Be(expected);
+        }
+
+        [Theory, JsonFixture]
+        public void PlaceholderRange(string expected)
+        {
+            var placeholderRange = new PlaceholderRange
+            {
+                Range = new Range(
+                    new Position(1, 2),
+                    new Position(3, 4)
+                ),
+                Placeholder = "placeholder"
+            };
+
+            var model = new RangeOrPlaceholderRange(placeholderRange);
+
+            var result = Fixture.SerializeObject(model);
+
+            result.Should().Be(expected);
+        }
+    }
+}

--- a/test/Lsp.Tests/Capabilities/Server/PrepareRenameTests_$PlaceholderRange.json
+++ b/test/Lsp.Tests/Capabilities/Server/PrepareRenameTests_$PlaceholderRange.json
@@ -1,0 +1,13 @@
+﻿{
+    "range": {
+        "start": {
+            "line": 1,
+            "character": 2
+        },
+        "end": {
+            "line": 3,
+            "character": 4
+        }
+    },
+    "placeholder": "placeholder"
+}

--- a/test/Lsp.Tests/Capabilities/Server/PrepareRenameTests_$Range.json
+++ b/test/Lsp.Tests/Capabilities/Server/PrepareRenameTests_$Range.json
@@ -1,0 +1,10 @@
+﻿{
+    "start": {
+        "line": 1,
+        "character": 2
+    },
+    "end": {
+        "line": 3,
+        "character": 4
+    }
+}


### PR DESCRIPTION
This will add a new converter for RangeOrPlaceholderRange to the Serializer. 

@RangeOrPlaceholderRangeConverter

I let `CanRead` return `false` because the client will never send such an object. I also return an empty `RangeOrPlaceholderRange` in case of `Read`. Not sure, perhaps it`s better to return null or throw?

Fixes #214