### PR TITLE
Refactored IResponseRouter for better type inference

### DIFF
--- a/src/JsonRpc/IResponseRouter.cs
+++ b/src/JsonRpc/IResponseRouter.cs
@@ -9,12 +9,10 @@ namespace OmniSharp.Extensions.JsonRpc
     {
         void SendNotification(string method);
         void SendNotification<T>(string method, T @params);
-        void SendNotification(IRequest @params);
-        Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken);
-        Task<TResponse> SendRequest<TResponse>(IRequest<TResponse> @params, CancellationToken cancellationToken);
-        Task SendRequest(IRequest @params, CancellationToken cancellationToken);
-        Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken);
-        Task SendRequest<T>(string method, T @params, CancellationToken cancellationToken);
+        void SendNotification(IRequest request);
+        IResponseRouterReturns SendRequest<T>(string method, T @params);
+        IResponseRouterReturns SendRequest(string method);
+        Task<TResponse> SendRequest<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken);
         TaskCompletionSource<JToken> GetRequest(long id);
     }
 }

--- a/src/JsonRpc/IReturning.cs
+++ b/src/JsonRpc/IReturning.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace OmniSharp.Extensions.JsonRpc
+{
+    public interface IResponseRouterReturns
+    {
+        Task<TResponse> Returning<TResponse>(CancellationToken cancellationToken);
+        Task ReturningVoid(CancellationToken cancellationToken);
+    }
+}

--- a/src/JsonRpc/JsonRpcServer.cs
+++ b/src/JsonRpc/JsonRpcServer.cs
@@ -197,29 +197,19 @@ namespace OmniSharp.Extensions.JsonRpc
             _responseRouter.SendNotification(@params);
         }
 
-        public Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken)
-        {
-            return _responseRouter.SendRequest<T, TResponse>(method, @params, cancellationToken);
-        }
-
         public Task<TResponse> SendRequest<TResponse>(IRequest<TResponse> @params, CancellationToken cancellationToken)
         {
             return _responseRouter.SendRequest(@params, cancellationToken);
         }
 
-        public Task SendRequest(IRequest @params, CancellationToken cancellationToken)
+        public IResponseRouterReturns SendRequest<T>(string method, T @params)
         {
-            return _responseRouter.SendRequest(@params, cancellationToken);
+            return _responseRouter.SendRequest<T>(method, @params);
         }
 
-        public Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken)
+        public IResponseRouterReturns SendRequest(string method)
         {
-            return _responseRouter.SendRequest<TResponse>(method, cancellationToken);
-        }
-
-        public Task SendRequest<T>(string method, T @params, CancellationToken cancellationToken)
-        {
-            return _responseRouter.SendRequest(method, @params, cancellationToken);
+            return _responseRouter.SendRequest(method);
         }
 
         public TaskCompletionSource<JToken> GetRequest(long id)

--- a/src/JsonRpc/ResponseRouter.cs
+++ b/src/JsonRpc/ResponseRouter.cs
@@ -10,28 +10,31 @@ namespace OmniSharp.Extensions.JsonRpc
 {
     public class ResponseRouter : IResponseRouter
     {
-        private readonly IOutputHandler _outputHandler;
-        private readonly ISerializer _serializer;
-        private readonly object _lock = new object();
-        private readonly ConcurrentDictionary<long, TaskCompletionSource<JToken>> _requests = new ConcurrentDictionary<long, TaskCompletionSource<JToken>>();
-        private static readonly ConcurrentDictionary<Type, string> _methodCache = new ConcurrentDictionary<Type, string>();
+        internal readonly IOutputHandler OutputHandler;
+        internal readonly ISerializer Serializer;
+
+        internal readonly ConcurrentDictionary<long, TaskCompletionSource<JToken>> Requests =
+            new ConcurrentDictionary<long, TaskCompletionSource<JToken>>();
+
+        internal static readonly ConcurrentDictionary<Type, string> MethodCache =
+            new ConcurrentDictionary<Type, string>();
 
         public ResponseRouter(IOutputHandler outputHandler, ISerializer serializer)
         {
-            _outputHandler = outputHandler;
-            _serializer = serializer;
+            OutputHandler = outputHandler;
+            Serializer = serializer;
         }
 
         public void SendNotification(string method)
         {
-            _outputHandler.Send(new Client.Notification() {
+            OutputHandler.Send(new Client.Notification() {
                 Method = method
             }, CancellationToken.None);
         }
 
         public void SendNotification<T>(string method, T @params)
         {
-            _outputHandler.Send(new Client.Notification() {
+            OutputHandler.Send(new Client.Notification() {
                 Method = method,
                 Params = @params
             }, CancellationToken.None);
@@ -42,100 +45,30 @@ namespace OmniSharp.Extensions.JsonRpc
             SendNotification(GetMethodName(@params.GetType()), @params);
         }
 
-        public async Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken)
-        {
-            var tcs = new TaskCompletionSource<JToken>();
-
-            var nextId = _serializer.GetNextId();
-            _requests.TryAdd(nextId, tcs);
-
-            _outputHandler.Send(new Client.Request() {
-                Method = method,
-                Params = @params,
-                Id = nextId
-            }, cancellationToken);
-
-            try
-            {
-                var result = await tcs.Task;
-                if (typeof(TResponse) == typeof(Unit))
-                {
-                    return (TResponse)(object)Unit.Value;
-                }
-                return result.ToObject<TResponse>(_serializer.JsonSerializer);
-            }
-            finally
-            {
-                _requests.TryRemove(nextId, out _);
-            }
-        }
-
         public Task<TResponse> SendRequest<TResponse>(IRequest<TResponse> @params, CancellationToken cancellationToken)
         {
-            return SendRequest<IRequest<TResponse>, TResponse>(GetMethodName(@params.GetType()), @params, cancellationToken);
+            return SendRequest(GetMethodName(@params.GetType()), @params).Returning<TResponse>(cancellationToken);
         }
 
-        public Task SendRequest(IRequest @params, CancellationToken cancellationToken)
+        public IResponseRouterReturns SendRequest(string method)
         {
-            return SendRequest(GetMethodName(@params.GetType()), @params, cancellationToken);
+            return new ResponseRouterReturnsImpl(this, method, null);
         }
 
-        public async Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken)
+        public IResponseRouterReturns SendRequest<T>(string method, T @params)
         {
-            var nextId = _serializer.GetNextId();
-
-            var tcs = new TaskCompletionSource<JToken>();
-            _requests.TryAdd(nextId, tcs);
-
-            _outputHandler.Send(new Client.Request() {
-                Method = method,
-                Params = null,
-                Id = nextId
-            }, cancellationToken);
-
-            try
-            {
-                var result = await tcs.Task;
-                return result.ToObject<TResponse>(_serializer.JsonSerializer);
-            }
-            finally
-            {
-                _requests.TryRemove(nextId, out var _);
-            }
-        }
-
-        public async Task SendRequest<T>(string method, T @params, CancellationToken cancellationToken)
-        {
-            var nextId = _serializer.GetNextId();
-
-            var tcs = new TaskCompletionSource<JToken>();
-            _requests.TryAdd(nextId, tcs);
-
-            _outputHandler.Send(new Client.Request() {
-                Method = method,
-                Params = @params,
-                Id = nextId
-            }, cancellationToken);
-
-            try
-            {
-                await tcs.Task;
-            }
-            finally
-            {
-                _requests.TryRemove(nextId, out var _);
-            }
+            return new ResponseRouterReturnsImpl(this, method, @params);
         }
 
         public TaskCompletionSource<JToken> GetRequest(long id)
         {
-            _requests.TryGetValue(id, out var source);
+            Requests.TryGetValue(id, out var source);
             return source;
         }
 
         private string GetMethodName(Type type)
         {
-            if (!_methodCache.TryGetValue(type, out var methodName))
+            if (!MethodCache.TryGetValue(type, out var methodName))
             {
                 var attribute = type.GetCustomAttribute<MethodAttribute>(true);
                 if (attribute == null)
@@ -144,10 +77,57 @@ namespace OmniSharp.Extensions.JsonRpc
                 }
 
                 methodName = attribute.Method;
-                _methodCache.TryAdd(type, methodName);
+                MethodCache.TryAdd(type, methodName);
             }
 
             return methodName;
+        }
+
+        class ResponseRouterReturnsImpl : IResponseRouterReturns
+        {
+            private readonly ResponseRouter _router;
+            private readonly string _method;
+            private readonly object _params;
+
+            public ResponseRouterReturnsImpl(ResponseRouter router, string method, object @params)
+            {
+                _router = router;
+                _method = method;
+                _params = @params;
+            }
+
+            public async Task<TResponse> Returning<TResponse>(CancellationToken cancellationToken)
+            {
+                var nextId = _router.Serializer.GetNextId();
+                var tcs = new TaskCompletionSource<JToken>();
+                _router.Requests.TryAdd(nextId, tcs);
+
+                _router.OutputHandler.Send(new Client.Request() {
+                    Method = _method,
+                    Params = _params,
+                    Id = nextId
+                }, cancellationToken);
+
+                try
+                {
+                    var result = await tcs.Task;
+                    if (typeof(TResponse) == typeof(Unit))
+                    {
+                        return (TResponse) (object) Unit.Value;
+                    }
+
+                    return result.ToObject<TResponse>(_router.Serializer.JsonSerializer);
+                }
+                finally
+                {
+                    _router.Requests.TryRemove(nextId, out var _);
+                }
+            }
+
+            public async Task ReturningVoid(CancellationToken cancellationToken)
+            {
+                await Returning<Unit>(cancellationToken);
+            }
         }
     }
 }

--- a/src/Protocol/ClientProxyBase.cs
+++ b/src/Protocol/ClientProxyBase.cs
@@ -17,18 +17,14 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         public void SendNotification(string method) => _responseRouter.SendNotification(method);
 
         public void SendNotification<T>(string method, T @params) => _responseRouter.SendNotification(method, @params);
-        public void SendNotification(IRequest @params) => _responseRouter.SendNotification(@params);
 
-        public Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken) => _responseRouter.SendRequest<T, TResponse>(method, @params, cancellationToken);
-        public Task<TResponse> SendRequest<TResponse>(IRequest<TResponse> @params, CancellationToken cancellationToken) => _responseRouter.SendRequest(@params, cancellationToken);
-        public Task SendRequest(IRequest @params, CancellationToken cancellationToken)
-        {
-            return _responseRouter.SendRequest(@params, cancellationToken);
-        }
+        public void SendNotification(IRequest request) => _responseRouter.SendNotification(request);
 
-        public Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken) => _responseRouter.SendRequest<TResponse>(method, cancellationToken);
+        public IResponseRouterReturns SendRequest<T>(string method, T @params) => _responseRouter.SendRequest(method, @params);
 
-        public Task SendRequest<T>(string method, T @params, CancellationToken cancellationToken ) => _responseRouter.SendRequest(method, @params, cancellationToken);
+        public IResponseRouterReturns SendRequest(string method) => _responseRouter.SendRequest(method);
+
+        public Task<TResponse> SendRequest<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken) => _responseRouter.SendRequest(request, cancellationToken);
 
         public TaskCompletionSource<JToken> GetRequest(long id) => _responseRouter.GetRequest(id);
     }

--- a/src/Protocol/Workspace/Client/ExecuteCommandExtensions.cs
+++ b/src/Protocol/Workspace/Client/ExecuteCommandExtensions.cs
@@ -9,7 +9,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client
     {
         public static Task ExecuteCommand(this ILanguageClientWorkspace router, ExecuteCommandParams @params, CancellationToken cancellationToken = default)
         {
-            return router.SendRequest(WorkspaceNames.ExecuteCommand, @params, cancellationToken);
+            return router.SendRequest(@params, cancellationToken);
         }
     }
 }

--- a/src/Server/LanguageServer.cs
+++ b/src/Server/LanguageServer.cs
@@ -665,29 +665,19 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             _responseRouter.SendNotification(@params);
         }
 
-        public Task<TResponse> SendRequest<T, TResponse>(string method, T @params, CancellationToken cancellationToken)
+        public IResponseRouterReturns SendRequest(string method)
         {
-            return _responseRouter.SendRequest<T, TResponse>(method, @params, cancellationToken);
+            return _responseRouter.SendRequest(method);
+        }
+
+        public IResponseRouterReturns SendRequest<T>(string method, T @params)
+        {
+            return _responseRouter.SendRequest<T>(method, @params);
         }
 
         public Task<TResponse> SendRequest<TResponse>(IRequest<TResponse> @params, CancellationToken cancellationToken)
         {
             return _responseRouter.SendRequest(@params, cancellationToken);
-        }
-
-        public Task SendRequest(IRequest @params, CancellationToken cancellationToken)
-        {
-            return _responseRouter.SendRequest(@params, cancellationToken);
-        }
-
-        public Task<TResponse> SendRequest<TResponse>(string method, CancellationToken cancellationToken)
-        {
-            return _responseRouter.SendRequest<TResponse>(method, cancellationToken);
-        }
-
-        public Task SendRequest<T>(string method, T @params, CancellationToken cancellationToken)
-        {
-            return _responseRouter.SendRequest(method, @params, cancellationToken);
         }
 
         public TaskCompletionSource<JToken> GetRequest(long id)


### PR DESCRIPTION
This is a quick change related `IResponseRouter`.

Currently if you have a params object and a response object you always have to define the type of both to call `SendRequest`.  This new pattern returns an object lets you define the return type of the request, so it's a little easier to do `SendRequest("somemethod", someParams).Returning<ReturnType>(cancellationToken)`