### PR TITLE
Fix FoldingRangeKind serialization to be string

### DIFF
--- a/src/Protocol/Models/FoldingRangeKind.cs
+++ b/src/Protocol/Models/FoldingRangeKind.cs
@@ -1,10 +1,13 @@
 using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
     /// <summary>
     /// Enum of known range kinds
     /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum FoldingRangeKind
     {
         /// <summary>

--- a/test/Lsp.Tests/Models/FoldingRangeKindTests.cs
+++ b/test/Lsp.Tests/Models/FoldingRangeKindTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
+using Xunit;
+
+namespace Lsp.Tests
+{
+    public class FoldingRangeKindTests
+    {
+        [Fact]
+        public void CommentTest()
+        {
+            var serializer = new Serializer();
+            var json = serializer.SerializeObject(FoldingRangeKind.Comment);
+            json.Should().Be("\"comment\"");
+        }
+
+        [Fact]
+        public void ImportsTest()
+        {
+            var serializer = new Serializer();
+            var json = serializer.SerializeObject(FoldingRangeKind.Imports);
+            json.Should().Be("\"imports\"");
+        }
+
+        [Fact]
+        public void RegionTest()
+        {
+            var serializer = new Serializer();
+            var json = serializer.SerializeObject(FoldingRangeKind.Region);
+            json.Should().Be("\"region\"");
+        }
+    }
+}


### PR DESCRIPTION
This just needed the `[JsonConverter(typeof(StringEnumConverter))]`.

This should fix https://github.com/PowerShell/vscode-powershell/issues/2700