### PR TITLE
Added cancellation to all async methods that didn't already have it.

### DIFF
--- a/sample/SampleServer/Program.cs
+++ b/sample/SampleServer/Program.cs
@@ -76,7 +76,7 @@ namespace SampleServer
                             Section = "terminal",
                         });
                     })
-                    .OnInitialize(new InitializeDelegate(async (server, request) => {
+                    .OnInitialize(async (server, request, token) => {
                         var manager = server.ProgressManager.WorkDone(request, new WorkDoneProgressBegin() {
                             Title = "Server is starting...",
                             Percentage = 10,
@@ -89,8 +89,8 @@ namespace SampleServer
                             Percentage = 20,
                             Message = "loading in progress"
                         });
-                    }))
-                    .OnInitialized(new InitializedDelegate(async (server, request, response) => {
+                    })
+                    .OnInitialized(async (server, request, response, token) => {
                         workDone.OnNext(new WorkDoneProgressReport() {
                             Percentage = 40,
                             Message = "loading almost done",
@@ -102,9 +102,9 @@ namespace SampleServer
                             Message = "loading done",
                             Percentage = 100,
                         });
-                    }))
-                    .OnStarted(async (languageServer, result) => {
-                        using var manager = await languageServer.ProgressManager.Create(new WorkDoneProgressBegin() { Title = "Doing some work..." });
+                    })
+                    .OnStarted(async (languageServer, result, token) => {
+                        using var manager = languageServer.ProgressManager.Create(new WorkDoneProgressBegin() { Title = "Doing some work..." });
 
                         manager.OnNext(new WorkDoneProgressReport() { Message = "doing things..." });
                         await Task.Delay(10000);

--- a/sample/SampleServer/Program.cs
+++ b/sample/SampleServer/Program.cs
@@ -102,6 +102,7 @@ namespace SampleServer
                             Message = "loading done",
                             Percentage = 100,
                         });
+                        workDone.OnCompleted();
                     })
                     .OnStarted(async (languageServer, result, token) => {
                         using var manager = languageServer.ProgressManager.Create(new WorkDoneProgressBegin() { Title = "Doing some work..." });

--- a/src/Dap.Protocol/Requests/RunInTerminalExtensions.cs
+++ b/src/Dap.Protocol/Requests/RunInTerminalExtensions.cs
@@ -1,12 +1,13 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
 {
     public static class RunInTerminalExtensions
     {
-        public static Task<RunInTerminalResponse> RunInTerminal(this IDebugAdapterClient mediator, RunInTerminalArguments @params)
+        public static Task<RunInTerminalResponse> RunInTerminal(this IDebugAdapterClient mediator, RunInTerminalArguments @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<RunInTerminalArguments, RunInTerminalResponse>(RequestNames.RunInTerminal, @params);
+            return mediator.SendRequest<RunInTerminalArguments, RunInTerminalResponse>(RequestNames.RunInTerminal, @params, cancellationToken);
         }
     }
 

--- a/src/Dap.Protocol/Requests/RunInTerminalExtensions.cs
+++ b/src/Dap.Protocol/Requests/RunInTerminalExtensions.cs
@@ -7,7 +7,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
     {
         public static Task<RunInTerminalResponse> RunInTerminal(this IDebugAdapterClient mediator, RunInTerminalArguments @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<RunInTerminalArguments, RunInTerminalResponse>(RequestNames.RunInTerminal, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 

--- a/src/JsonRpc/CancelParams.cs
+++ b/src/JsonRpc/CancelParams.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace OmniSharp.Extensions.JsonRpc
 {
+    [Method(JsonRpcNames.CancelRequest)]
     public class CancelParams : IRequest
     {
         /// <summary>

--- a/src/JsonRpc/IOutputHandler.cs
+++ b/src/JsonRpc/IOutputHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OmniSharp.Extensions.JsonRpc
@@ -6,7 +7,7 @@ namespace OmniSharp.Extensions.JsonRpc
     public interface IOutputHandler : IDisposable
     {
         void Start();
-        void Send(object value);
+        void Send(object value, CancellationToken cancellationToken);
         Task WaitForShutdown();
     }
 }

--- a/src/JsonRpc/IResponseRouter.cs
+++ b/src/JsonRpc/IResponseRouter.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using MediatR;
 using Newtonsoft.Json.Linq;
 
 namespace OmniSharp.Extensions.JsonRpc
@@ -8,7 +9,10 @@ namespace OmniSharp.Extensions.JsonRpc
     {
         void SendNotification(string method);
         void SendNotification<T>(string method, T @params);
+        void SendNotification(IRequest @params);
         Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken);
+        Task<TResponse> SendRequest<TResponse>(IRequest<TResponse> @params, CancellationToken cancellationToken);
+        Task SendRequest(IRequest @params, CancellationToken cancellationToken);
         Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken);
         Task SendRequest<T>(string method, T @params, CancellationToken cancellationToken);
         TaskCompletionSource<JToken> GetRequest(long id);

--- a/src/JsonRpc/IResponseRouter.cs
+++ b/src/JsonRpc/IResponseRouter.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
@@ -7,9 +8,9 @@ namespace OmniSharp.Extensions.JsonRpc
     {
         void SendNotification(string method);
         void SendNotification<T>(string method, T @params);
-        Task<TResponse> SendRequest<T, TResponse>(string method, T @params);
-        Task<TResponse> SendRequest<TResponse>(string method);
-        Task SendRequest<T>(string method, T @params);
+        Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken);
+        Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken);
+        Task SendRequest<T>(string method, T @params, CancellationToken cancellationToken);
         TaskCompletionSource<JToken> GetRequest(long id);
     }
 }

--- a/src/JsonRpc/JsonRpcServer.cs
+++ b/src/JsonRpc/JsonRpcServer.cs
@@ -180,9 +180,24 @@ namespace OmniSharp.Extensions.JsonRpc
             _responseRouter.SendNotification(method, @params);
         }
 
+        public void SendNotification(IRequest @params)
+        {
+            _responseRouter.SendNotification(@params);
+        }
+
         public Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken)
         {
             return _responseRouter.SendRequest<T, TResponse>(method, @params, cancellationToken);
+        }
+
+        public Task<TResponse> SendRequest<TResponse>(IRequest<TResponse> @params, CancellationToken cancellationToken)
+        {
+            return _responseRouter.SendRequest(@params, cancellationToken);
+        }
+
+        public Task SendRequest(IRequest @params, CancellationToken cancellationToken)
+        {
+            return _responseRouter.SendRequest(@params, cancellationToken);
         }
 
         public Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken)

--- a/src/JsonRpc/JsonRpcServer.cs
+++ b/src/JsonRpc/JsonRpcServer.cs
@@ -180,19 +180,19 @@ namespace OmniSharp.Extensions.JsonRpc
             _responseRouter.SendNotification(method, @params);
         }
 
-        public Task<TResponse> SendRequest<T, TResponse>(string method, T @params)
+        public Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken)
         {
-            return _responseRouter.SendRequest<T, TResponse>(method, @params);
+            return _responseRouter.SendRequest<T, TResponse>(method, @params, cancellationToken);
         }
 
-        public Task<TResponse> SendRequest<TResponse>(string method)
+        public Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken)
         {
-            return _responseRouter.SendRequest<TResponse>(method);
+            return _responseRouter.SendRequest<TResponse>(method, cancellationToken);
         }
 
-        public Task SendRequest<T>(string method, T @params)
+        public Task SendRequest<T>(string method, T @params, CancellationToken cancellationToken)
         {
-            return _responseRouter.SendRequest(method, @params);
+            return _responseRouter.SendRequest(method, @params, cancellationToken);
         }
 
         public TaskCompletionSource<JToken> GetRequest(long id)

--- a/src/JsonRpc/OutputHandler.cs
+++ b/src/JsonRpc/OutputHandler.cs
@@ -18,13 +18,14 @@ namespace OmniSharp.Extensions.JsonRpc
 
         public OutputHandler(Stream output, ISerializer serializer)
         {
-            if (!output.CanWrite) throw new ArgumentException($"must provide a writable stream for {nameof(output)}", nameof(output));
+            if (!output.CanWrite)
+                throw new ArgumentException($"must provide a writable stream for {nameof(output)}", nameof(output));
             _output = output;
             _serializer = serializer;
             _queue = new BlockingCollection<object>();
             _cancel = new CancellationTokenSource();
             _outputIsFinished = new TaskCompletionSource<object>();
-            _thread = new Thread(ProcessOutputQueue) { IsBackground = true, Name = "ProcessOutputQueue" };
+            _thread = new Thread(ProcessOutputQueue) {IsBackground = true, Name = "ProcessOutputQueue"};
         }
 
         public void Start()
@@ -32,9 +33,10 @@ namespace OmniSharp.Extensions.JsonRpc
             _thread.Start();
         }
 
-        public void Send(object value)
+        public void Send(object value, CancellationToken cancellationToken)
         {
-            _queue.Add(value);
+            if (!cancellationToken.IsCancellationRequested)
+                _queue.Add(value);
         }
 
         private void ProcessOutputQueue()
@@ -62,7 +64,7 @@ namespace OmniSharp.Extensions.JsonRpc
                             ms.Write(contentBytes, 0, contentBytes.Length);
                             if (!token.IsCancellationRequested)
                             {
-                                _output.Write(ms.ToArray(), 0, (int)ms.Position);
+                                _output.Write(ms.ToArray(), 0, (int) ms.Position);
                             }
                         }
 

--- a/src/JsonRpc/ResponseRouter.cs
+++ b/src/JsonRpc/ResponseRouter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
@@ -21,7 +22,7 @@ namespace OmniSharp.Extensions.JsonRpc
         {
             _outputHandler.Send(new Client.Notification() {
                 Method = method
-            });
+            }, CancellationToken.None);
         }
 
         public void SendNotification<T>(string method, T @params)
@@ -29,12 +30,13 @@ namespace OmniSharp.Extensions.JsonRpc
             _outputHandler.Send(new Client.Notification() {
                 Method = method,
                 Params = @params
-            });
+            }, CancellationToken.None);
         }
 
-        public async Task<TResponse> SendRequest<T, TResponse>(string method, T @params)
+        public async Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken)
         {
             var tcs = new TaskCompletionSource<JToken>();
+
             var nextId = _serializer.GetNextId();
             _requests.TryAdd(nextId, tcs);
 
@@ -42,7 +44,7 @@ namespace OmniSharp.Extensions.JsonRpc
                 Method = method,
                 Params = @params,
                 Id = nextId
-            });
+            }, cancellationToken);
 
             try
             {
@@ -55,7 +57,7 @@ namespace OmniSharp.Extensions.JsonRpc
             }
         }
 
-        public async Task<TResponse> SendRequest<TResponse>(string method)
+        public async Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken)
         {
             var nextId = _serializer.GetNextId();
 
@@ -66,7 +68,7 @@ namespace OmniSharp.Extensions.JsonRpc
                 Method = method,
                 Params = null,
                 Id = nextId
-            });
+            }, cancellationToken);
 
             try
             {
@@ -79,7 +81,7 @@ namespace OmniSharp.Extensions.JsonRpc
             }
         }
 
-        public async Task SendRequest<T>(string method, T @params)
+        public async Task SendRequest<T>(string method, T @params, CancellationToken cancellationToken)
         {
             var nextId = _serializer.GetNextId();
 
@@ -90,7 +92,7 @@ namespace OmniSharp.Extensions.JsonRpc
                 Method = method,
                 Params = @params,
                 Id = nextId
-            });
+            }, cancellationToken);
 
             try
             {

--- a/src/Protocol/Client/Server/RegisterCapabilityExtensions.cs
+++ b/src/Protocol/Client/Server/RegisterCapabilityExtensions.cs
@@ -10,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server
 {
     public static class RegisterCapabilityExtensions
     {
-        public static async Task RegisterCapability(this ILanguageServerClient mediator, RegistrationParams @params, CancellationToken cancellationToken = default)
+        public static Task RegisterCapability(this ILanguageServerClient mediator, RegistrationParams @params, CancellationToken cancellationToken = default)
         {
-            await mediator.SendRequest(ClientNames.RegisterCapability, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Client/Server/RegisterCapabilityExtensions.cs
+++ b/src/Protocol/Client/Server/RegisterCapabilityExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server
 {
     public static class RegisterCapabilityExtensions
     {
-        public static async Task RegisterCapability(this ILanguageServerClient mediator, RegistrationParams @params)
+        public static async Task RegisterCapability(this ILanguageServerClient mediator, RegistrationParams @params, CancellationToken cancellationToken = default)
         {
-            await mediator.SendRequest(ClientNames.RegisterCapability, @params);
+            await mediator.SendRequest(ClientNames.RegisterCapability, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Client/Server/UnregisterCapabilityExtensions.cs
+++ b/src/Protocol/Client/Server/UnregisterCapabilityExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -10,9 +11,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server
 {
     public static class UnregisterCapabilityExtensions
     {
-        public static async Task UnregisterCapability(this ILanguageServerClient mediator, UnregistrationParams @params)
+        public static async Task UnregisterCapability(this ILanguageServerClient mediator, UnregistrationParams @params, CancellationToken cancellationToken = default)
         {
-            await mediator.SendRequest(ClientNames.UnregisterCapability, @params);
+            await mediator.SendRequest(ClientNames.UnregisterCapability, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Client/Server/UnregisterCapabilityExtensions.cs
+++ b/src/Protocol/Client/Server/UnregisterCapabilityExtensions.cs
@@ -11,9 +11,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server
 {
     public static class UnregisterCapabilityExtensions
     {
-        public static async Task UnregisterCapability(this ILanguageServerClient mediator, UnregistrationParams @params, CancellationToken cancellationToken = default)
+        public static Task UnregisterCapability(this ILanguageServerClient mediator, UnregistrationParams @params, CancellationToken cancellationToken = default)
         {
-            await mediator.SendRequest(ClientNames.UnregisterCapability, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/ClientProxyBase.cs
+++ b/src/Protocol/ClientProxyBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.JsonRpc;
 
@@ -16,11 +17,11 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
         public void SendNotification<T>(string method, T @params) => _responseRouter.SendNotification(method, @params);
 
-        public Task<TResponse> SendRequest<T, TResponse>(string method, T @params) => _responseRouter.SendRequest<T, TResponse>(method, @params);
+        public Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken) => _responseRouter.SendRequest<T, TResponse>(method, @params, cancellationToken);
 
-        public Task<TResponse> SendRequest<TResponse>(string method) => _responseRouter.SendRequest<TResponse>(method);
+        public Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken) => _responseRouter.SendRequest<TResponse>(method, cancellationToken);
 
-        public Task SendRequest<T>(string method, T @params) => _responseRouter.SendRequest(method, @params);
+        public Task SendRequest<T>(string method, T @params, CancellationToken cancellationToken ) => _responseRouter.SendRequest(method, @params, cancellationToken);
 
         public TaskCompletionSource<JToken> GetRequest(long id) => _responseRouter.GetRequest(id);
     }

--- a/src/Protocol/ClientProxyBase.cs
+++ b/src/Protocol/ClientProxyBase.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using MediatR;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.JsonRpc;
 
@@ -16,8 +17,14 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         public void SendNotification(string method) => _responseRouter.SendNotification(method);
 
         public void SendNotification<T>(string method, T @params) => _responseRouter.SendNotification(method, @params);
+        public void SendNotification(IRequest @params) => _responseRouter.SendNotification(@params);
 
         public Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken) => _responseRouter.SendRequest<T, TResponse>(method, @params, cancellationToken);
+        public Task<TResponse> SendRequest<TResponse>(IRequest<TResponse> @params, CancellationToken cancellationToken) => _responseRouter.SendRequest(@params, cancellationToken);
+        public Task SendRequest(IRequest @params, CancellationToken cancellationToken)
+        {
+            return _responseRouter.SendRequest(@params, cancellationToken);
+        }
 
         public Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken) => _responseRouter.SendRequest<TResponse>(method, cancellationToken);
 

--- a/src/Protocol/Document/Client/CodeActionExtensions.cs
+++ b/src/Protocol/Document/Client/CodeActionExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<CommandOrCodeActionContainer> CodeAction(this ILanguageClientDocument mediator, CodeActionParams @params, CancellationToken cancellationToken )
         {
-            return mediator.SendRequest<CodeActionParams, CommandOrCodeActionContainer>(DocumentNames.CodeAction, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/CodeActionExtensions.cs
+++ b/src/Protocol/Document/Client/CodeActionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class CodeActionExtensions
     {
-        public static Task<CommandOrCodeActionContainer> CodeAction(this ILanguageClientDocument mediator, CodeActionParams @params)
+        public static Task<CommandOrCodeActionContainer> CodeAction(this ILanguageClientDocument mediator, CodeActionParams @params, CancellationToken cancellationToken )
         {
-            return mediator.SendRequest<CodeActionParams, CommandOrCodeActionContainer>(DocumentNames.CodeAction, @params);
+            return mediator.SendRequest<CodeActionParams, CommandOrCodeActionContainer>(DocumentNames.CodeAction, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/CodeLensExtensions.cs
+++ b/src/Protocol/Document/Client/CodeLensExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<CodeLensContainer> CodeLens(this ILanguageClientDocument mediator, CodeLensParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<CodeLensParams, CodeLensContainer>(DocumentNames.CodeLens, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/CodeLensExtensions.cs
+++ b/src/Protocol/Document/Client/CodeLensExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class CodeLensExtensions
     {
-        public static Task<CodeLensContainer> CodeLens(this ILanguageClientDocument mediator, CodeLensParams @params)
+        public static Task<CodeLensContainer> CodeLens(this ILanguageClientDocument mediator, CodeLensParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<CodeLensParams, CodeLensContainer>(DocumentNames.CodeLens, @params);
+            return mediator.SendRequest<CodeLensParams, CodeLensContainer>(DocumentNames.CodeLens, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/CodeLensResolveExtensions.cs
+++ b/src/Protocol/Document/Client/CodeLensResolveExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -8,9 +9,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class CodeLensResolveExtensions
     {
-        public static Task<CodeLens> CodeLensResolve(this ILanguageClientDocument mediator, CodeLens @params)
+        public static Task<CodeLens> CodeLensResolve(this ILanguageClientDocument mediator, CodeLens @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<CodeLens, CodeLens>(DocumentNames.CodeLensResolve, @params);
+            return mediator.SendRequest<CodeLens, CodeLens>(DocumentNames.CodeLensResolve, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/CodeLensResolveExtensions.cs
+++ b/src/Protocol/Document/Client/CodeLensResolveExtensions.cs
@@ -11,7 +11,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<CodeLens> CodeLensResolve(this ILanguageClientDocument mediator, CodeLens @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<CodeLens, CodeLens>(DocumentNames.CodeLensResolve, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/ColorPresentationExtensions.cs
+++ b/src/Protocol/Document/Client/ColorPresentationExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<Container<ColorPresentation>> ColorPresentation(this ILanguageClientDocument mediator, ColorPresentationParams @params, CancellationToken cancellationToken= default)
         {
-            return mediator.SendRequest<ColorPresentationParams, Container<ColorPresentation>>(DocumentNames.ColorPresentation, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/ColorPresentationExtensions.cs
+++ b/src/Protocol/Document/Client/ColorPresentationExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class ColorPresentationExtensions
     {
-        public static Task<Container<ColorPresentation>> ColorPresentation(this ILanguageClientDocument mediator, ColorPresentationParams @params)
+        public static Task<Container<ColorPresentation>> ColorPresentation(this ILanguageClientDocument mediator, ColorPresentationParams @params, CancellationToken cancellationToken= default)
         {
-            return mediator.SendRequest<ColorPresentationParams, Container<ColorPresentation>>(DocumentNames.ColorPresentation, @params);
+            return mediator.SendRequest<ColorPresentationParams, Container<ColorPresentation>>(DocumentNames.ColorPresentation, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/CompletionExtensions.cs
+++ b/src/Protocol/Document/Client/CompletionExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<CompletionList> Completion(this ILanguageClientDocument mediator, CompletionParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<CompletionParams, CompletionList>(DocumentNames.Completion, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/CompletionExtensions.cs
+++ b/src/Protocol/Document/Client/CompletionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class CompletionExtensions
     {
-        public static Task<CompletionList> Completion(this ILanguageClientDocument mediator, CompletionParams @params)
+        public static Task<CompletionList> Completion(this ILanguageClientDocument mediator, CompletionParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<CompletionParams, CompletionList>(DocumentNames.Completion, @params);
+            return mediator.SendRequest<CompletionParams, CompletionList>(DocumentNames.Completion, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/CompletionResolveExtensions.cs
+++ b/src/Protocol/Document/Client/CompletionResolveExtensions.cs
@@ -11,7 +11,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<CompletionItem> CompletionResolve(this ILanguageClientDocument mediator, CompletionItem @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<CompletionItem, CompletionItem>(DocumentNames.CompletionResolve, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/CompletionResolveExtensions.cs
+++ b/src/Protocol/Document/Client/CompletionResolveExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -8,9 +9,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class CompletionResolveExtensions
     {
-        public static Task<CompletionItem> CompletionResolve(this ILanguageClientDocument mediator, CompletionItem @params)
+        public static Task<CompletionItem> CompletionResolve(this ILanguageClientDocument mediator, CompletionItem @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<CompletionItem, CompletionItem>(DocumentNames.CompletionResolve, @params);
+            return mediator.SendRequest<CompletionItem, CompletionItem>(DocumentNames.CompletionResolve, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DeclarationExtensions.cs
+++ b/src/Protocol/Document/Client/DeclarationExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<LocationOrLocationLinks> Declaration(this ILanguageClientDocument mediator, DeclarationParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DeclarationParams, LocationOrLocationLinks>(DocumentNames.Declaration, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DeclarationExtensions.cs
+++ b/src/Protocol/Document/Client/DeclarationExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class DeclarationExtensions
     {
-        public static Task<LocationOrLocationLinks> Declaration(this ILanguageClientDocument mediator, DeclarationParams @params)
+        public static Task<LocationOrLocationLinks> Declaration(this ILanguageClientDocument mediator, DeclarationParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DeclarationParams, LocationOrLocationLinks>(DocumentNames.Declaration, @params);
+            return mediator.SendRequest<DeclarationParams, LocationOrLocationLinks>(DocumentNames.Declaration, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DefinitionExtensions.cs
+++ b/src/Protocol/Document/Client/DefinitionExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<LocationOrLocationLinks> Definition(this ILanguageClientDocument mediator, DefinitionParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DefinitionParams, LocationOrLocationLinks>(DocumentNames.Definition, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DefinitionExtensions.cs
+++ b/src/Protocol/Document/Client/DefinitionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class DefinitionExtensions
     {
-        public static Task<LocationOrLocationLinks> Definition(this ILanguageClientDocument mediator, DefinitionParams @params)
+        public static Task<LocationOrLocationLinks> Definition(this ILanguageClientDocument mediator, DefinitionParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DefinitionParams, LocationOrLocationLinks>(DocumentNames.Definition, @params);
+            return mediator.SendRequest<DefinitionParams, LocationOrLocationLinks>(DocumentNames.Definition, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentColorExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentColorExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class DocumentColorExtensions
     {
-        public static Task<Container<ColorPresentation>> DocumentColor(this ILanguageClientDocument mediator, DocumentColorParams @params)
+        public static Task<Container<ColorPresentation>> DocumentColor(this ILanguageClientDocument mediator, DocumentColorParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentColorParams, Container<ColorPresentation>>(DocumentNames.DocumentColor, @params);
+            return mediator.SendRequest<DocumentColorParams, Container<ColorPresentation>>(DocumentNames.DocumentColor, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentColorExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentColorExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<Container<ColorPresentation>> DocumentColor(this ILanguageClientDocument mediator, DocumentColorParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentColorParams, Container<ColorPresentation>>(DocumentNames.DocumentColor, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentFormattingExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentFormattingExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<TextEditContainer> DocumentFormatting(this ILanguageClientDocument mediator, DocumentFormattingParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentFormattingParams, TextEditContainer>(DocumentNames.Formatting, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentFormattingExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentFormattingExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class DocumentFormattingExtensions
     {
-        public static Task<TextEditContainer> DocumentFormatting(this ILanguageClientDocument mediator, DocumentFormattingParams @params)
+        public static Task<TextEditContainer> DocumentFormatting(this ILanguageClientDocument mediator, DocumentFormattingParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentFormattingParams, TextEditContainer>(DocumentNames.Formatting, @params);
+            return mediator.SendRequest<DocumentFormattingParams, TextEditContainer>(DocumentNames.Formatting, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentHighlightExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentHighlightExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<DocumentHighlightContainer> DocumentHighlight(this ILanguageClientDocument mediator, DocumentHighlightParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentHighlightParams, DocumentHighlightContainer>(DocumentNames.DocumentHighlight, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentHighlightExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentHighlightExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class DocumentHighlightExtensions
     {
-        public static Task<DocumentHighlightContainer> DocumentHighlight(this ILanguageClientDocument mediator, DocumentHighlightParams @params)
+        public static Task<DocumentHighlightContainer> DocumentHighlight(this ILanguageClientDocument mediator, DocumentHighlightParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentHighlightParams, DocumentHighlightContainer>(DocumentNames.DocumentHighlight, @params);
+            return mediator.SendRequest<DocumentHighlightParams, DocumentHighlightContainer>(DocumentNames.DocumentHighlight, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentLinkExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentLinkExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<DocumentLinkContainer> DocumentLink(this ILanguageClientDocument mediator, DocumentLinkParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentLinkParams, DocumentLinkContainer>(DocumentNames.DocumentLink, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentLinkExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentLinkExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class DocumentLinkExtensions
     {
-        public static Task<DocumentLinkContainer> DocumentLink(this ILanguageClientDocument mediator, DocumentLinkParams @params)
+        public static Task<DocumentLinkContainer> DocumentLink(this ILanguageClientDocument mediator, DocumentLinkParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentLinkParams, DocumentLinkContainer>(DocumentNames.DocumentLink, @params);
+            return mediator.SendRequest<DocumentLinkParams, DocumentLinkContainer>(DocumentNames.DocumentLink, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentLinkResolveExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentLinkResolveExtensions.cs
@@ -11,7 +11,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<DocumentLink> DocumentLinkResolve(this ILanguageClientDocument mediator, DocumentLink @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentLink, DocumentLink>(DocumentNames.DocumentLinkResolve, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentLinkResolveExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentLinkResolveExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -8,9 +9,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class DocumentLinkResolveExtensions
     {
-        public static Task<DocumentLink> DocumentLinkResolve(this ILanguageClientDocument mediator, DocumentLink @params)
+        public static Task<DocumentLink> DocumentLinkResolve(this ILanguageClientDocument mediator, DocumentLink @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentLink, DocumentLink>(DocumentNames.DocumentLinkResolve, @params);
+            return mediator.SendRequest<DocumentLink, DocumentLink>(DocumentNames.DocumentLinkResolve, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentOnTypeFormatExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentOnTypeFormatExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class DocumentOnTypeFormatExtensions
     {
-        public static Task<TextEditContainer> DocumentOnTypeFormat(this ILanguageClientDocument mediator, DocumentOnTypeFormattingParams @params)
+        public static Task<TextEditContainer> DocumentOnTypeFormat(this ILanguageClientDocument mediator, DocumentOnTypeFormattingParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentOnTypeFormattingParams, TextEditContainer>(DocumentNames.OnTypeFormatting, @params);
+            return mediator.SendRequest<DocumentOnTypeFormattingParams, TextEditContainer>(DocumentNames.OnTypeFormatting, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentOnTypeFormatExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentOnTypeFormatExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<TextEditContainer> DocumentOnTypeFormat(this ILanguageClientDocument mediator, DocumentOnTypeFormattingParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentOnTypeFormattingParams, TextEditContainer>(DocumentNames.OnTypeFormatting, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentRangeFormattingExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentRangeFormattingExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<TextEditContainer> DocumentRangeFormatting(this ILanguageClientDocument mediator, DocumentRangeFormattingParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentRangeFormattingParams, TextEditContainer>(DocumentNames.RangeFormatting, @params,  cancellationToken);
+            return mediator.SendRequest(@params,  cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentRangeFormattingExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentRangeFormattingExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class DocumentRangeFormattingExtensions
     {
-        public static Task<TextEditContainer> DocumentRangeFormatting(this ILanguageClientDocument mediator, DocumentRangeFormattingParams @params)
+        public static Task<TextEditContainer> DocumentRangeFormatting(this ILanguageClientDocument mediator, DocumentRangeFormattingParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentRangeFormattingParams, TextEditContainer>(DocumentNames.RangeFormatting, @params);
+            return mediator.SendRequest<DocumentRangeFormattingParams, TextEditContainer>(DocumentNames.RangeFormatting, @params,  cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentSymbolExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentSymbolExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<SymbolInformationOrDocumentSymbolContainer> DocumentSymbol(this ILanguageClientDocument mediator, DocumentSymbolParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentSymbolParams, SymbolInformationOrDocumentSymbolContainer>(DocumentNames.DocumentSymbol, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/DocumentSymbolExtensions.cs
+++ b/src/Protocol/Document/Client/DocumentSymbolExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class DocumentSymbolExtensions
     {
-        public static Task<SymbolInformationOrDocumentSymbolContainer> DocumentSymbol(this ILanguageClientDocument mediator, DocumentSymbolParams @params)
+        public static Task<SymbolInformationOrDocumentSymbolContainer> DocumentSymbol(this ILanguageClientDocument mediator, DocumentSymbolParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<DocumentSymbolParams, SymbolInformationOrDocumentSymbolContainer>(DocumentNames.DocumentSymbol, @params);
+            return mediator.SendRequest<DocumentSymbolParams, SymbolInformationOrDocumentSymbolContainer>(DocumentNames.DocumentSymbol, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/HoverExtensions.cs
+++ b/src/Protocol/Document/Client/HoverExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<Hover> Hover(this ILanguageClientDocument mediator, HoverParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<HoverParams, Hover>(DocumentNames.Hover, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/HoverExtensions.cs
+++ b/src/Protocol/Document/Client/HoverExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class HoverExtensions
     {
-        public static Task<Hover> Hover(this ILanguageClientDocument mediator, HoverParams @params)
+        public static Task<Hover> Hover(this ILanguageClientDocument mediator, HoverParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<HoverParams, Hover>(DocumentNames.Hover, @params);
+            return mediator.SendRequest<HoverParams, Hover>(DocumentNames.Hover, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/ImplementationExtensions.cs
+++ b/src/Protocol/Document/Client/ImplementationExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class ImplementationExtensions
     {
-        public static Task<LocationOrLocationLinks> Implementation(this ILanguageClientDocument mediator, ImplementationParams @params)
+        public static Task<LocationOrLocationLinks> Implementation(this ILanguageClientDocument mediator, ImplementationParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<ImplementationParams, LocationOrLocationLinks>(DocumentNames.Implementation, @params);
+            return mediator.SendRequest<ImplementationParams, LocationOrLocationLinks>(DocumentNames.Implementation, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/ImplementationExtensions.cs
+++ b/src/Protocol/Document/Client/ImplementationExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<LocationOrLocationLinks> Implementation(this ILanguageClientDocument mediator, ImplementationParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<ImplementationParams, LocationOrLocationLinks>(DocumentNames.Implementation, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/ReferencesExtensions.cs
+++ b/src/Protocol/Document/Client/ReferencesExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class ReferencesExtensions
     {
-        public static Task<LocationContainer> References(this ILanguageClientDocument mediator, ReferenceParams @params)
+        public static Task<LocationContainer> References(this ILanguageClientDocument mediator, ReferenceParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<ReferenceParams, LocationContainer>(DocumentNames.References, @params);
+            return mediator.SendRequest<ReferenceParams, LocationContainer>(DocumentNames.References, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/ReferencesExtensions.cs
+++ b/src/Protocol/Document/Client/ReferencesExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<LocationContainer> References(this ILanguageClientDocument mediator, ReferenceParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<ReferenceParams, LocationContainer>(DocumentNames.References, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/RenameExtensions.cs
+++ b/src/Protocol/Document/Client/RenameExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<WorkspaceEdit> Rename(this ILanguageClientDocument mediator, RenameParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<RenameParams, WorkspaceEdit>(DocumentNames.Rename, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/RenameExtensions.cs
+++ b/src/Protocol/Document/Client/RenameExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class RenameExtensions
     {
-        public static Task<WorkspaceEdit> Rename(this ILanguageClientDocument mediator, RenameParams @params)
+        public static Task<WorkspaceEdit> Rename(this ILanguageClientDocument mediator, RenameParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<RenameParams, WorkspaceEdit>(DocumentNames.Rename, @params);
+            return mediator.SendRequest<RenameParams, WorkspaceEdit>(DocumentNames.Rename, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/SignatureHelpExtensions.cs
+++ b/src/Protocol/Document/Client/SignatureHelpExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class SignatureHelpExtensions
     {
-        public static Task<SignatureHelp> SignatureHelp(this ILanguageClientDocument mediator, SignatureHelpParams @params)
+        public static Task<SignatureHelp> SignatureHelp(this ILanguageClientDocument mediator, SignatureHelpParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<SignatureHelpParams, SignatureHelp>(DocumentNames.SignatureHelp, @params);
+            return mediator.SendRequest<SignatureHelpParams, SignatureHelp>(DocumentNames.SignatureHelp, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/SignatureHelpExtensions.cs
+++ b/src/Protocol/Document/Client/SignatureHelpExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<SignatureHelp> SignatureHelp(this ILanguageClientDocument mediator, SignatureHelpParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<SignatureHelpParams, SignatureHelp>(DocumentNames.SignatureHelp, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/TypeDefinitionExtensions.cs
+++ b/src/Protocol/Document/Client/TypeDefinitionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class TypeDefinitionExtensions
     {
-        public static Task<LocationOrLocationLinks> TypeDefinition(this ILanguageClientDocument mediator, TypeDefinitionParams @params)
+        public static Task<LocationOrLocationLinks> TypeDefinition(this ILanguageClientDocument mediator, TypeDefinitionParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<TypeDefinitionParams, LocationOrLocationLinks>(DocumentNames.TypeDefinition, @params);
+            return mediator.SendRequest<TypeDefinitionParams, LocationOrLocationLinks>(DocumentNames.TypeDefinition, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/TypeDefinitionExtensions.cs
+++ b/src/Protocol/Document/Client/TypeDefinitionExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<LocationOrLocationLinks> TypeDefinition(this ILanguageClientDocument mediator, TypeDefinitionParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<TypeDefinitionParams, LocationOrLocationLinks>(DocumentNames.TypeDefinition, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/WillSaveWaitUntilTextDocumentExtensions.cs
+++ b/src/Protocol/Document/Client/WillSaveWaitUntilTextDocumentExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task WillSaveWaitUntilTextDocument(this ILanguageClientDocument mediator, WillSaveWaitUntilTextDocumentParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest(DocumentNames.WillSaveWaitUntil, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Document/Client/WillSaveWaitUntilTextDocumentExtensions.cs
+++ b/src/Protocol/Document/Client/WillSaveWaitUntilTextDocumentExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class WillSaveWaitUntilTextDocumentExtensions
     {
-        public static Task WillSaveWaitUntilTextDocument(this ILanguageClientDocument mediator, WillSaveWaitUntilTextDocumentParams @params)
+        public static Task WillSaveWaitUntilTextDocument(this ILanguageClientDocument mediator, WillSaveWaitUntilTextDocumentParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest(DocumentNames.WillSaveWaitUntil, @params);
+            return mediator.SendRequest(DocumentNames.WillSaveWaitUntil, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/General/Client/InitializeExtensions.cs
+++ b/src/Protocol/General/Client/InitializeExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -8,9 +9,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class InitializeExtensions
     {
-        public static Task<InitializeResult> Initialize(this ILanguageClient mediator, InitializeParams @params)
+        public static Task<InitializeResult> Initialize(this ILanguageClient mediator, InitializeParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<InitializeParams, InitializeResult>(GeneralNames.Initialize, @params);
+            return mediator.SendRequest<InitializeParams, InitializeResult>(GeneralNames.Initialize, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/General/Client/InitializeExtensions.cs
+++ b/src/Protocol/General/Client/InitializeExtensions.cs
@@ -11,7 +11,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task<InitializeResult> Initialize(this ILanguageClient mediator, InitializeParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<InitializeParams, InitializeResult>(GeneralNames.Initialize, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/General/Client/ShutdownExtensions.cs
+++ b/src/Protocol/General/Client/ShutdownExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client;
@@ -8,9 +9,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class ShutdownExtensions
     {
-        public static Task Shutdown(this ILanguageClient mediator)
+        public static Task Shutdown(this ILanguageClient mediator, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<object>(GeneralNames.Shutdown);
+            return mediator.SendRequest<object>(GeneralNames.Shutdown, cancellationToken);
         }
     }
 }

--- a/src/Protocol/General/Client/ShutdownExtensions.cs
+++ b/src/Protocol/General/Client/ShutdownExtensions.cs
@@ -2,6 +2,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 // ReSharper disable CheckNamespace
 
@@ -11,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task Shutdown(this ILanguageClient mediator, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<object>(GeneralNames.Shutdown, cancellationToken);
+            return mediator.SendRequest(new ShutdownParams(), cancellationToken);
         }
     }
 }

--- a/src/Protocol/Models/ApplyWorkspaceEditParams.cs
+++ b/src/Protocol/Models/ApplyWorkspaceEditParams.cs
@@ -1,10 +1,12 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(WorkspaceNames.ApplyEdit)]
     public class ApplyWorkspaceEditParams : IRequest<ApplyWorkspaceEditResponse>
     {
         /// <summary>

--- a/src/Protocol/Models/CodeActionParams.cs
+++ b/src/Protocol/Models/CodeActionParams.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
@@ -8,6 +9,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
     /// <summary>
     /// Params for the CodeActionRequest
     /// </summary>
+    [Method(DocumentNames.CodeAction)]
     public class CodeActionParams : ITextDocumentIdentifierParams, IRequest<CommandOrCodeActionContainer>, IWorkDoneProgressParams, IPartialItems<CodeActionOrCommand>
     {
         /// <summary>

--- a/src/Protocol/Models/CodeLens.cs
+++ b/src/Protocol/Models/CodeLens.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
@@ -13,6 +14,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
     /// A code lens is _unresolved_ when no command is associated to it. For performance
     /// reasons the creation of a code lens and resolving should be done in two stages.
     /// </summary>
+    [Method(DocumentNames.CodeLensResolve)]
     public class CodeLens : ICanBeResolved, IRequest<CodeLens>
     {
         /// <summary>

--- a/src/Protocol/Models/CodeLensParams.cs
+++ b/src/Protocol/Models/CodeLensParams.cs
@@ -1,10 +1,12 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.CodeLens)]
     public class CodeLensParams : ITextDocumentIdentifierParams, IRequest<CodeLensContainer>, IWorkDoneProgressParams, IPartialItems<CodeLens>
     {
         /// <summary>

--- a/src/Protocol/Models/ColorPresentationParams.cs
+++ b/src/Protocol/Models/ColorPresentationParams.cs
@@ -1,7 +1,9 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.ColorPresentation)]
     public class ColorPresentationParams : IRequest<Container<ColorPresentation>>
     {
         /// <summary>

--- a/src/Protocol/Models/CompletionItem.cs
+++ b/src/Protocol/Models/CompletionItem.cs
@@ -2,10 +2,12 @@ using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.CompletionResolve)]
     public class CompletionItem : ICanBeResolved, IRequest<CompletionItem>
     {
         /// <summary>

--- a/src/Protocol/Models/CompletionParams.cs
+++ b/src/Protocol/Models/CompletionParams.cs
@@ -1,10 +1,13 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.Completion)]
     public class CompletionParams : WorkDoneTextDocumentPositionParams, IRequest<CompletionList>, IPartialItems<CompletionItem>
     {
         /// <summary>

--- a/src/Protocol/Models/ConfigurationParams.cs
+++ b/src/Protocol/Models/ConfigurationParams.cs
@@ -1,8 +1,10 @@
 using MediatR;
 using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(WorkspaceNames.WorkspaceConfiguration)]
     public class ConfigurationParams : IRequest<Container<JToken>>
     {
         public Container<ConfigurationItem> Items { get; set; }

--- a/src/Protocol/Models/DeclarationParams.cs
+++ b/src/Protocol/Models/DeclarationParams.cs
@@ -1,7 +1,9 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.Declaration)]
     public class DeclarationParams : WorkDoneTextDocumentPositionParams, IRequest<LocationOrLocationLinks>, IPartialItems<LocationLink>
     {
         /// <inheritdoc />

--- a/src/Protocol/Models/DefinitionParams.cs
+++ b/src/Protocol/Models/DefinitionParams.cs
@@ -1,8 +1,10 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.Definition)]
     public class DefinitionParams : WorkDoneTextDocumentPositionParams, IRequest<LocationOrLocationLinks>, IPartialItems<LocationOrLocationLink>
     {
         /// <inheritdoc />

--- a/src/Protocol/Models/DidChangeConfigurationParams.cs
+++ b/src/Protocol/Models/DidChangeConfigurationParams.cs
@@ -3,9 +3,11 @@ using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(WorkspaceNames.DidChangeConfiguration)]
     public class DidChangeConfigurationParams : IRequest
     {
         /// <summary>

--- a/src/Protocol/Models/DidChangeTextDocumentParams.cs
+++ b/src/Protocol/Models/DidChangeTextDocumentParams.cs
@@ -1,9 +1,11 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.DidChange)]
     public class DidChangeTextDocumentParams : IRequest
     {
         /// <summary>

--- a/src/Protocol/Models/DidChangeWatchedFilesParams.cs
+++ b/src/Protocol/Models/DidChangeWatchedFilesParams.cs
@@ -1,8 +1,10 @@
 using MediatR;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(WorkspaceNames.DidChangeWatchedFiles)]
     public class DidChangeWatchedFilesParams : IRequest
     {
         /// <summary>

--- a/src/Protocol/Models/DidChangeWorkspaceFoldersParams.cs
+++ b/src/Protocol/Models/DidChangeWorkspaceFoldersParams.cs
@@ -1,7 +1,9 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(WorkspaceNames.WorkspaceFolders)]
     public class DidChangeWorkspaceFoldersParams : IRequest
     {
         /// <summary>

--- a/src/Protocol/Models/DidCloseTextDocumentParams.cs
+++ b/src/Protocol/Models/DidCloseTextDocumentParams.cs
@@ -1,9 +1,11 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.DidClose)]
     public class DidCloseTextDocumentParams : ITextDocumentIdentifierParams, IRequest
     {
         /// <summary>

--- a/src/Protocol/Models/DidOpenTextDocumentParams.cs
+++ b/src/Protocol/Models/DidOpenTextDocumentParams.cs
@@ -1,9 +1,11 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.DidOpen)]
     public class DidOpenTextDocumentParams : IRequest
     {
         /// <summary>

--- a/src/Protocol/Models/DidSaveTextDocumentParams.cs
+++ b/src/Protocol/Models/DidSaveTextDocumentParams.cs
@@ -1,10 +1,12 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.DidSave)]
     public class DidSaveTextDocumentParams : ITextDocumentIdentifierParams, IRequest
     {
         /// <summary>

--- a/src/Protocol/Models/DocumentColorParams.cs
+++ b/src/Protocol/Models/DocumentColorParams.cs
@@ -1,8 +1,10 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.DocumentColor)]
     public class DocumentColorParams : IRequest<Container<ColorPresentation>>, IWorkDoneProgressParams, IPartialItems<ColorPresentation>
     {
         /// <summary>

--- a/src/Protocol/Models/DocumentFormattingParams.cs
+++ b/src/Protocol/Models/DocumentFormattingParams.cs
@@ -1,10 +1,12 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+[Method(DocumentNames.Formatting)]
     public class DocumentFormattingParams : ITextDocumentIdentifierParams, IRequest<TextEditContainer>, IWorkDoneProgressParams
     {
         /// <summary>

--- a/src/Protocol/Models/DocumentHighlightParams.cs
+++ b/src/Protocol/Models/DocumentHighlightParams.cs
@@ -1,8 +1,10 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.DocumentHighlight)]
     public class DocumentHighlightParams : WorkDoneTextDocumentPositionParams, IRequest<DocumentHighlightContainer>, IPartialItems<DocumentHighlight>
     {
         /// <inheritdoc />

--- a/src/Protocol/Models/DocumentLink.cs
+++ b/src/Protocol/Models/DocumentLink.cs
@@ -2,6 +2,7 @@ using System;
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters;
 
@@ -11,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
     /// A document link is a range in a text document that links to an internal or external resource, like another
     /// text document or a web site.
     /// </summary>
-
+    [Method(DocumentNames.DocumentLinkResolve)]
     public class DocumentLink : ICanBeResolved, IRequest<DocumentLink>
     {
         /// <summary>

--- a/src/Protocol/Models/DocumentLinkParams.cs
+++ b/src/Protocol/Models/DocumentLinkParams.cs
@@ -1,10 +1,12 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.DocumentLink)]
     public class DocumentLinkParams : ITextDocumentIdentifierParams, IRequest<DocumentLinkContainer>, IWorkDoneProgressParams, IPartialItems<DocumentLink>
     {
         /// <summary>

--- a/src/Protocol/Models/DocumentOnTypeFormattingParams.cs
+++ b/src/Protocol/Models/DocumentOnTypeFormattingParams.cs
@@ -1,9 +1,11 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.OnTypeFormatting)]
     public class DocumentOnTypeFormattingParams : ITextDocumentIdentifierParams, IRequest<TextEditContainer>
     {
         /// <summary>

--- a/src/Protocol/Models/DocumentRangeFormattingParams.cs
+++ b/src/Protocol/Models/DocumentRangeFormattingParams.cs
@@ -1,10 +1,12 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.RangeFormatting)]
     public class DocumentRangeFormattingParams : ITextDocumentIdentifierParams, IRequest<TextEditContainer>, IWorkDoneProgressParams
     {
         /// <summary>

--- a/src/Protocol/Models/DocumentSymbolParams.cs
+++ b/src/Protocol/Models/DocumentSymbolParams.cs
@@ -1,10 +1,12 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.DocumentSymbol)]
     public class DocumentSymbolParams : ITextDocumentIdentifierParams, IRequest<SymbolInformationOrDocumentSymbolContainer>, IWorkDoneProgressParams, IPartialItems<SymbolInformationOrDocumentSymbol>
     {
         /// <summary>

--- a/src/Protocol/Models/ExecuteCommandParams.cs
+++ b/src/Protocol/Models/ExecuteCommandParams.cs
@@ -2,10 +2,12 @@ using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(WorkspaceNames.ExecuteCommand)]
     public class ExecuteCommandParams : IRequest, IWorkDoneProgressParams
     {
         /// <summary>

--- a/src/Protocol/Models/FoldingRangeParam.cs
+++ b/src/Protocol/Models/FoldingRangeParam.cs
@@ -1,8 +1,10 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.FoldingRange)]
     public class FoldingRangeRequestParam : ITextDocumentIdentifierParams, IRequest<Container<FoldingRange>>, IWorkDoneProgressParams, IPartialItems<FoldingRange>
     {
         /// <summary>

--- a/src/Protocol/Models/HoverParams.cs
+++ b/src/Protocol/Models/HoverParams.cs
@@ -1,7 +1,9 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.Hover)]
     public class HoverParams : WorkDoneTextDocumentPositionParams, IRequest<Hover>, IWorkDoneProgressParams
     {
     }

--- a/src/Protocol/Models/ImplementationParams.cs
+++ b/src/Protocol/Models/ImplementationParams.cs
@@ -1,8 +1,10 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.Implementation)]
     public class ImplementationParams : WorkDoneTextDocumentPositionParams, IRequest<LocationOrLocationLinks>, IPartialItems<LocationOrLocationLink>
     {
         /// <inheritdoc />

--- a/src/Protocol/Models/InitializeParams.cs
+++ b/src/Protocol/Models/InitializeParams.cs
@@ -2,12 +2,14 @@ using System;
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(GeneralNames.Initialize)]
     public class InitializeParams : IWorkDoneProgressParams, IRequest<InitializeResult>
     {
         /// <summary>

--- a/src/Protocol/Models/InitializedParams.cs
+++ b/src/Protocol/Models/InitializedParams.cs
@@ -2,11 +2,13 @@ using System;
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(GeneralNames.Initialized)]
     public class InitializedParams : IRequest
     {
     }

--- a/src/Protocol/Models/LogMessageParams.cs
+++ b/src/Protocol/Models/LogMessageParams.cs
@@ -1,9 +1,11 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(WindowNames.LogMessage)]
     public class LogMessageParams : IRequest
     {
         /// <summary>

--- a/src/Protocol/Models/PrepareRenameParams.cs
+++ b/src/Protocol/Models/PrepareRenameParams.cs
@@ -1,7 +1,9 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.PrepareRename)]
     public class PrepareRenameParams : TextDocumentPositionParams, IRequest<RangeOrPlaceholderRange>
     {
     }

--- a/src/Protocol/Models/ProgressExtensions.cs
+++ b/src/Protocol/Models/ProgressExtensions.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using OmniSharp.Extensions.JsonRpc;
 
@@ -5,14 +7,21 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
     public static class ProgressExtensions
     {
-        public static void SendProgress<T>(this IResponseRouter mediator, ProgressToken token, T value, JsonSerializer jsonSerializer)
+        public static void SendProgress<T>(this IResponseRouter mediator, ProgressToken token, T value,
+            JsonSerializer jsonSerializer)
         {
-            mediator.SendNotification(GeneralNames.Progress, ProgressParams.Create<T>(token, value, jsonSerializer));
+            mediator.SendNotification(ProgressParams.Create<T>(token, value, jsonSerializer));
         }
 
         public static void SendProgress(this IResponseRouter mediator, ProgressParams @params)
         {
-            mediator.SendNotification(GeneralNames.Progress, @params);
+            mediator.SendNotification(@params);
+        }
+
+        public static Task CreateProgress(this IResponseRouter mediator, ProgressToken token,
+            CancellationToken cancellationToken)
+        {
+            return mediator.SendRequest(new WorkDoneProgressCreateParams() {Token = token}, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Models/ProgressParams.cs
+++ b/src/Protocol/Models/ProgressParams.cs
@@ -1,9 +1,11 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(GeneralNames.Progress)]
     public class ProgressParams : IRequest
     {
         public static ProgressParams Create<T>(ProgressToken token, T value, JsonSerializer jsonSerializer)

--- a/src/Protocol/Models/PublishDiagnosticsParams.cs
+++ b/src/Protocol/Models/PublishDiagnosticsParams.cs
@@ -2,11 +2,13 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.PublishDiagnostics)]
     public class PublishDiagnosticsParams : IRequest
     {
         /// <summary>

--- a/src/Protocol/Models/ReferenceParams.cs
+++ b/src/Protocol/Models/ReferenceParams.cs
@@ -1,10 +1,12 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.References)]
     public class ReferenceParams : WorkDoneTextDocumentPositionParams, IRequest<LocationContainer>, IPartialItems<Location>
     {
         public ReferenceContext Context { get; set; }

--- a/src/Protocol/Models/RegistrationParams.cs
+++ b/src/Protocol/Models/RegistrationParams.cs
@@ -1,9 +1,11 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(ClientNames.RegisterCapability)]
     public class RegistrationParams : IRequest
     {
         public RegistrationContainer Registrations { get; set; }

--- a/src/Protocol/Models/RenameParams.cs
+++ b/src/Protocol/Models/RenameParams.cs
@@ -1,10 +1,12 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.Rename)]
     public class RenameParams : ITextDocumentIdentifierParams, IRequest<WorkspaceEdit>, IWorkDoneProgressParams
     {
         /// <summary>

--- a/src/Protocol/Models/SelectionRangeParam.cs
+++ b/src/Protocol/Models/SelectionRangeParam.cs
@@ -1,8 +1,10 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.SelectionRange)]
     public class SelectionRangeParam : ITextDocumentIdentifierParams, IRequest<Container<SelectionRange>>, IWorkDoneProgressParams, IPartialItems<SelectionRange>
     {
         /// <summary>

--- a/src/Protocol/Models/ShowMessageParams.cs
+++ b/src/Protocol/Models/ShowMessageParams.cs
@@ -1,12 +1,14 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
     /// <summary>
     ///  The show message notification is sent from a server to a client to ask the client to display a particular message in the user interface.
     /// </summary>
+[Method(WindowNames.ShowMessage)]
     public class ShowMessageParams : IRequest
     {
         /// <summary>

--- a/src/Protocol/Models/ShowMessageRequestParams.cs
+++ b/src/Protocol/Models/ShowMessageRequestParams.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
@@ -8,6 +9,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
     /// <summary>
     ///  The show message request is sent from a server to a client to ask the client to display a particular message in the user interface. In addition to the show message notification the request allows to pass actions and to wait for an answer from the client.
     /// </summary>
+[Method(WindowNames.ShowMessageRequest)]
     public class ShowMessageRequestParams : IRequest<MessageActionItem>
     {
         /// <summary>

--- a/src/Protocol/Models/ShutdownParams.cs
+++ b/src/Protocol/Models/ShutdownParams.cs
@@ -1,7 +1,9 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(GeneralNames.Shutdown)]
     public class ShutdownParams : IRequest
     {
 

--- a/src/Protocol/Models/SignatureHelpParams.cs
+++ b/src/Protocol/Models/SignatureHelpParams.cs
@@ -1,7 +1,9 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.SignatureHelp)]
     public class SignatureHelpParams : WorkDoneTextDocumentPositionParams, IRequest<SignatureHelp>
     {
         /// <summary>

--- a/src/Protocol/Models/TypeDefinitionParams.cs
+++ b/src/Protocol/Models/TypeDefinitionParams.cs
@@ -1,8 +1,10 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(DocumentNames.TypeDefinition)]
     public class TypeDefinitionParams : WorkDoneTextDocumentPositionParams, IRequest<LocationOrLocationLinks>, IPartialItems<LocationOrLocationLink>
     {
         /// <inheritdoc />

--- a/src/Protocol/Models/UnregistrationParams.cs
+++ b/src/Protocol/Models/UnregistrationParams.cs
@@ -1,9 +1,11 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(ClientNames.UnregisterCapability)]
     public class UnregistrationParams : IRequest
     {
         public UnregistrationContainer Unregisterations { get; set; }

--- a/src/Protocol/Models/WillSaveTextDocumentParams.cs
+++ b/src/Protocol/Models/WillSaveTextDocumentParams.cs
@@ -1,12 +1,14 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
     /// <summary>
     ///  The parameters send in a will save text document notification.
     /// </summary>
+    [Method(DocumentNames.WillSave)]
     public class WillSaveTextDocumentParams : IRequest
     {
         /// <summary>

--- a/src/Protocol/Models/WillSaveWaitUntilTextDocumentParams.cs
+++ b/src/Protocol/Models/WillSaveWaitUntilTextDocumentParams.cs
@@ -1,10 +1,12 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
     /// <summary>
     ///  The parameters send in a will save text document notification.
     /// </summary>
+    [Method(DocumentNames.WillSaveWaitUntil)]
     public class WillSaveWaitUntilTextDocumentParams : IRequest<TextEditContainer>
     {
         /// <summary>

--- a/src/Protocol/Models/WorkDoneProgressCancelParams.cs
+++ b/src/Protocol/Models/WorkDoneProgressCancelParams.cs
@@ -1,7 +1,9 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(WindowNames.WorkDoneProgressCancel)]
     public class WorkDoneProgressCancelParams : IRequest
     {
         /// <summary>

--- a/src/Protocol/Models/WorkDoneProgressCreateParams.cs
+++ b/src/Protocol/Models/WorkDoneProgressCreateParams.cs
@@ -1,7 +1,9 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(WindowNames.WorkDoneProgressCreate)]
     public class WorkDoneProgressCreateParams : IRequest
     {
         /// <summary>

--- a/src/Protocol/Models/WorkDoneTextDocumentPositionParams.cs
+++ b/src/Protocol/Models/WorkDoneTextDocumentPositionParams.cs
@@ -2,7 +2,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
-    public class WorkDoneTextDocumentPositionParams : TextDocumentPositionParams, IWorkDoneProgressParams
+    public abstract class WorkDoneTextDocumentPositionParams : TextDocumentPositionParams, IWorkDoneProgressParams
     {
         /// <inheritdoc/>
         [Optional]

--- a/src/Protocol/Models/WorkspaceFolderParams.cs
+++ b/src/Protocol/Models/WorkspaceFolderParams.cs
@@ -1,7 +1,9 @@
 using MediatR;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
+    [Method(WorkspaceNames.WorkspaceFolders)]
     public class WorkspaceFolderParams : IRequest<Container<WorkspaceFolder>>
     {
 

--- a/src/Protocol/Models/WorkspaceSymbolParams.cs
+++ b/src/Protocol/Models/WorkspaceSymbolParams.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
@@ -8,6 +9,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
     /// <summary>
     /// The parameters of a Workspace Symbol Request.
     /// </summary>
+    [Method(WorkspaceNames.WorkspaceSymbol)]
     public class WorkspaceSymbolParams : IRequest<Container<SymbolInformation>>, IWorkDoneProgressParams, IPartialItems<SymbolInformation>
     {
         /// <summary>

--- a/src/Protocol/ProgressManager.cs
+++ b/src/Protocol/ProgressManager.cs
@@ -20,23 +20,22 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
     {
         private IResponseRouter _router;
         private ISerializer _serializer;
-        private bool _initialized;
         private bool _supported;
-        private readonly ConcurrentDictionary<ProgressToken, (object observer, CancellationTokenSource cts)> _activeObservers
-            = new ConcurrentDictionary<ProgressToken, (object observer, CancellationTokenSource cts)>();
+
+        private readonly ConcurrentDictionary<ProgressToken, IDisposable> _activeObservers
+            = new ConcurrentDictionary<ProgressToken, IDisposable>();
+
         private readonly ConcurrentDictionary<ProgressToken, ISubject<JToken>> _activeObservables
             = new ConcurrentDictionary<ProgressToken, ISubject<JToken>>();
 
-        public void Initialized(IResponseRouter router, ISerializer serializer, WindowClientCapabilities windowClientCapabilities)
+        public void Initialized(IResponseRouter router, ISerializer serializer,
+            WindowClientCapabilities windowClientCapabilities)
         {
             _router = router;
             _serializer = serializer;
-            _initialized = true;
             _supported = windowClientCapabilities.WorkDoneProgress.IsSupported &&
                          windowClientCapabilities.WorkDoneProgress.Value;
         }
-
-        public bool IsInitialized => _initialized;
 
         public bool IsSupported => _supported;
 
@@ -44,27 +43,31 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         /// Creates a <see cref="IObserver{WorkDoneProgressReport}" /> that will send all of its progress information to the same source.
         /// The other side can cancel this, so the <see cref="CancellationToken" /> should be respected.
         /// </summary>
-        public ProgressObserver<WorkDoneProgressReport> Create(WorkDoneProgressBegin begin, Func<Exception, WorkDoneProgressEnd> onError = null, Func<WorkDoneProgressEnd> onComplete = null)
+        public ProgressObserver<WorkDoneProgressReport> Create(WorkDoneProgressBegin begin,
+            Func<Exception, WorkDoneProgressEnd> onError = null, Func<WorkDoneProgressEnd> onComplete = null,
+            CancellationToken? cancellationToken = null)
         {
-            if (!_initialized || !_supported)
+            if (!_supported)
             {
                 return ProgressObserver<WorkDoneProgressReport>.Noop;
             }
 
-            onError ??= error => new WorkDoneProgressEnd() {
+            onError ??= error => new WorkDoneProgressEnd()
+            {
                 Message = error.ToString()
             };
 
             onComplete ??= () => new WorkDoneProgressEnd();
 
-            var observer = ProgressObserver.CreateWorkDoneProgress(_router, _serializer, begin, onError, onComplete);
+            var observer = ProgressObserver.CreateWorkDoneProgress(_router, _serializer, begin, onError, onComplete,
+                cancellationToken ?? CancellationToken.None);
+            _activeObservers.TryAdd(observer.ProgressToken, observer);
 
-            var source = new CancellationTokenSource();
-            source.Token.Register(() => {
-                if (_activeObservers.TryRemove(observer.Token, out var item))
+            observer.CancellationToken.Register(() =>
+            {
+                if (_activeObservers.TryRemove(observer.ProgressToken, out _))
                     observer.OnCompleted();
             });
-            _activeObservers.TryAdd(observer.Token, (observer, source));
 
             return observer;
         }
@@ -72,33 +75,36 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         /// <summary>
         /// Creates a <see cref="ProgressObserver" /> that will send all of its progress information to the same source.
         /// </summary>
-        public ProgressObserver<WorkDoneProgressReport> WorkDone(IWorkDoneProgressParams request, WorkDoneProgressBegin begin, Func<Exception, WorkDoneProgressEnd> onError = null, Func<WorkDoneProgressEnd> onComplete = null, CancellationToken? cancellationToken = null)
+        public ProgressObserver<WorkDoneProgressReport> WorkDone(IWorkDoneProgressParams request,
+            WorkDoneProgressBegin begin, Func<Exception, WorkDoneProgressEnd> onError = null,
+            Func<WorkDoneProgressEnd> onComplete = null, CancellationToken? cancellationToken = null)
         {
-            if (!_initialized || !_supported || request.WorkDoneToken == null)
+            if (!_supported || request.WorkDoneToken == null)
             {
                 return ProgressObserver<WorkDoneProgressReport>.Noop;
             }
 
             if (_activeObservers.TryGetValue(request.WorkDoneToken, out var item))
             {
-                return (ProgressObserver<WorkDoneProgressReport>)item.observer;
+                return (ProgressObserver<WorkDoneProgressReport>) item;
             }
 
-            onError ??= error => new WorkDoneProgressEnd() {
+            onError ??= error => new WorkDoneProgressEnd()
+            {
                 Message = error.ToString()
             };
 
             onComplete ??= () => new WorkDoneProgressEnd();
 
-            var observer = ProgressObserver.CreateWorkDoneProgress(request.WorkDoneToken, _router, _serializer, begin, onError, onComplete);
+            var observer = ProgressObserver.CreateWorkDoneProgress(request.WorkDoneToken, _router, _serializer, begin,
+                onError, onComplete, cancellationToken ?? CancellationToken.None);
+            _activeObservers.TryAdd(observer.ProgressToken, observer);
 
-            var source = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken ?? CancellationToken.None);
-            source.Token.Register(() => {
+            observer.CancellationToken.Register(() =>
+            {
                 if (_activeObservers.TryRemove(request.WorkDoneToken, out _))
                     observer.OnCompleted();
             });
-
-            _activeObservers.TryAdd(request.WorkDoneToken, (observer, source));
 
             return observer;
         }
@@ -109,30 +115,30 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         /// </summary>
         public ProgressObserver<T> For<T>(ProgressToken token, CancellationToken? cancellationToken = null)
         {
-            if (!_initialized || !_supported || token == null)
+            if (!_supported || token == null)
             {
                 return ProgressObserver<T>.Noop;
             }
 
             if (_activeObservers.TryGetValue(token, out var item))
             {
-                return (ProgressObserver<T>)item.observer;
+                return (ProgressObserver<T>) item;
             }
 
-            var observer = ProgressObserver.Create<T>(token, _router, _serializer);
+            var observer = ProgressObserver.Create<T>(token, _router, _serializer, cancellationToken ?? CancellationToken.None);
+            _activeObservers.TryAdd(token, observer);
 
-            var source = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken ?? CancellationToken.None);
-            source.Token.Register(() => {
+            observer.CancellationToken.Register(() =>
+            {
                 if (_activeObservers.TryRemove(token, out var _))
                     observer.OnCompleted();
             });
 
-            _activeObservers.TryAdd(token, (observer, source));
-
             return observer;
         }
 
-        public ProgressObserver<Container<T>> For<T>(IPartialResultParams<T> request, CancellationToken? cancellationToken = null)
+        public ProgressObserver<Container<T>> For<T>(IPartialResultParams<T> request,
+            CancellationToken? cancellationToken = null)
         {
             // This can be null.
             // If you use partial results then your final result must be empty as per the spec
@@ -140,7 +146,8 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             return For<Container<T>>(request.PartialResultToken, cancellationToken);
         }
 
-        public ProgressObserver<Container<T>> For<T>(IPartialItems<T> request, CancellationToken? cancellationToken = null)
+        public ProgressObserver<Container<T>> For<T>(IPartialItems<T> request,
+            CancellationToken? cancellationToken = null)
         {
             // This can be null.
             // If you use partial results then your final result must be empty as per the spec
@@ -156,21 +163,25 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             return For<T>(request.PartialResultToken, cancellationToken);
         }
 
-        Task<MediatR.Unit> IRequestHandler<WorkDoneProgressCancelParams, MediatR.Unit>.Handle(WorkDoneProgressCancelParams request, CancellationToken cancellationToken)
+        Task<MediatR.Unit> IRequestHandler<WorkDoneProgressCancelParams, MediatR.Unit>.Handle(
+            WorkDoneProgressCancelParams request, CancellationToken cancellationToken)
         {
             if (_activeObservers.TryGetValue(request.Token, out var item))
             {
-                item.cts.Cancel();
+                item.Dispose();
             }
+
             return MediatR.Unit.Task;
         }
 
-        Task<MediatR.Unit> IRequestHandler<ProgressParams, MediatR.Unit>.Handle(ProgressParams request, CancellationToken cancellationToken)
+        Task<MediatR.Unit> IRequestHandler<ProgressParams, MediatR.Unit>.Handle(ProgressParams request,
+            CancellationToken cancellationToken)
         {
             if (this._activeObservables.TryGetValue(request.Token, out var subject))
             {
                 subject.OnNext(request.Value);
             }
+
             return MediatR.Unit.Task;
         }
     }

--- a/src/Protocol/ResultObserver.cs
+++ b/src/Protocol/ResultObserver.cs
@@ -1,37 +1,148 @@
 using System;
+using System.Collections.Generic;
 using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 // ReSharper disable once CheckNamespace
 namespace OmniSharp.Extensions.LanguageServer.Protocol
 {
-    public class ResultObserver<T> : IDisposable, IObserver<T>
+    public static class ProgressObserver
     {
-        public static ResultObserver<T> Noop { get; } = new ResultObserver<T>(Observer.Create<T>(x => { }));
-        public ResultObserver(IObserver<T> observer)
+        public static ProgressObserver<WorkDoneProgressReport> CreateWorkDoneProgress(
+            ProgressToken token,
+            IResponseRouter router,
+            ISerializer serializer,
+            WorkDoneProgressBegin begin,
+            Func<Exception, WorkDoneProgressEnd> onError,
+            Func<WorkDoneProgressEnd> onComplete)
         {
-            Result = observer;
+            var earlyEvents = new AsyncSubject<List<WorkDoneProgress>>();
+            var observer = new Subject<WorkDoneProgress>();
+            var disposable = new CompositeDisposable {observer, earlyEvents};
+
+            var worker = CreateWorker<WorkDoneProgress>(token, router, serializer, onError, onComplete, disposable);
+
+            disposable.Add(
+                observer.Scan(new List<WorkDoneProgress>() {begin}, (acc, v) =>
+                    {
+                        acc.Add(v);
+                        return acc;
+                    })
+                    .TakeUntil(earlyEvents)
+                    .Subscribe(earlyEvents.OnNext)
+            );
+
+            disposable.Add(
+                Observable.FromAsync(
+                    ct => router.SendRequest(WindowNames.WorkDoneProgressCreate,
+                        new WorkDoneProgressCreateParams() {Token = token,}, ct)
+                ).Subscribe(_ => { }, earlyEvents.OnCompleted)
+            );
+
+            disposable.Add(
+                earlyEvents.SelectMany(z => z).Concat(observer).Subscribe(worker)
+            );
+
+            return new ProgressObserver<WorkDoneProgressReport>(token, observer);
         }
 
-        public IObserver<T> Result { get; }
+        public static ProgressObserver<WorkDoneProgressReport> CreateWorkDoneProgress(IResponseRouter router, ISerializer serializer,
+            WorkDoneProgressBegin begin, Func<Exception, WorkDoneProgressEnd> onError = null,
+            Func<WorkDoneProgressEnd> onComplete = null)
+        {
+            var token = new ProgressToken(Guid.NewGuid().ToString());
+            return CreateWorkDoneProgress(token, router, serializer, begin, onError, onComplete);
+        }
+
+        public static ProgressObserver<T> Create<T>(
+            ProgressToken token, IResponseRouter router,
+            ISerializer serializer)
+        {
+            var observer = new Subject<WorkDoneProgress>();
+            var disposable = new CompositeDisposable {observer};
+
+            return new ProgressObserver<T>(token, CreateWorker<T>(token, router, serializer, disposable));
+        }
+
+        private static IObserver<T> CreateWorker<T>(
+            ProgressToken token,
+            IResponseRouter router,
+            ISerializer serializer,
+            Func<Exception, WorkDoneProgressEnd> onError,
+            Func<WorkDoneProgressEnd> onComplete,
+            IDisposable disposable)
+        {
+            return Observer.Create<T>(
+                value => router.SendProgress(token.Create(value, serializer.JsonSerializer)),
+                error =>
+                {
+                    router.SendProgress(token.Create(onError(error), serializer.JsonSerializer));
+                    disposable.Dispose();
+                },
+                () =>
+                {
+                    var result = onComplete();
+                    if (result == null)
+                    {
+                        disposable.Dispose();
+                        return;
+                    }
+
+                    router.SendProgress(token.Create(result, serializer.JsonSerializer));
+                    disposable.Dispose();
+                });
+        }
+
+        private static IObserver<T> CreateWorker<T>(
+            ProgressToken token,
+            IResponseRouter router,
+            ISerializer serializer,
+            IDisposable disposable)
+        {
+            return Observer.Create<T>(
+                value => router.SendProgress(token.Create(value, serializer.JsonSerializer)),
+                error => disposable.Dispose(),
+                disposable.Dispose);
+        }
+    }
+    public class ProgressObserver<T> : IDisposable, IObserver<T>
+    {
+        public static ProgressObserver<T> Noop { get; } =
+            new ProgressObserver<T>(new ProgressToken(Guid.Empty.ToString()),
+                Observer.Create<T>(x => { }));
+
+        private readonly IObserver<T> _currentObserver;
+
+        internal ProgressObserver(ProgressToken token, IObserver<T> observer)
+        {
+            _currentObserver = observer;
+            Token = token;
+        }
+
+        public ProgressToken Token { get; }
 
         public void Dispose()
         {
-            Result.OnCompleted();
+            _currentObserver.OnCompleted();
         }
 
         public void OnCompleted()
         {
-            Result.OnCompleted();
+            _currentObserver.OnCompleted();
         }
 
         public void OnError(Exception error)
         {
-            Result.OnError(error);
+            _currentObserver.OnError(error);
         }
 
         public void OnNext(T value)
         {
-            Result.OnNext(value);
+            _currentObserver.OnNext(value);
         }
     }
 }

--- a/src/Protocol/Window/Client/ILogMessageHandler.cs
+++ b/src/Protocol/Window/Client/ILogMessageHandler.cs
@@ -1,5 +1,11 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
 // ReSharper disable CheckNamespace
 
@@ -7,4 +13,31 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     [Parallel, Method(WindowNames.LogMessage)]
     public interface ILogMessageHandler : IJsonRpcNotificationHandler<LogMessageParams> { }
+
+    public abstract class LogMessageHandler : ILogMessageHandler
+    {
+        public abstract Task<Unit> Handle(LogMessageParams request, CancellationToken cancellationToken);
+    }
+
+    public static class LogMessageHandlerExtensions
+    {
+        public static IDisposable OnLogMessage(
+            this ILanguageServerRegistry registry,
+            Func<LogMessageParams, CancellationToken, Task<Unit>> handler)
+        {
+            return registry.AddHandlers(new DelegatingHandler(handler));
+        }
+
+        class DelegatingHandler : LogMessageHandler
+        {
+            private readonly Func<LogMessageParams, CancellationToken, Task<Unit>> _handler;
+
+            public DelegatingHandler(Func<LogMessageParams, CancellationToken, Task<Unit>> handler)
+            {
+                _handler = handler;
+            }
+
+            public override Task<Unit> Handle(LogMessageParams request, CancellationToken cancellationToken) => _handler.Invoke(request, cancellationToken);
+        }
+    }
 }

--- a/src/Protocol/Window/Client/IShowMessageHandler.cs
+++ b/src/Protocol/Window/Client/IShowMessageHandler.cs
@@ -1,5 +1,10 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
 // ReSharper disable CheckNamespace
 
@@ -7,4 +12,31 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     [Parallel, Method(WindowNames.ShowMessage)]
     public interface IShowMessageHandler : IJsonRpcNotificationHandler<ShowMessageParams> { }
+
+    public abstract class ShowMessageHandler : IShowMessageHandler
+    {
+        public abstract Task<Unit> Handle(ShowMessageParams request, CancellationToken cancellationToken);
+    }
+
+    public static class ShowMessageHandlerExtensions
+    {
+        public static IDisposable OnShowMessage(
+            this ILanguageServerRegistry registry,
+            Func<ShowMessageParams, CancellationToken, Task<Unit>> handler)
+        {
+            return registry.AddHandlers(new DelegatingHandler(handler));
+        }
+
+        class DelegatingHandler : ShowMessageHandler
+        {
+            private readonly Func<ShowMessageParams, CancellationToken, Task<Unit>> _handler;
+
+            public DelegatingHandler(Func<ShowMessageParams, CancellationToken, Task<Unit>> handler)
+            {
+                _handler = handler;
+            }
+
+            public override Task<Unit> Handle(ShowMessageParams request, CancellationToken cancellationToken) => _handler.Invoke(request, cancellationToken);
+        }
+    }
 }

--- a/src/Protocol/Window/Client/IShowMessageRequestHandler.cs
+++ b/src/Protocol/Window/Client/IShowMessageRequestHandler.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Threading;
 using System.Threading.Tasks;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
 // ReSharper disable CheckNamespace
 
@@ -8,4 +12,31 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     [Serial, Method(WindowNames.ShowMessageRequest)]
     public interface IShowMessageRequestHandler : IJsonRpcRequestHandler<ShowMessageRequestParams, MessageActionItem> { }
+
+    public abstract class ShowMessageRequestHandler : IShowMessageRequestHandler
+    {
+        public abstract Task<MessageActionItem> Handle(ShowMessageRequestParams request, CancellationToken cancellationToken);
+    }
+
+    public static class ShowMessageRequestHandlerExtensions
+    {
+        public static IDisposable OnShowMessageRequest(
+            this ILanguageServerRegistry registry,
+            Func<ShowMessageRequestParams, CancellationToken, Task<MessageActionItem>> handler)
+        {
+            return registry.AddHandlers(new DelegatingHandler(handler));
+        }
+
+        class DelegatingHandler : ShowMessageRequestHandler
+        {
+            private readonly Func<ShowMessageRequestParams, CancellationToken, Task<MessageActionItem>> _handler;
+
+            public DelegatingHandler(Func<ShowMessageRequestParams, CancellationToken, Task<MessageActionItem>> handler)
+            {
+                _handler = handler;
+            }
+
+            public override Task<MessageActionItem> Handle(ShowMessageRequestParams request, CancellationToken cancellationToken) => _handler.Invoke(request, cancellationToken);
+        }
+    }
 }

--- a/src/Protocol/Window/Client/ITelemetryEventHandler.cs
+++ b/src/Protocol/Window/Client/ITelemetryEventHandler.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
@@ -8,4 +12,31 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     [Parallel, Method(WindowNames.TelemetryEvent)]
     public interface ITelemetryEventHandler : IJsonRpcNotificationHandler<TelemetryEventParams> { }
+
+    public abstract class TelemetryEventHandler : ITelemetryEventHandler
+    {
+        public abstract Task<Unit> Handle(TelemetryEventParams request, CancellationToken cancellationToken);
+    }
+
+    public static class TelemetryEventHandlerExtensions
+    {
+        public static IDisposable OnTelemetryEvent(
+            this ILanguageServerRegistry registry,
+            Func<TelemetryEventParams, CancellationToken, Task<Unit>> handler)
+        {
+            return registry.AddHandlers(new DelegatingHandler(handler));
+        }
+
+        class DelegatingHandler : TelemetryEventHandler
+        {
+            private readonly Func<TelemetryEventParams, CancellationToken, Task<Unit>> _handler;
+
+            public DelegatingHandler(Func<TelemetryEventParams, CancellationToken, Task<Unit>> handler)
+            {
+                _handler = handler;
+            }
+
+            public override Task<Unit> Handle(TelemetryEventParams request, CancellationToken cancellationToken) => _handler.Invoke(request, cancellationToken);
+        }
+    }
 }

--- a/src/Protocol/Window/Client/TelemetryEventParams.cs
+++ b/src/Protocol/Window/Client/TelemetryEventParams.cs
@@ -3,11 +3,13 @@ using System.Threading.Tasks;
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.JsonRpc;
 
 // ReSharper disable CheckNamespace
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
+    [Method(WindowNames.TelemetryEvent)]
     public class TelemetryEventParams : IRequest
     {
         [JsonExtensionData]

--- a/src/Protocol/Window/Server/ShowMessageRequestExtensions.cs
+++ b/src/Protocol/Window/Server/ShowMessageRequestExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -8,19 +9,19 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server
 {
     public static class ShowMessageRequestExtensions
     {
-        public static Task<MessageActionItem> ShowMessage(this ILanguageServerWindow mediator, ShowMessageRequestParams @params)
+        public static Task<MessageActionItem> ShowMessage(this ILanguageServerWindow mediator, ShowMessageRequestParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<ShowMessageRequestParams, MessageActionItem>(WindowNames.ShowMessageRequest, @params);
+            return mediator.SendRequest<ShowMessageRequestParams, MessageActionItem>(WindowNames.ShowMessageRequest, @params, cancellationToken);
         }
 
-        public static Task<MessageActionItem> Show(this ILanguageServerWindow mediator, ShowMessageRequestParams @params)
+        public static Task<MessageActionItem> Show(this ILanguageServerWindow mediator, ShowMessageRequestParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.ShowMessage(@params);
+            return mediator.ShowMessage(@params, cancellationToken);
         }
 
-        public static Task<MessageActionItem> Request(this ILanguageServerWindow mediator, ShowMessageRequestParams @params)
+        public static Task<MessageActionItem> Request(this ILanguageServerWindow mediator, ShowMessageRequestParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.ShowMessage(@params);
+            return mediator.ShowMessage(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Window/Server/ShowMessageRequestExtensions.cs
+++ b/src/Protocol/Window/Server/ShowMessageRequestExtensions.cs
@@ -11,7 +11,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server
     {
         public static Task<MessageActionItem> ShowMessage(this ILanguageServerWindow mediator, ShowMessageRequestParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<ShowMessageRequestParams, MessageActionItem>(WindowNames.ShowMessageRequest, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
 
         public static Task<MessageActionItem> Show(this ILanguageServerWindow mediator, ShowMessageRequestParams @params, CancellationToken cancellationToken = default)

--- a/src/Protocol/Window/Server/WorkDoneProgressExtensions.cs
+++ b/src/Protocol/Window/Server/WorkDoneProgressExtensions.cs
@@ -10,7 +10,12 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server
     {
         public static async Task Create(this ILanguageServerWindowProgress mediator, WorkDoneProgressCreateParams @params, CancellationToken cancellationToken = default)
         {
-            await mediator.SendRequest(WindowNames.WorkDoneProgressCreate, @params, cancellationToken);
+            await mediator.SendRequest(@params, cancellationToken);
+        }
+
+        public static void Cancel(this ILanguageServerWindowProgress mediator, WorkDoneProgressCancelParams @params)
+        {
+            mediator.SendNotification(@params);
         }
     }
 }

--- a/src/Protocol/Window/Server/WorkDoneProgressExtensions.cs
+++ b/src/Protocol/Window/Server/WorkDoneProgressExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
@@ -7,9 +8,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server
 {
     public static class WorkDoneProgressExtensions
     {
-        public static async Task Create(this ILanguageServerWindowProgress mediator, WorkDoneProgressCreateParams @params)
+        public static async Task Create(this ILanguageServerWindowProgress mediator, WorkDoneProgressCreateParams @params, CancellationToken cancellationToken = default)
         {
-            await mediator.SendRequest(WindowNames.WorkDoneProgressCreate, @params);
+            await mediator.SendRequest(WindowNames.WorkDoneProgressCreate, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Workspace/Client/ExecuteCommandExtensions.cs
+++ b/src/Protocol/Workspace/Client/ExecuteCommandExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
@@ -6,9 +7,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class ExecuteCommandExtensions
     {
-        public static Task ExecuteCommand(this ILanguageClientWorkspace router, ExecuteCommandParams @params)
+        public static Task ExecuteCommand(this ILanguageClientWorkspace router, ExecuteCommandParams @params, CancellationToken cancellationToken = default)
         {
-            return router.SendRequest(WorkspaceNames.ExecuteCommand, @params);
+            return router.SendRequest(WorkspaceNames.ExecuteCommand, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Workspace/Client/WorkspaceSymbolsExtensions.cs
+++ b/src/Protocol/Workspace/Client/WorkspaceSymbolsExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
@@ -7,9 +8,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
 {
     public static class WorkspaceSymbolsExtensions
     {
-        public static Task<Container<SymbolInformation>> WorkspaceSymbol(this ILanguageClientWorkspace router, WorkspaceSymbolParams @params)
+        public static Task<Container<SymbolInformation>> WorkspaceSymbol(this ILanguageClientWorkspace router, WorkspaceSymbolParams @params, CancellationToken cancellationToken = default)
         {
-            return router.SendRequest<WorkspaceSymbolParams, Container<SymbolInformation>>(WorkspaceNames.WorkspaceSymbol, @params);
+            return router.SendRequest<WorkspaceSymbolParams, Container<SymbolInformation>>(WorkspaceNames.WorkspaceSymbol, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Workspace/Server/ApplyEditExtensions.cs
+++ b/src/Protocol/Workspace/Server/ApplyEditExtensions.cs
@@ -10,7 +10,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server
     {
         public static Task<ApplyWorkspaceEditResponse> ApplyEdit(this ILanguageServerWorkspace mediator, ApplyWorkspaceEditParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<ApplyWorkspaceEditParams, ApplyWorkspaceEditResponse>(WorkspaceNames.ApplyEdit, @params, cancellationToken);
+            return mediator.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Workspace/Server/ApplyEditExtensions.cs
+++ b/src/Protocol/Workspace/Server/ApplyEditExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
@@ -7,9 +8,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server
 {
     public static class ApplyEditExtensions
     {
-        public static Task<ApplyWorkspaceEditResponse> ApplyEdit(this ILanguageServerWorkspace mediator, ApplyWorkspaceEditParams @params)
+        public static Task<ApplyWorkspaceEditResponse> ApplyEdit(this ILanguageServerWorkspace mediator, ApplyWorkspaceEditParams @params, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<ApplyWorkspaceEditParams, ApplyWorkspaceEditResponse>(WorkspaceNames.ApplyEdit, @params);
+            return mediator.SendRequest<ApplyWorkspaceEditParams, ApplyWorkspaceEditResponse>(WorkspaceNames.ApplyEdit, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Workspace/Server/WorkspaceConfigurationExtensions.cs
+++ b/src/Protocol/Workspace/Server/WorkspaceConfigurationExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -7,9 +8,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server
 {
     public static class WorkspaceConfigurationExtensions
     {
-        public static Task<Container<JToken>> WorkspaceConfiguration(this ILanguageServerWorkspace router, ConfigurationParams @params)
+        public static Task<Container<JToken>> WorkspaceConfiguration(this ILanguageServerWorkspace router, ConfigurationParams @params, CancellationToken cancellationToken = default)
         {
-            return router.SendRequest<ConfigurationParams, Container<JToken>>(WorkspaceNames.WorkspaceConfiguration, @params);
+            return router.SendRequest<ConfigurationParams, Container<JToken>>(WorkspaceNames.WorkspaceConfiguration, @params, cancellationToken);
         }
     }
 }

--- a/src/Protocol/Workspace/Server/WorkspaceFoldersExtensions.cs
+++ b/src/Protocol/Workspace/Server/WorkspaceFoldersExtensions.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server
     {
         public static Task<Container<WorkspaceFolder>> WorkspaceFolders(this ILanguageServerWorkspace mediator, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<Container<WorkspaceFolder>>(WorkspaceNames.WorkspaceFolders, cancellationToken);
+            return mediator.SendRequest(new WorkspaceFolderParams(), cancellationToken);
         }
     }
 }

--- a/src/Protocol/Workspace/Server/WorkspaceFoldersExtensions.cs
+++ b/src/Protocol/Workspace/Server/WorkspaceFoldersExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System.Threading.Tasks;
@@ -9,9 +10,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server
     using static WorkspaceNames;
     public static class WorkspaceFoldersExtensions
     {
-        public static Task<Container<WorkspaceFolder>> WorkspaceFolders(this ILanguageServerWorkspace mediator)
+        public static Task<Container<WorkspaceFolder>> WorkspaceFolders(this ILanguageServerWorkspace mediator, CancellationToken cancellationToken = default)
         {
-            return mediator.SendRequest<Container<WorkspaceFolder>>(WorkspaceNames.WorkspaceFolders);
+            return mediator.SendRequest<Container<WorkspaceFolder>>(WorkspaceNames.WorkspaceFolders, cancellationToken);
         }
     }
 }

--- a/src/Server/Configuration/DidChangeConfigurationProvider.cs
+++ b/src/Server/Configuration/DidChangeConfigurationProvider.cs
@@ -55,7 +55,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Configuration
 
         public void SetCapability(DidChangeConfigurationCapability capability) => _capability = capability;
 
-        Task IOnStarted.OnStarted(ILanguageServer server, InitializeResult result) => GetWorkspaceConfiguration();
+        Task IOnStarted.OnStarted(ILanguageServer server, InitializeResult result, CancellationToken cancellationToken) => GetWorkspaceConfiguration();
 
         private async Task GetWorkspaceConfiguration()
         {

--- a/src/Server/InitializeDelegate.cs
+++ b/src/Server/InitializeDelegate.cs
@@ -1,13 +1,14 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace OmniSharp.Extensions.LanguageServer.Server
 {
-    public delegate Task InitializeDelegate(ILanguageServer server, InitializeParams request);
-    public delegate Task StartedDelegate(ILanguageServer server, InitializeResult result);
+    public delegate Task InitializeDelegate(ILanguageServer server, InitializeParams request, CancellationToken cancellationToken);
+    public delegate Task StartedDelegate(ILanguageServer server, InitializeResult result, CancellationToken cancellationToken);
 
     public interface IOnStarted
     {
-        Task OnStarted(ILanguageServer server, InitializeResult result);
+        Task OnStarted(ILanguageServer server, InitializeResult result, CancellationToken cancellationToken);
     }
 }

--- a/src/Server/InitializedDelegate.cs
+++ b/src/Server/InitializedDelegate.cs
@@ -1,7 +1,8 @@
+using System.Threading;
 using System.Threading.Tasks;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace OmniSharp.Extensions.LanguageServer.Server
 {
-    public delegate Task InitializedDelegate(ILanguageServer server, InitializeParams request, InitializeResult response);
+    public delegate Task InitializedDelegate(ILanguageServer server, InitializeParams request, InitializeResult response, CancellationToken cancellationToken);
 }

--- a/src/Server/LanguageServer.cs
+++ b/src/Server/LanguageServer.cs
@@ -638,9 +638,24 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             _responseRouter.SendNotification(method, @params);
         }
 
+        public void SendNotification(IRequest @params)
+        {
+            _responseRouter.SendNotification(@params);
+        }
+
         public Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken)
         {
             return _responseRouter.SendRequest<T, TResponse>(method, @params, cancellationToken);
+        }
+
+        public Task<TResponse> SendRequest<TResponse>(IRequest<TResponse> @params, CancellationToken cancellationToken)
+        {
+            return _responseRouter.SendRequest(@params, cancellationToken);
+        }
+
+        public Task SendRequest(IRequest @params, CancellationToken cancellationToken)
+        {
+            return _responseRouter.SendRequest(@params, cancellationToken);
         }
 
         public Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken)

--- a/src/Server/LanguageServer.cs
+++ b/src/Server/LanguageServer.cs
@@ -280,25 +280,25 @@ namespace OmniSharp.Extensions.LanguageServer.Server
         public IDisposable AddHandler(string method, IJsonRpcHandler handler)
         {
             var handlerDisposable = _collection.Add(method, handler);
-            return RegisterHandlers(handlerDisposable);
+            return RegisterHandlers(handlerDisposable, CancellationToken.None);
         }
 
         public IDisposable AddHandler(string method, Func<IServiceProvider, IJsonRpcHandler> handlerFunc)
         {
             var handlerDisposable = _collection.Add(method, handlerFunc);
-            return RegisterHandlers(handlerDisposable);
+            return RegisterHandlers(handlerDisposable, CancellationToken.None);
         }
 
         public IDisposable AddHandlers(params IJsonRpcHandler[] handlers)
         {
             var handlerDisposable = _collection.Add(handlers);
-            return RegisterHandlers(handlerDisposable);
+            return RegisterHandlers(handlerDisposable, CancellationToken.None);
         }
 
         public IDisposable AddHandler(string method, Type handlerType)
         {
             var handlerDisposable = _collection.Add(method, handlerType);
-            return RegisterHandlers(handlerDisposable);
+            return RegisterHandlers(handlerDisposable, CancellationToken.None);
         }
 
         public IDisposable AddHandler<T>()
@@ -310,7 +310,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
         public IDisposable AddHandlers(params Type[] handlerTypes)
         {
             var handlerDisposable = _collection.Add(_serviceProvider, handlerTypes);
-            return RegisterHandlers(handlerDisposable);
+            return RegisterHandlers(handlerDisposable, CancellationToken.None);
         }
 
         public IDisposable AddTextDocumentIdentifier(params ITextDocumentIdentifier[] handlers)
@@ -350,7 +350,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             {
                 await _initializeComplete
                     .Select(result => _startedDelegates.Select(@delegate =>
-                            Observable.FromAsync(() => @delegate(this, result))
+                            Observable.FromAsync(() => @delegate(this, result, token))
                         )
                         .ToObservable()
                         .Merge()
@@ -370,7 +370,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             }
         }
 
-        private IDisposable RegisterHandlers(LspHandlerDescriptorDisposable handlerDisposable)
+        private IDisposable RegisterHandlers(LspHandlerDescriptorDisposable handlerDisposable, CancellationToken token)
         {
             var registrations = new List<Registration>();
             foreach (var descriptor in handlerDisposable.Descriptors)
@@ -389,7 +389,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
                     // Fire and forget to initialize the handler
                     _initializeComplete
                         .Select(result =>
-                            Observable.FromAsync(() => descriptor.StartedDelegate(this, result)))
+                            Observable.FromAsync(() => descriptor.StartedDelegate(this, result, token)))
                         .Merge()
                         .Subscribe();
                 }
@@ -464,7 +464,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             var windowCapabilities = ClientSettings.Capabilities.Window ??= new WindowClientCapabilities();
             _progressManager.Initialized(_responseRouter, _serializer, windowCapabilities);
 
-            await Task.WhenAll(_initializeDelegates.Select(c => c(this, request)));
+            await Task.WhenAll(_initializeDelegates.Select(c => c(this, request, token)));
 
             var ccp = new ClientCapabilityProvider(_collection, windowCapabilities.WorkDoneProgress);
 
@@ -578,7 +578,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
                 }
             };
 
-            await Task.WhenAll(_initializedDelegates.Select(c => c(this, request, result)));
+            await Task.WhenAll(_initializedDelegates.Select(c => c(this, request, result, token)));
 
             foreach (var item in _collection)
             {
@@ -638,19 +638,19 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             _responseRouter.SendNotification(method, @params);
         }
 
-        public Task<TResponse> SendRequest<T, TResponse>(string method, T @params)
+        public Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken)
         {
-            return _responseRouter.SendRequest<T, TResponse>(method, @params);
+            return _responseRouter.SendRequest<T, TResponse>(method, @params, cancellationToken);
         }
 
-        public Task<TResponse> SendRequest<TResponse>(string method)
+        public Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken)
         {
-            return _responseRouter.SendRequest<TResponse>(method);
+            return _responseRouter.SendRequest<TResponse>(method, cancellationToken);
         }
 
-        public Task SendRequest<T>(string method, T @params)
+        public Task SendRequest<T>(string method, T @params, CancellationToken cancellationToken)
         {
-            return _responseRouter.SendRequest(method, @params);
+            return _responseRouter.SendRequest(method, @params, cancellationToken);
         }
 
         public TaskCompletionSource<JToken> GetRequest(long id)

--- a/test/JsonRpc.Tests/DapInputHandlerTests.cs
+++ b/test/JsonRpc.Tests/DapInputHandlerTests.cs
@@ -154,13 +154,13 @@ namespace JsonRpc.Tests
                 incomingRequestRouter,
                 Substitute.For<IResponseRouter>(),
                 cts => {
-                    outputHandler.When(x => x.Send(Arg.Any<object>()))
+                    outputHandler.When(x => x.Send(Arg.Any<object>(), Arg.Any<CancellationToken>()))
                         .Do(x => {
                             cts.Cancel();
                         });
                 }))
             {
-                outputHandler.Received().Send(Arg.Is<object>(x => x == response));
+                outputHandler.Received().Send(Arg.Is<object>(x => x == response), Arg.Any<CancellationToken>());
             }
         }
 
@@ -186,13 +186,13 @@ namespace JsonRpc.Tests
                 incomingRequestRouter,
                 Substitute.For<IResponseRouter>(),
                 cts => {
-                    outputHandler.When(x => x.Send(Arg.Any<object>()))
+                    outputHandler.When(x => x.Send(Arg.Any<object>(), Arg.Any<CancellationToken>()))
                         .Do(x => {
                             cts.Cancel();
                         });
                 }))
             {
-                outputHandler.Received().Send(Arg.Is<object>(x => x == error));
+                outputHandler.Received().Send(Arg.Is<object>(x => x == error), Arg.Any<CancellationToken>());
             }
         }
 

--- a/test/JsonRpc.Tests/DapOutputHandlerTests.cs
+++ b/test/JsonRpc.Tests/DapOutputHandlerTests.cs
@@ -53,7 +53,7 @@ namespace JsonRpc.Tests
             using (handler)
             {
 
-                handler.Send(value);
+                handler.Send(value, CancellationToken.None);
                 await wait();
                 const string send = "Content-Length: 88\r\n\r\n{\"seq\":1,\"type\":\"response\",\"request_seq\":1,\"success\":true,\"command\":\"command\",\"body\":{}}";
                 received.Should().Be(send);
@@ -84,7 +84,7 @@ namespace JsonRpc.Tests
             using (handler)
             {
 
-                handler.Send(value);
+                handler.Send(value, CancellationToken.None);
                 await wait();
                 const string send = "Content-Length: 51\r\n\r\n{\"seq\":1,\"type\":\"event\",\"event\":\"method\",\"body\":{}}";
                 received.Should().Be(send);
@@ -116,7 +116,7 @@ namespace JsonRpc.Tests
             using (handler)
             {
 
-                handler.Send(value);
+                handler.Send(value, CancellationToken.None);
                 await wait();
                 const string send = "Content-Length: 60\r\n\r\n{\"seq\":1,\"type\":\"request\",\"command\":\"method\",\"arguments\":{}}";
                 received.Should().Be(send);
@@ -144,7 +144,7 @@ namespace JsonRpc.Tests
             using (handler)
             {
 
-                handler.Send(value);
+                handler.Send(value, CancellationToken.None);
                 await wait();
                 const string send = "Content-Length: 76\r\n\r\n{\"seq\":1,\"type\":\"response\",\"request_seq\":1,\"success\":false,\"message\":\"data\"}";
                 received.Should().Be(send);

--- a/test/JsonRpc.Tests/InputHandlerTests.cs
+++ b/test/JsonRpc.Tests/InputHandlerTests.cs
@@ -156,13 +156,13 @@ namespace JsonRpc.Tests
                 incomingRequestRouter,
                 Substitute.For<IResponseRouter>(),
                 cts => {
-                    outputHandler.When(x => x.Send(Arg.Any<object>()))
+                    outputHandler.When(x => x.Send(Arg.Any<object>(), Arg.Any<CancellationToken>()))
                         .Do(x => {
                             cts.Cancel();
                         });
                 }))
             {
-                outputHandler.Received().Send(Arg.Is<object>(x => x == response));
+                outputHandler.Received().Send(Arg.Is<object>(x => x == response), Arg.Any<CancellationToken>());
             }
         }
 
@@ -188,13 +188,13 @@ namespace JsonRpc.Tests
                 incomingRequestRouter,
                 Substitute.For<IResponseRouter>(),
                 cts => {
-                    outputHandler.When(x => x.Send(Arg.Any<object>()))
+                    outputHandler.When(x => x.Send(Arg.Any<object>(), Arg.Any<CancellationToken>()))
                         .Do(x => {
                             cts.Cancel();
                         });
                 }))
             {
-                outputHandler.Received().Send(Arg.Is<object>(x => x == error));
+                outputHandler.Received().Send(Arg.Is<object>(x => x == error), Arg.Any<CancellationToken>());
             }
         }
 
@@ -300,7 +300,7 @@ namespace JsonRpc.Tests
                 incomingRequestRouter,
                 Substitute.For<IResponseRouter>(),
                 cts => {
-                    outputHandler.When(x => x.Send(Arg.Any<object>()))
+                    outputHandler.When(x => x.Send(Arg.Any<object>(), Arg.Any<CancellationToken>()))
                         .Do(x => {
                             cts.Cancel();
                         });

--- a/test/JsonRpc.Tests/OutputHandlerTests.cs
+++ b/test/JsonRpc.Tests/OutputHandlerTests.cs
@@ -51,7 +51,7 @@ namespace JsonRpc.Tests
             using (handler)
             {
 
-                handler.Send(value);
+                handler.Send(value, CancellationToken.None);
                 await wait();
                 const string send = "Content-Length: 35\r\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":1}";
                 received.Should().Be(send);
@@ -83,7 +83,7 @@ namespace JsonRpc.Tests
             using (handler)
             {
 
-                handler.Send(value);
+                handler.Send(value, CancellationToken.None);
                 await wait();
                 const string send = "Content-Length: 47\r\n\r\n{\"jsonrpc\":\"2.0\",\"method\":\"method\",\"params\":{}}";
                 received.Should().Be(send);
@@ -115,7 +115,7 @@ namespace JsonRpc.Tests
             using (handler)
             {
 
-                handler.Send(value);
+                handler.Send(value, CancellationToken.None);
                 await wait();
                 const string send = "Content-Length: 54\r\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"method\",\"params\":{}}";
                 received.Should().Be(send);
@@ -143,7 +143,7 @@ namespace JsonRpc.Tests
             using (handler)
             {
 
-                handler.Send(value);
+                handler.Send(value, CancellationToken.None);
                 await wait();
                 const string send = "Content-Length: 75\r\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":1,\"data\":{},\"message\":\"something\"}}";
                 received.Should().Be(send);

--- a/test/JsonRpc.Tests/ResponseRouterTests.cs
+++ b/test/JsonRpc.Tests/ResponseRouterTests.cs
@@ -1,0 +1,94 @@
+﻿using System.Linq;
+using System.Reactive;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MediatR;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.JsonRpc.Client;
+using OmniSharp.Extensions.JsonRpc.Serialization;
+using Xunit;
+using Notification = OmniSharp.Extensions.JsonRpc.Client.Notification;
+using Unit = MediatR.Unit;
+
+namespace Lsp.Tests
+{
+    public class ResponseRouterTests
+    {
+        [Fact]
+        public async Task WorksWithResultType()
+        {
+            var outputHandler = Substitute.For<IOutputHandler>();
+            var router = new ResponseRouter(outputHandler, new JsonRpcSerializer());
+
+            outputHandler
+                .When(x => x.Send(Arg.Is<object>(x => x.GetType() == typeof(Request)), Arg.Any<CancellationToken>()))
+                .Do(call =>
+                {
+                    var tcs = router.GetRequest((long) call.Arg<Request>().Id);
+                    tcs.SetResult(new JObject());
+                });
+
+            var response = await router.SendRequest(new ItemParams(), CancellationToken.None);
+
+            var request = outputHandler.ReceivedCalls().Single().GetArguments()[0] as Request;
+            request.Method.Should().Be("abcd");
+
+            response.Should().NotBeNull();
+            response.Should().BeOfType<ItemResult>();
+        }
+
+        [Fact]
+        public async Task WorksWithUnitType()
+        {
+            var outputHandler = Substitute.For<IOutputHandler>();
+            var router = new ResponseRouter(outputHandler, new JsonRpcSerializer());
+
+            outputHandler
+                .When(x => x.Send(Arg.Is<object>(x => x.GetType() == typeof(Request)), Arg.Any<CancellationToken>()))
+                .Do(call =>
+                {
+                    var tcs = router.GetRequest((long) call.Arg<Request>().Id);
+                    tcs.SetResult(new JObject());
+                });
+
+            await router.SendRequest(new UnitParams(), CancellationToken.None);
+
+            var request = outputHandler.ReceivedCalls().Single().GetArguments()[0] as Request;
+            request.Method.Should().Be("unit");
+        }
+
+        [Fact]
+        public async Task WorksWithNotification()
+        {
+            var outputHandler = Substitute.For<IOutputHandler>();
+            var router = new ResponseRouter(outputHandler, new JsonRpcSerializer());
+
+            router.SendNotification(new NotificationParams());
+
+            var request = outputHandler.ReceivedCalls().Single().GetArguments()[0] as Notification;
+            request.Method.Should().Be("notification");
+        }
+
+        [Method("abcd")]
+        public class ItemParams : IRequest<ItemResult>
+        {
+        }
+
+        public class ItemResult
+        {
+        }
+
+        [Method("unit")]
+        public class UnitParams : IRequest
+        {
+        }
+
+        [Method("notification")]
+        public class NotificationParams : IRequest
+        {
+        }
+    }
+}

--- a/test/Lsp.Tests/LanguageServerTests.cs
+++ b/test/Lsp.Tests/LanguageServerTests.cs
@@ -79,7 +79,7 @@ namespace Lsp.Tests
         {
             var startupInterface = Substitute.For(new [] {typeof(IOnStarted), typeof(IDidChangeConfigurationHandler) }, Array.Empty<object>()) as IOnStarted;
             var startedDelegate = Substitute.For<StartedDelegate>();
-            startedDelegate(Arg.Any<ILanguageServer>(), Arg.Any<InitializeResult>()).Returns(Task.CompletedTask);
+            startedDelegate(Arg.Any<ILanguageServer>(), Arg.Any<InitializeResult>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
             var process = new NamedPipeServerProcess(Guid.NewGuid().ToString("N"), LoggerFactory);
             await process.Start();
             var client = new LanguageClient(LoggerFactory, process);
@@ -106,8 +106,8 @@ namespace Lsp.Tests
             );
             using var server = await serverStart;
 
-            _ = startedDelegate.Received(4)(Arg.Any<ILanguageServer>(), Arg.Any<InitializeResult>());
-            _ = startupInterface.Received(1).OnStarted(Arg.Any<ILanguageServer>(), Arg.Any<InitializeResult>());
+            _ = startedDelegate.Received(4)(Arg.Any<ILanguageServer>(), Arg.Any<InitializeResult>(), Arg.Any<CancellationToken>());
+            _ = startupInterface.Received(1).OnStarted(Arg.Any<ILanguageServer>(), Arg.Any<InitializeResult>(), Arg.Any<CancellationToken>());
         }
     }
 }

--- a/test/Lsp.Tests/WorkspaceSymbolKindTests.cs
+++ b/test/Lsp.Tests/WorkspaceSymbolKindTests.cs
@@ -1,8 +1,15 @@
+using System;
+using System.Linq;
+using System.Reflection;
 using FluentAssertions;
+using MediatR;
+using NSubstitute;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using Xunit;
 
 namespace Lsp.Tests
@@ -47,6 +54,81 @@ namespace Lsp.Tests
 
             var result = serializer.DeserializeObject<SymbolInformation>(json);
             result.Kind.Should().Be(SymbolKind.Class);
+        }
+    }
+
+    public class FoundationTests
+    {
+        [Theory(DisplayName = "Params types should have a method attribute")]
+        [ClassData(typeof(ParamsShouldHaveMethodAttributeData))]
+        public void ParamsShouldHaveMethodAttribute(Type type)
+        {
+            type.GetCustomAttributes<MethodAttribute>().Any().Should()
+                .Be(true, $"{type.Name} is missing a method attribute");
+        }
+
+        [Theory(DisplayName = "Handler interfaces should have a method attribute")]
+        [ClassData(typeof(HandlersShouldHaveMethodAttributeData))]
+        public void HandlersShouldHaveMethodAttribute(Type type)
+        {
+            type.GetCustomAttributes<MethodAttribute>().Any().Should()
+                .Be(true, $"{type.Name} is missing a method attribute");
+        }
+
+        [Theory(DisplayName = "Handler interfaces should have a method attribute")]
+        [ClassData(typeof(HandlersShouldAbstractClassData))]
+        public void HandlersShouldAbstractClass(Type type)
+        {
+            var types = type.Assembly.ExportedTypes;
+            var abstractHandler = type.Assembly.ExportedTypes
+                .FirstOrDefault(z => z.IsAbstract && z.IsClass && type.IsAssignableFrom(z));
+            abstractHandler.Should().NotBeNull($"{type.Name} is missing abstract base class");
+            var delegatingHandler = type.Assembly.DefinedTypes.FirstOrDefault(z => abstractHandler.IsAssignableFrom(z) && abstractHandler != z);
+            delegatingHandler.Should().NotBeNull($"{type.Name} is missing delegating handler class");
+            delegatingHandler.DeclaringType.Should().NotBeNull();
+            delegatingHandler.DeclaringType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Any(z => z.Name.StartsWith("On"))
+                .Should().BeTrue($"{type.Name} is missing delegating extension method");
+        }
+
+        public class ParamsShouldHaveMethodAttributeData : TheoryData<Type>
+        {
+            public ParamsShouldHaveMethodAttributeData()
+            {
+                foreach (var type in typeof(CompletionParams).Assembly.ExportedTypes
+                    .Where(z => z.IsClass && !z.IsAbstract && z.GetInterfaces().Any(z =>
+                        z.IsGenericType &&
+                        typeof(IRequest<>).IsAssignableFrom(z.GetGenericTypeDefinition()))))
+                {
+                    Add(type);
+                }
+            }
+        }
+
+        public class HandlersShouldHaveMethodAttributeData : TheoryData<Type>
+        {
+            public HandlersShouldHaveMethodAttributeData()
+            {
+                foreach (var type in typeof(CompletionParams).Assembly.ExportedTypes
+                    .Where(z => z.IsInterface && typeof(IJsonRpcHandler).IsAssignableFrom(z) && !z.IsGenericType)
+                    .Except(new[] {typeof(ITextDocumentSyncHandler)}))
+                {
+                    Add(type);
+                }
+            }
+        }
+
+        public class HandlersShouldAbstractClassData : TheoryData<Type>
+        {
+            public HandlersShouldAbstractClassData()
+            {
+                foreach (var type in typeof(CompletionParams).Assembly.ExportedTypes
+                    .Where(z => z.IsInterface && typeof(IJsonRpcHandler).IsAssignableFrom(z) && !z.IsGenericType)
+                    .Except(new[] {typeof(ITextDocumentSyncHandler)}))
+                {
+                    Add(type);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
In addition this adds support for using `SendRequest` with a params object directly and the return type will be infered mediatr style by using the `T` in `IRequest<T>`