### PR TITLE
Add SendEmptyRequest Method for shutdown request

### DIFF
--- a/src/Client/LanguageClient.cs
+++ b/src/Client/LanguageClient.cs
@@ -300,7 +300,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client
             {
                 if (connection.IsOpen)
                 {
-                    connection.SendEmptyNotification("shutdown");
+                    await connection.SendEmptyRequest("shutdown");
                     connection.SendEmptyNotification("exit");
                     connection.Disconnect(flushOutgoing: true);
                 }

--- a/src/Client/Protocol/LspConnection.cs
+++ b/src/Client/Protocol/LspConnection.cs
@@ -353,6 +353,17 @@ namespace OmniSharp.Extensions.LanguageServer.Client.Protocol
         }
 
         /// <summary>
+        ///     Send an empty request to the language server.
+        /// </summary>
+        /// <param name="method">
+        ///     The request method name.
+        /// </param>
+        public Task SendEmptyRequest(string method)
+        {
+            return SendRequest(method, EmptyRequest.Instance);
+        }
+
+        /// <summary>
         ///     Send a request to the language server.
         /// </summary>
         /// <param name="method">


### PR DESCRIPTION
The LanguageClient sends a Shutdown notification. But the LanguageServer expects a request (as per spec), causing a server-side deserialization error.