### PR TITLE
misc changes for DocumentUri

### DIFF
--- a/src/Protocol/DocumentUri.Internal.cs
+++ b/src/Protocol/DocumentUri.Internal.cs
@@ -261,7 +261,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             if (!string.IsNullOrWhiteSpace(uri.Authority) && uri.Path.Length > 1 && uri.Scheme == "file")
             {
                 // unc path: file://shares/c$/far/boo
-                value = $"//{uri.Authority}{uri.Path}";
+                value = $@"\\{uri.Authority}{uri.Path}";
             }
             else if (
                 uri.Path.Length >= 3

--- a/src/Protocol/DocumentUri.cs
+++ b/src/Protocol/DocumentUri.cs
@@ -233,7 +233,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         /// <returns></returns>
         public static DocumentUri From(Uri uri)
         {
-            if (uri.OriginalString.IndexOf("%3A", StringComparison.OrdinalIgnoreCase) > -1)
+            if (uri.OriginalString.IndexOf(EncodeTable[CharCode.Colon], StringComparison.OrdinalIgnoreCase) > -1)
                 return From(uri.OriginalString);
             if (uri.Scheme == Uri.UriSchemeFile)
             {
@@ -402,7 +402,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             // normalize to fwd-slashes on windows,
             // on other systems bwd-slashes are valid
             // filename character, eg /f\oo/ba\r.txt
-            if (IsWindows)
+            if (path[0] != Slash)
             {
                 path = path.Replace('\\', Slash);
             }

--- a/test/Lsp.Tests/DocumentUriTests.cs
+++ b/test/Lsp.Tests/DocumentUriTests.cs
@@ -158,7 +158,7 @@ namespace Lsp.Tests
         [ClassData(typeof(WindowsPathUris))]
         public void Should_Handle_Windows_Uris(Uri uri, string expected)
         {
-            _testOutputHelper.WriteLine($"Given: {uri}");
+            _testOutputHelper.WriteLine($"Given: {uri.OriginalString}");
             _testOutputHelper.WriteLine($"Expected: {expected}");
             DocumentUri.From(uri).ToString().Should().Be(expected);
         }
@@ -173,7 +173,7 @@ namespace Lsp.Tests
         [ClassData(typeof(UncPathUris))]
         public void Should_Handle_Unc_Uris(Uri uri, string expected)
         {
-            _testOutputHelper.WriteLine($"Given: {uri}");
+            _testOutputHelper.WriteLine($"Given: {uri.OriginalString}");
             _testOutputHelper.WriteLine($"Expected: {expected}");
             DocumentUri.From(uri).ToString().Should().Be(expected);
         }
@@ -188,7 +188,7 @@ namespace Lsp.Tests
         [ClassData(typeof(UnixPathUris))]
         public void Should_Handle_Unix_Uris(Uri uri, string expected)
         {
-            _testOutputHelper.WriteLine($"Given: {uri}");
+            _testOutputHelper.WriteLine($"Given: {uri.OriginalString}");
             _testOutputHelper.WriteLine($"Expected: {expected}");
             DocumentUri.From(uri).ToString().Should().Be(expected);
         }
@@ -254,7 +254,7 @@ namespace Lsp.Tests
         [ClassData(typeof(WindowsFileUriToFileSystem))]
         public void Should_Normalize_Windows_Uris(Uri uri, string expected)
         {
-            _testOutputHelper.WriteLine($"Given: {uri}");
+            _testOutputHelper.WriteLine($"Given: {uri.OriginalString}");
             _testOutputHelper.WriteLine($"Expected: {expected}");
             DocumentUri.GetFileSystemPath(uri).Should().Be(expected);
         }
@@ -271,7 +271,7 @@ namespace Lsp.Tests
         [ClassData(typeof(UncFileUriToFileSystem))]
         public void Should_Normalize_Unc_Uris(Uri uri, string expected)
         {
-            _testOutputHelper.WriteLine($"Given: {uri}");
+            _testOutputHelper.WriteLine($"Given: {uri.OriginalString}");
             _testOutputHelper.WriteLine($"Expected: {expected}");
             DocumentUri.GetFileSystemPath(uri).Should().Be(expected);
         }

--- a/test/Lsp.Tests/VsCodeDocumentUriTests.cs
+++ b/test/Lsp.Tests/VsCodeDocumentUriTests.cs
@@ -40,8 +40,8 @@ namespace Lsp.Tests
             }
             else
             {
-                DocumentUri.File("c:\\win\\path").ToString().Should().Be("file:///c:%5Cwin%5Cpath");
-                DocumentUri.File("c:\\win/path").ToString().Should().Be("file:///c:%5Cwin/path");
+                DocumentUri.File("/usr/win\\path").ToString().Should().Be("file:///usr/win%5Cpath");
+                DocumentUri.File("/usr/win/path").ToString().Should().Be("file:///usr/win/path");
             }
         }
 
@@ -469,21 +469,16 @@ namespace Lsp.Tests
                 value.ToString().Should().Be(value2.ToString());
             };
 
-            test("file:///c:/alex.txt",
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "c:\\alex.txt" : "c:/alex.txt");
+            test("file:///c:/alex.txt", "c:\\alex.txt");
             test(
                 "file:///c:/Source/Z%C3%BCrich%20or%20Zurich%20(%CB%88zj%CA%8A%C9%99r%C9%AAk,/Code/resources/app/plugins",
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                    ? "c:\\Source\\Zürich or Zurich (ˈzjʊərɪk,\\Code\\resources\\app\\plugins"
-                    : "c:/Source/Zürich or Zurich (ˈzjʊərɪk,/Code/resources/app/plugins");
-            test("file://monacotools/folder/isi.txt",
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                    ? "\\\\monacotools\\folder\\isi.txt"
-                    : "//monacotools/folder/isi.txt");
-            test("file://monacotools1/certificates/SSL/",
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                    ? "\\\\monacotools1\\certificates\\SSL\\"
-                    : "//monacotools1/certificates/SSL/");
+                "c:\\Source\\Zürich or Zurich (ˈzjʊərɪk,\\Code\\resources\\app\\plugins");
+            test(
+                "file://monacotools/folder/isi.txt",
+                "\\\\monacotools\\folder\\isi.txt");
+            test(
+                "file://monacotools1/certificates/SSL/",
+                "\\\\monacotools1\\certificates\\SSL\\");
         }
 
         [Fact(DisplayName = "URI - http, query & toString")]


### PR DESCRIPTION
This removes any OS forks of logic (which allows non-Windows to handle Windows paths correctly, etc.)

There was also forward slashes instead of backslashes for the:
```
value = $@"\\{uri.Authority}{uri.Path}";
```
line.