### PR TITLE
Add AllCommitChars to (I)CompletionOptions to add json serialization …

### DIFF
--- a/src/Protocol/Models/ICompletionOptions.cs
+++ b/src/Protocol/Models/ICompletionOptions.cs
@@ -1,8 +1,9 @@
-﻿namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
+namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
     public interface ICompletionOptions
     {
         bool ResolveProvider { get; set; }
         Container<string> TriggerCharacters { get; set; }
+        Container<string> AllCommitCharacters { get; set; }
     }
 }

--- a/src/Protocol/Server/Capabilities/CompletionOptions.cs
+++ b/src/Protocol/Server/Capabilities/CompletionOptions.cs
@@ -23,10 +23,20 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities
         [Optional]
         public Container<string> TriggerCharacters { get; set; }
 
+        /// <summary>
+        /// The list of all possible characters that commit a completion. This field can be used
+        /// if clients don't support individual commit characters per completion item. See
+        /// `ClientCapabilities.textDocument.completion.completionItem.commitCharactersSupport`
+        ///
+        /// Since 3.2.0
+        [Optional]
+        public Container<string> AllCommitCharacters { get; set; }
+
         public static CompletionOptions Of(ICompletionOptions options)
         {
             return new CompletionOptions()
             {
+                AllCommitCharacters = options.AllCommitCharacters,
                 ResolveProvider = options.ResolveProvider,
                 TriggerCharacters = options.TriggerCharacters
             };


### PR DESCRIPTION
…for this during the intialization handshake. Without this, my omnisharp server in VS doesn't receive the AllCommitCharacters for the CompletionOptions.