### PR TITLE
Commands, bugs, helpers and more!

### DIFF
--- a/src/JsonRpc.Generators/Helpers.cs
+++ b/src/JsonRpc.Generators/Helpers.cs
@@ -828,6 +828,7 @@ namespace OmniSharp.Extensions.JsonRpc.Generators
             var name = SpecialCasedHandlerName(symbol);
             if (
                 name.StartsWith("Run")
+                || name.StartsWith("Execute")
                 // TODO: Change this next breaking change
                 // || name.StartsWith("Set")
                 // || name.StartsWith("Attach")

--- a/src/Protocol/Models/ExecuteCommandRegistrationOptions.cs
+++ b/src/Protocol/Models/ExecuteCommandRegistrationOptions.cs
@@ -1,9 +1,9 @@
-﻿namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
+namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
     /// <summary>
     /// Execute command registration options.
     /// </summary>
-    public class ExecuteCommandRegistrationOptions : WorkDoneTextDocumentRegistrationOptions, IExecuteCommandOptions
+    public class ExecuteCommandRegistrationOptions : WorkDoneProgressOptions, IExecuteCommandOptions
     {
         /// <summary>
         /// The commands to be executed on the server

--- a/src/Protocol/Workspace/IExecuteCommandHandler.cs
+++ b/src/Protocol/Workspace/IExecuteCommandHandler.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Generation;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client;
@@ -42,8 +43,9 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 
         public sealed override Task<Unit> Handle(ExecuteCommandParams request, CancellationToken cancellationToken)
         {
+            var args = request.Arguments ?? new JArray();
             T arg1 = default;
-            if (request.Arguments.Count > 0) arg1 = request.Arguments[0].ToObject<T>(_serializer.JsonSerializer);
+            if (args.Count > 0) arg1 = args[0].ToObject<T>(_serializer.JsonSerializer);
             return Handle(arg1, cancellationToken);
         }
 
@@ -61,10 +63,11 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 
         public sealed override Task<Unit> Handle(ExecuteCommandParams request, CancellationToken cancellationToken)
         {
+            var args = request.Arguments ?? new JArray();
             T arg1 = default;
-            if (request.Arguments.Count > 0) arg1 = request.Arguments[0].ToObject<T>(_serializer.JsonSerializer);
+            if (args.Count > 0) arg1 = args[0].ToObject<T>(_serializer.JsonSerializer);
             T2 arg2 = default;
-            if (request.Arguments.Count > 1) arg2 = request.Arguments[1].ToObject<T2>(_serializer.JsonSerializer);
+            if (args.Count > 1) arg2 = args[1].ToObject<T2>(_serializer.JsonSerializer);
             return Handle(arg1, arg2, cancellationToken);
         }
 
@@ -82,12 +85,13 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 
         public sealed override Task<Unit> Handle(ExecuteCommandParams request, CancellationToken cancellationToken)
         {
+            var args = request.Arguments ?? new JArray();
             T arg1 = default;
-            if (request.Arguments.Count > 0) arg1 = request.Arguments[0].ToObject<T>(_serializer.JsonSerializer);
+            if (args.Count > 0) arg1 = args[0].ToObject<T>(_serializer.JsonSerializer);
             T2 arg2 = default;
-            if (request.Arguments.Count > 1) arg2 = request.Arguments[1].ToObject<T2>(_serializer.JsonSerializer);
+            if (args.Count > 1) arg2 = args[1].ToObject<T2>(_serializer.JsonSerializer);
             T3 arg3 = default;
-            if (request.Arguments.Count > 2) arg3 = request.Arguments[2].ToObject<T3>(_serializer.JsonSerializer);
+            if (args.Count > 2) arg3 = args[2].ToObject<T3>(_serializer.JsonSerializer);
             return Handle(arg1, arg2, arg3, cancellationToken);
         }
 
@@ -105,14 +109,15 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 
         public sealed override Task<Unit> Handle(ExecuteCommandParams request, CancellationToken cancellationToken)
         {
+            var args = request.Arguments ?? new JArray();
             T arg1 = default;
-            if (request.Arguments.Count > 0) arg1 = request.Arguments[0].ToObject<T>(_serializer.JsonSerializer);
+            if (args.Count > 0) arg1 = args[0].ToObject<T>(_serializer.JsonSerializer);
             T2 arg2 = default;
-            if (request.Arguments.Count > 1) arg2 = request.Arguments[1].ToObject<T2>(_serializer.JsonSerializer);
+            if (args.Count > 1) arg2 = args[1].ToObject<T2>(_serializer.JsonSerializer);
             T3 arg3 = default;
-            if (request.Arguments.Count > 2) arg3 = request.Arguments[2].ToObject<T3>(_serializer.JsonSerializer);
+            if (args.Count > 2) arg3 = args[2].ToObject<T3>(_serializer.JsonSerializer);
             T4 arg4 = default;
-            if (request.Arguments.Count > 3) arg4 = request.Arguments[3].ToObject<T4>(_serializer.JsonSerializer);
+            if (args.Count > 3) arg4 = args[3].ToObject<T4>(_serializer.JsonSerializer);
             return Handle(arg1, arg2, arg3, arg4, cancellationToken);
         }
 
@@ -130,16 +135,17 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 
         public sealed override Task<Unit> Handle(ExecuteCommandParams request, CancellationToken cancellationToken)
         {
+            var args = request.Arguments ?? new JArray();
             T arg1 = default;
-            if (request.Arguments.Count > 0) arg1 = request.Arguments[0].ToObject<T>(_serializer.JsonSerializer);
+            if (args.Count > 0) arg1 = args[0].ToObject<T>(_serializer.JsonSerializer);
             T2 arg2 = default;
-            if (request.Arguments.Count > 1) arg2 = request.Arguments[1].ToObject<T2>(_serializer.JsonSerializer);
+            if (args.Count > 1) arg2 = args[1].ToObject<T2>(_serializer.JsonSerializer);
             T3 arg3 = default;
-            if (request.Arguments.Count > 2) arg3 = request.Arguments[2].ToObject<T3>(_serializer.JsonSerializer);
+            if (args.Count > 2) arg3 = args[2].ToObject<T3>(_serializer.JsonSerializer);
             T4 arg4 = default;
-            if (request.Arguments.Count > 3) arg4 = request.Arguments[3].ToObject<T4>(_serializer.JsonSerializer);
+            if (args.Count > 3) arg4 = args[3].ToObject<T4>(_serializer.JsonSerializer);
             T5 arg5 = default;
-            if (request.Arguments.Count > 4) arg5 = request.Arguments[4].ToObject<T5>(_serializer.JsonSerializer);
+            if (args.Count > 4) arg5 = args[4].ToObject<T5>(_serializer.JsonSerializer);
             return Handle(arg1, arg2, arg3, arg4, arg5, cancellationToken);
         }
 
@@ -157,18 +163,19 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 
         public sealed override Task<Unit> Handle(ExecuteCommandParams request, CancellationToken cancellationToken)
         {
+            var args = request.Arguments ?? new JArray();
             T arg1 = default;
-            if (request.Arguments.Count > 0) arg1 = request.Arguments[0].ToObject<T>(_serializer.JsonSerializer);
+            if (args.Count > 0) arg1 = args[0].ToObject<T>(_serializer.JsonSerializer);
             T2 arg2 = default;
-            if (request.Arguments.Count > 1) arg2 = request.Arguments[1].ToObject<T2>(_serializer.JsonSerializer);
+            if (args.Count > 1) arg2 = args[1].ToObject<T2>(_serializer.JsonSerializer);
             T3 arg3 = default;
-            if (request.Arguments.Count > 2) arg3 = request.Arguments[2].ToObject<T3>(_serializer.JsonSerializer);
+            if (args.Count > 2) arg3 = args[2].ToObject<T3>(_serializer.JsonSerializer);
             T4 arg4 = default;
-            if (request.Arguments.Count > 3) arg4 = request.Arguments[3].ToObject<T4>(_serializer.JsonSerializer);
+            if (args.Count > 3) arg4 = args[3].ToObject<T4>(_serializer.JsonSerializer);
             T5 arg5 = default;
-            if (request.Arguments.Count > 4) arg5 = request.Arguments[4].ToObject<T5>(_serializer.JsonSerializer);
+            if (args.Count > 4) arg5 = args[4].ToObject<T5>(_serializer.JsonSerializer);
             T6 arg6 = default;
-            if (request.Arguments.Count > 5) arg6 = request.Arguments[5].ToObject<T6>(_serializer.JsonSerializer);
+            if (args.Count > 5) arg6 = args[5].ToObject<T6>(_serializer.JsonSerializer);
             return Handle(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
         }
 

--- a/src/Protocol/Workspace/IExecuteCommandHandler.cs
+++ b/src/Protocol/Workspace/IExecuteCommandHandler.cs
@@ -1,11 +1,14 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Generation;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 {
@@ -28,11 +31,282 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
         protected ExecuteCommandCapability Capability { get; private set; }
     }
 
+    public abstract class ExecuteCommandHandlerBase<T> : ExecuteCommandHandler
+    {
+        private readonly ISerializer _serializer;
+
+        public ExecuteCommandHandlerBase(string command, ISerializer serializer) : base(new ExecuteCommandRegistrationOptions() { Commands = new Container<string>(command) })
+        {
+            _serializer = serializer;
+        }
+
+        public sealed override Task<Unit> Handle(ExecuteCommandParams request, CancellationToken cancellationToken)
+        {
+            T arg1 = default;
+            if (request.Arguments.Count > 0) arg1 = request.Arguments[0].ToObject<T>(_serializer.JsonSerializer);
+            return Handle(arg1, cancellationToken);
+        }
+
+        public abstract Task<Unit> Handle(T arg1, CancellationToken cancellationToken);
+    }
+
+    public abstract class ExecuteCommandHandlerBase<T, T2> : ExecuteCommandHandler
+    {
+        private readonly ISerializer _serializer;
+
+        public ExecuteCommandHandlerBase(string command, ISerializer serializer) : base(new ExecuteCommandRegistrationOptions() { Commands = new Container<string>(command) })
+        {
+            _serializer = serializer;
+        }
+
+        public sealed override Task<Unit> Handle(ExecuteCommandParams request, CancellationToken cancellationToken)
+        {
+            T arg1 = default;
+            if (request.Arguments.Count > 0) arg1 = request.Arguments[0].ToObject<T>(_serializer.JsonSerializer);
+            T2 arg2 = default;
+            if (request.Arguments.Count > 1) arg2 = request.Arguments[1].ToObject<T2>(_serializer.JsonSerializer);
+            return Handle(arg1, arg2, cancellationToken);
+        }
+
+        public abstract Task<Unit> Handle(T arg1, T2 arg2, CancellationToken cancellationToken);
+    }
+
+    public abstract class ExecuteCommandHandlerBase<T, T2, T3> : ExecuteCommandHandler
+    {
+        private readonly ISerializer _serializer;
+
+        public ExecuteCommandHandlerBase(string command, ISerializer serializer) : base(new ExecuteCommandRegistrationOptions() { Commands = new Container<string>(command) })
+        {
+            _serializer = serializer;
+        }
+
+        public sealed override Task<Unit> Handle(ExecuteCommandParams request, CancellationToken cancellationToken)
+        {
+            T arg1 = default;
+            if (request.Arguments.Count > 0) arg1 = request.Arguments[0].ToObject<T>(_serializer.JsonSerializer);
+            T2 arg2 = default;
+            if (request.Arguments.Count > 1) arg2 = request.Arguments[1].ToObject<T2>(_serializer.JsonSerializer);
+            T3 arg3 = default;
+            if (request.Arguments.Count > 2) arg3 = request.Arguments[2].ToObject<T3>(_serializer.JsonSerializer);
+            return Handle(arg1, arg2, arg3, cancellationToken);
+        }
+
+        public abstract Task<Unit> Handle(T arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken);
+    }
+
+    public abstract class ExecuteCommandHandlerBase<T, T2, T3, T4> : ExecuteCommandHandler
+    {
+        private readonly ISerializer _serializer;
+
+        public ExecuteCommandHandlerBase(string command, ISerializer serializer) : base(new ExecuteCommandRegistrationOptions() { Commands = new Container<string>(command) })
+        {
+            _serializer = serializer;
+        }
+
+        public sealed override Task<Unit> Handle(ExecuteCommandParams request, CancellationToken cancellationToken)
+        {
+            T arg1 = default;
+            if (request.Arguments.Count > 0) arg1 = request.Arguments[0].ToObject<T>(_serializer.JsonSerializer);
+            T2 arg2 = default;
+            if (request.Arguments.Count > 1) arg2 = request.Arguments[1].ToObject<T2>(_serializer.JsonSerializer);
+            T3 arg3 = default;
+            if (request.Arguments.Count > 2) arg3 = request.Arguments[2].ToObject<T3>(_serializer.JsonSerializer);
+            T4 arg4 = default;
+            if (request.Arguments.Count > 3) arg4 = request.Arguments[3].ToObject<T4>(_serializer.JsonSerializer);
+            return Handle(arg1, arg2, arg3, arg4, cancellationToken);
+        }
+
+        public abstract Task<Unit> Handle(T arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken);
+    }
+
+    public abstract class ExecuteCommandHandlerBase<T, T2, T3, T4, T5> : ExecuteCommandHandler
+    {
+        private readonly ISerializer _serializer;
+
+        public ExecuteCommandHandlerBase(string command, ISerializer serializer) : base(new ExecuteCommandRegistrationOptions() { Commands = new Container<string>(command) })
+        {
+            _serializer = serializer;
+        }
+
+        public sealed override Task<Unit> Handle(ExecuteCommandParams request, CancellationToken cancellationToken)
+        {
+            T arg1 = default;
+            if (request.Arguments.Count > 0) arg1 = request.Arguments[0].ToObject<T>(_serializer.JsonSerializer);
+            T2 arg2 = default;
+            if (request.Arguments.Count > 1) arg2 = request.Arguments[1].ToObject<T2>(_serializer.JsonSerializer);
+            T3 arg3 = default;
+            if (request.Arguments.Count > 2) arg3 = request.Arguments[2].ToObject<T3>(_serializer.JsonSerializer);
+            T4 arg4 = default;
+            if (request.Arguments.Count > 3) arg4 = request.Arguments[3].ToObject<T4>(_serializer.JsonSerializer);
+            T5 arg5 = default;
+            if (request.Arguments.Count > 4) arg5 = request.Arguments[4].ToObject<T5>(_serializer.JsonSerializer);
+            return Handle(arg1, arg2, arg3, arg4, arg5, cancellationToken);
+        }
+
+        public abstract Task<Unit> Handle(T arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken);
+    }
+
+    public abstract class ExecuteCommandHandlerBase<T, T2, T3, T4, T5, T6> : ExecuteCommandHandler
+    {
+        private readonly ISerializer _serializer;
+
+        public ExecuteCommandHandlerBase(string command, ISerializer serializer) : base(new ExecuteCommandRegistrationOptions() { Commands = new Container<string>(command) })
+        {
+            _serializer = serializer;
+        }
+
+        public sealed override Task<Unit> Handle(ExecuteCommandParams request, CancellationToken cancellationToken)
+        {
+            T arg1 = default;
+            if (request.Arguments.Count > 0) arg1 = request.Arguments[0].ToObject<T>(_serializer.JsonSerializer);
+            T2 arg2 = default;
+            if (request.Arguments.Count > 1) arg2 = request.Arguments[1].ToObject<T2>(_serializer.JsonSerializer);
+            T3 arg3 = default;
+            if (request.Arguments.Count > 2) arg3 = request.Arguments[2].ToObject<T3>(_serializer.JsonSerializer);
+            T4 arg4 = default;
+            if (request.Arguments.Count > 3) arg4 = request.Arguments[3].ToObject<T4>(_serializer.JsonSerializer);
+            T5 arg5 = default;
+            if (request.Arguments.Count > 4) arg5 = request.Arguments[4].ToObject<T5>(_serializer.JsonSerializer);
+            T6 arg6 = default;
+            if (request.Arguments.Count > 5) arg6 = request.Arguments[5].ToObject<T6>(_serializer.JsonSerializer);
+            return Handle(arg1, arg2, arg3, arg4, arg5, arg6, cancellationToken);
+        }
+
+        public abstract Task<Unit> Handle(T arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken);
+    }
+
     public static partial class ExecuteCommandExtensions
     {
         public static Task ExecuteCommand(this IWorkspaceLanguageClient mediator, Command @params, CancellationToken cancellationToken = default)
-            => mediator.ExecuteCommand(new ExecuteCommandParams() {Arguments = @params.Arguments, Command = @params.Name}, cancellationToken);
+            => mediator.ExecuteCommand(new ExecuteCommandParams() { Arguments = @params.Arguments, Command = @params.Name }, cancellationToken);
+
         public static Task ExecuteCommand(this ILanguageClient mediator, Command @params, CancellationToken cancellationToken = default)
-            => mediator.ExecuteCommand(new ExecuteCommandParams() {Arguments = @params.Arguments, Command = @params.Name}, cancellationToken);
+            => mediator.ExecuteCommand(new ExecuteCommandParams() { Arguments = @params.Arguments, Command = @params.Name }, cancellationToken);
+
+        public static ILanguageServerRegistry OnExecuteCommand<T>(this ILanguageServerRegistry registry, string command, Func<T, Task> handler)
+        {
+            return registry.AddHandler(_ => new Handler<T>(command, handler, _.GetRequiredService<ISerializer>()));
+        }
+
+        class Handler<T> : ExecuteCommandHandlerBase<T>
+        {
+            private readonly Func<T, Task> _handler;
+
+            public Handler(string command, Func<T, Task> handler, ISerializer serializer) : base(command, serializer)
+            {
+                _handler = handler;
+            }
+
+            public override async Task<Unit> Handle(T arg1, CancellationToken cancellationToken)
+            {
+                await _handler(arg1);
+                return Unit.Value;
+            }
+        }
+
+        public static ILanguageServerRegistry OnExecuteCommand<T, T2>(this ILanguageServerRegistry registry, string command, Func<T, T2, Task> handler)
+        {
+            return registry.AddHandler(_ => new Handler<T, T2>(command, handler, _.GetRequiredService<ISerializer>()));
+        }
+
+        class Handler<T, T2> : ExecuteCommandHandlerBase<T, T2>
+        {
+            private readonly Func<T, T2, Task> _handler;
+
+            public Handler(string command, Func<T, T2, Task> handler, ISerializer serializer) : base(command, serializer)
+            {
+                _handler = handler;
+            }
+
+            public override async Task<Unit> Handle(T arg1, T2 arg2, CancellationToken cancellationToken)
+            {
+                await _handler(arg1, arg2);
+                return Unit.Value;
+            }
+        }
+
+        public static ILanguageServerRegistry OnExecuteCommand<T, T2, T3>(this ILanguageServerRegistry registry, string command, Func<T, T2, T3, Task> handler)
+        {
+            return registry.AddHandler(_ => new Handler<T, T2, T3>(command, handler, _.GetRequiredService<ISerializer>()));
+        }
+
+        class Handler<T, T2, T3> : ExecuteCommandHandlerBase<T, T2, T3>
+        {
+            private readonly Func<T, T2, T3, Task> _handler;
+
+            public Handler(string command, Func<T, T2, T3, Task> handler, ISerializer serializer) : base(command, serializer)
+            {
+                _handler = handler;
+            }
+
+            public override async Task<Unit> Handle(T arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
+            {
+                await _handler(arg1, arg2, arg3);
+                return Unit.Value;
+            }
+        }
+
+        public static ILanguageServerRegistry OnExecuteCommand<T, T2, T3, T4>(this ILanguageServerRegistry registry, string command, Func<T, T2, T3, T4, Task> handler)
+        {
+            return registry.AddHandler(_ => new Handler<T, T2, T3, T4>(command, handler, _.GetRequiredService<ISerializer>()));
+        }
+
+        class Handler<T, T2, T3, T4> : ExecuteCommandHandlerBase<T, T2, T3, T4>
+        {
+            private readonly Func<T, T2, T3, T4, Task> _handler;
+
+            public Handler(string command, Func<T, T2, T3, T4, Task> handler, ISerializer serializer) : base(command, serializer)
+            {
+                _handler = handler;
+            }
+
+            public override async Task<Unit> Handle(T arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
+            {
+                await _handler(arg1, arg2, arg3, arg4);
+                return Unit.Value;
+            }
+        }
+
+        public static ILanguageServerRegistry OnExecuteCommand<T, T2, T3, T4, T5>(this ILanguageServerRegistry registry, string command, Func<T, T2, T3, T4, T5, Task> handler)
+        {
+            return registry.AddHandler(_ => new Handler<T, T2, T3, T4, T5>(command, handler, _.GetRequiredService<ISerializer>()));
+        }
+
+        class Handler<T, T2, T3, T4, T5> : ExecuteCommandHandlerBase<T, T2, T3, T4, T5>
+        {
+            private readonly Func<T, T2, T3, T4, T5, Task> _handler;
+
+            public Handler(string command, Func<T, T2, T3, T4, T5, Task> handler, ISerializer serializer) : base(command, serializer)
+            {
+                _handler = handler;
+            }
+
+            public override async Task<Unit> Handle(T arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
+            {
+                await _handler(arg1, arg2, arg3, arg4, arg5);
+                return Unit.Value;
+            }
+        }
+
+        public static ILanguageServerRegistry OnExecuteCommand<T, T2, T3, T4, T5, T6>(this ILanguageServerRegistry registry, string command, Func<T, T2, T3, T4, T5, T6, Task> handler)
+        {
+            return registry.AddHandler(_ => new Handler<T, T2, T3, T4, T5, T6>(command, handler, _.GetRequiredService<ISerializer>()));
+        }
+
+        class Handler<T, T2, T3, T4, T5, T6> : ExecuteCommandHandlerBase<T, T2, T3, T4, T5, T6>
+        {
+            private readonly Func<T, T2, T3, T4, T5, T6, Task> _handler;
+
+            public Handler(string command, Func<T, T2, T3, T4, T5, T6, Task> handler, ISerializer serializer) : base(command, serializer)
+            {
+                _handler = handler;
+            }
+
+            public override async Task<Unit> Handle(T arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
+            {
+                await _handler(arg1, arg2, arg3, arg4, arg5, arg6);
+                return Unit.Value;
+            }
+        }
     }
 }

--- a/src/Protocol/Workspace/IExecuteCommandHandler.cs
+++ b/src/Protocol/Workspace/IExecuteCommandHandler.cs
@@ -27,4 +27,12 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
         public virtual void SetCapability(ExecuteCommandCapability capability) => Capability = capability;
         protected ExecuteCommandCapability Capability { get; private set; }
     }
+
+    public static partial class ExecuteCommandExtensions
+    {
+        public static Task ExecuteCommand(this IWorkspaceLanguageClient mediator, Command @params, CancellationToken cancellationToken = default)
+            => mediator.ExecuteCommand(new ExecuteCommandParams() {Arguments = @params.Arguments, Command = @params.Name}, cancellationToken);
+        public static Task ExecuteCommand(this ILanguageClient mediator, Command @params, CancellationToken cancellationToken = default)
+            => mediator.ExecuteCommand(new ExecuteCommandParams() {Arguments = @params.Arguments, Command = @params.Name}, cancellationToken);
+    }
 }

--- a/src/Server/Matchers/TextDocumentMatcher.cs
+++ b/src/Server/Matchers/TextDocumentMatcher.cs
@@ -17,7 +17,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Matchers
         public TextDocumentMatcher(ILogger<TextDocumentMatcher> logger, TextDocumentIdentifiers textDocumentIdentifiers)
         {
             _logger = logger;
-            _textDocumentIdentifiers = textDocumentIdentifiers;;
+            _textDocumentIdentifiers = textDocumentIdentifiers; ;
         }
 
         public IEnumerable<ILspHandlerDescriptor> FindHandler(object parameters, IEnumerable<ILspHandlerDescriptor> descriptors)
@@ -26,6 +26,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Matchers
             {
                 case ITextDocumentIdentifierParams textDocumentIdentifierParams:
                     {
+                        if (textDocumentIdentifierParams.TextDocument?.Uri == null) break;
                         var attributes = GetTextDocumentAttributes(textDocumentIdentifierParams.TextDocument.Uri);
 
                         _logger.LogTrace("Found attributes {Count}, {Attributes}", attributes.Count, attributes.Select(x => $"{x.LanguageId}:{x.Scheme}:{x.Uri}"));
@@ -34,6 +35,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Matchers
                     }
                 case DidOpenTextDocumentParams openTextDocumentParams:
                     {
+                        if (openTextDocumentParams.TextDocument?.Uri == null) break;
                         var attributes = new TextDocumentAttributes(openTextDocumentParams.TextDocument.Uri, openTextDocumentParams.TextDocument.LanguageId);
 
                         _logger.LogTrace("Created attribute {Attribute}", $"{attributes.LanguageId}:{attributes.Scheme}:{attributes.Uri}");
@@ -42,6 +44,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Matchers
                     }
                 case DidChangeTextDocumentParams didChangeDocumentParams:
                     {
+                        if (didChangeDocumentParams.TextDocument?.Uri == null) break;
                         // TODO: Do something with document version here?
                         var attributes = GetTextDocumentAttributes(didChangeDocumentParams.TextDocument.Uri);
 

--- a/src/Shared/SharedHandlerCollection.cs
+++ b/src/Shared/SharedHandlerCollection.cs
@@ -263,6 +263,11 @@ namespace OmniSharp.Extensions.LanguageServer.Shared
                 }
             }
 
+            if (handler is IRegistration<ExecuteCommandRegistrationOptions> commandRegistration)
+            {
+                key += "|" + string.Join("|", commandRegistration.GetRegistrationOptions()?.Commands ?? Array.Empty<string>());
+            }
+
             if (string.IsNullOrWhiteSpace(key)) key = "default";
 
             var requestProcessType =

--- a/src/Shared/SharedHandlerCollection.cs
+++ b/src/Shared/SharedHandlerCollection.cs
@@ -46,7 +46,7 @@ namespace OmniSharp.Extensions.LanguageServer.Shared
             return GetEnumerator();
         }
 
-        IDisposable IHandlersManager.Add(IJsonRpcHandler handler, JsonRpcHandlerOptions options) => Add(new[] {handler}, options);
+        IDisposable IHandlersManager.Add(IJsonRpcHandler handler, JsonRpcHandlerOptions options) => Add(new[] { handler }, options);
 
         IDisposable IHandlersManager.Add(string method, IJsonRpcHandler handler, JsonRpcHandlerOptions options) => Add(method, handler, options);
 
@@ -58,7 +58,7 @@ namespace OmniSharp.Extensions.LanguageServer.Shared
                 destinationMethod,
                 source.HandlerType,
                 source.Handler,
-                source.RequestProcessType.HasValue ? new JsonRpcHandlerOptions() {RequestProcessType = source.RequestProcessType.Value} : null,
+                source.RequestProcessType.HasValue ? new JsonRpcHandlerOptions() { RequestProcessType = source.RequestProcessType.Value } : null,
                 source.TypeDescriptor,
                 source.HandlerType,
                 source.RegistrationType,
@@ -70,7 +70,7 @@ namespace OmniSharp.Extensions.LanguageServer.Shared
                 cd.Add(_textDocumentIdentifiers.Add(textDocumentIdentifier));
             }
 
-            return new LspHandlerDescriptorDisposable(new[] {descriptor}, cd);
+            return new LspHandlerDescriptorDisposable(new[] { descriptor }, cd);
         }
 
         public LspHandlerDescriptorDisposable Add(string method, IJsonRpcHandler handler, JsonRpcHandlerOptions options)
@@ -83,7 +83,7 @@ namespace OmniSharp.Extensions.LanguageServer.Shared
                 cd.Add(_textDocumentIdentifiers.Add(textDocumentIdentifier));
             }
 
-            return new LspHandlerDescriptorDisposable(new[] {descriptor}, cd);
+            return new LspHandlerDescriptorDisposable(new[] { descriptor }, cd);
         }
 
         public LspHandlerDescriptorDisposable Add(string method, Func<IServiceProvider, IJsonRpcHandler> handlerFunc, JsonRpcHandlerOptions options)
@@ -97,7 +97,7 @@ namespace OmniSharp.Extensions.LanguageServer.Shared
                 cd.Add(_textDocumentIdentifiers.Add(textDocumentIdentifier));
             }
 
-            return new LspHandlerDescriptorDisposable(new[] {descriptor}, cd);
+            return new LspHandlerDescriptorDisposable(new[] { descriptor }, cd);
         }
 
         public LspHandlerDescriptorDisposable Add(string method, Type handlerType, JsonRpcHandlerOptions options)
@@ -110,7 +110,7 @@ namespace OmniSharp.Extensions.LanguageServer.Shared
                 cd.Add(_textDocumentIdentifiers.Add(textDocumentIdentifier));
             }
 
-            return new LspHandlerDescriptorDisposable(new[] {descriptor}, cd);
+            return new LspHandlerDescriptorDisposable(new[] { descriptor }, cd);
         }
 
         public LspHandlerDescriptorDisposable Add(params Type[] handlerTypes)
@@ -168,16 +168,16 @@ namespace OmniSharp.Extensions.LanguageServer.Shared
         class EqualityComparer : IEqualityComparer<(string method, Type implementedInterface)>
         {
 
-        public bool Equals((string method, Type implementedInterface) x, (string method, Type implementedInterface) y)
-        {
-            return x.method?.Equals(y.method) == true;
-        }
+            public bool Equals((string method, Type implementedInterface) x, (string method, Type implementedInterface) y)
+            {
+                return x.method?.Equals(y.method) == true;
+            }
 
-        public int GetHashCode((string method, Type implementedInterface) obj)
-        {
-            return obj.method?.GetHashCode() ?? 0;
+            public int GetHashCode((string method, Type implementedInterface) obj)
+            {
+                return obj.method?.GetHashCode() ?? 0;
+            }
         }
-    }
 
         private LspHandlerDescriptorDisposable Add(IJsonRpcHandler[] handlers, JsonRpcHandlerOptions options)
         {
@@ -241,7 +241,7 @@ namespace OmniSharp.Extensions.LanguageServer.Shared
             {
                 registrationOptions = GetRegistrationMethod
                     .MakeGenericMethod(registrationType)
-                    .Invoke(null, new object[] {handler});
+                    .Invoke(null, new object[] { handler });
             }
 
             var key = "default";
@@ -262,10 +262,9 @@ namespace OmniSharp.Extensions.LanguageServer.Shared
                     key = handlerRegistration?.GetRegistrationOptions()?.DocumentSelector ?? key;
                 }
             }
-
-            if (handler is IRegistration<ExecuteCommandRegistrationOptions> commandRegistration)
+            else if (handler is IRegistration<ExecuteCommandRegistrationOptions> commandRegistration)
             {
-                key += "|" + string.Join("|", commandRegistration.GetRegistrationOptions()?.Commands ?? Array.Empty<string>());
+                key = string.Join("|", commandRegistration.GetRegistrationOptions()?.Commands ?? Array.Empty<string>());
             }
 
             if (string.IsNullOrWhiteSpace(key)) key = "default";
@@ -286,7 +285,7 @@ namespace OmniSharp.Extensions.LanguageServer.Shared
                 @params,
                 registrationType,
                 registrationOptions,
-                (registrationType == null ? (Func<bool>) (() => false) : (() => _supportedCapabilities.AllowsDynamicRegistration(capabilityType))),
+                (registrationType == null ? (Func<bool>)(() => false) : (() => _supportedCapabilities.AllowsDynamicRegistration(capabilityType))),
                 capabilityType,
                 requestProcessType,
                 () => { _handlers.RemoveWhere(d => d.Handler == handler); },

--- a/test/JsonRpc.Tests/AutoNSubstitute/TestExtensions.cs
+++ b/test/JsonRpc.Tests/AutoNSubstitute/TestExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using OmniSharp.Extensions.JsonRpc.Testing;
+using Serilog.Events;
 using Xunit.Abstractions;
 
 // ReSharper disable once CheckNamespace
@@ -12,11 +13,14 @@ namespace NSubstitute
             cancellationTokenSource.Token.WaitHandle.WaitOne();
         }
 
-        public static JsonRpcTestOptions ConfigureForXUnit(this JsonRpcTestOptions jsonRpcTestOptions, ITestOutputHelper outputHelper)
+        public static JsonRpcTestOptions ConfigureForXUnit(
+            this JsonRpcTestOptions jsonRpcTestOptions, 
+            ITestOutputHelper outputHelper, 
+            LogEventLevel logEventLevel = LogEventLevel.Debug)
         {
             return jsonRpcTestOptions
-                .WithClientLoggerFactory(new TestLoggerFactory(outputHelper, "{Timestamp:yyyy-MM-dd HH:mm:ss} [Client] [{Level}] {Message}{NewLine}{Exception}"))
-                .WithServerLoggerFactory(new TestLoggerFactory(outputHelper, "{Timestamp:yyyy-MM-dd HH:mm:ss} [Server] [{Level}] {Message}{NewLine}{Exception}"));
+                .WithClientLoggerFactory(new TestLoggerFactory(outputHelper, "{Timestamp:yyyy-MM-dd HH:mm:ss} [Client] [{Level}] {Message}{NewLine}{Exception}", logEventLevel))
+                .WithServerLoggerFactory(new TestLoggerFactory(outputHelper, "{Timestamp:yyyy-MM-dd HH:mm:ss} [Server] [{Level}] {Message}{NewLine}{Exception}", logEventLevel));
         }
     }
 }

--- a/test/Lsp.Tests/FoundationTests.cs
+++ b/test/Lsp.Tests/FoundationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -575,6 +575,7 @@ namespace Lsp.Tests
                 || name.StartsWith("Prepare")
                 || name.StartsWith("Publish")
                 || name.StartsWith("ApplyWorkspaceEdit")
+                || name.StartsWith("Execute")
                 || name.StartsWith("Unregister"))
             {
                 return name;

--- a/test/Lsp.Tests/FoundationTests.cs
+++ b/test/Lsp.Tests/FoundationTests.cs
@@ -106,7 +106,11 @@ namespace Lsp.Tests
             var abstractHandler = descriptor.HandlerType.Assembly.ExportedTypes.FirstOrDefault(z => z.IsAbstract && z.IsClass && descriptor.HandlerType.IsAssignableFrom(z));
             abstractHandler.Should().NotBeNull($"{descriptor.HandlerType.FullName} is missing abstract base class");
 
-            var delegatingHandler = descriptor.HandlerType.Assembly.DefinedTypes.FirstOrDefault(z => abstractHandler.IsAssignableFrom(z) && abstractHandler != z);
+            var delegatingHandler = descriptor.HandlerType.Assembly.DefinedTypes.FirstOrDefault(z =>
+                abstractHandler.IsAssignableFrom(z)
+                && abstractHandler != z
+                && !z.IsGenericTypeDefinition
+            );
             if (delegatingHandler != null)
             {
                 _logger.LogInformation("Delegating Handler: {Type}", delegatingHandler);

--- a/test/Lsp.Tests/Integration/DynamicRegistrationTests.cs
+++ b/test/Lsp.Tests/Integration/DynamicRegistrationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
@@ -83,7 +83,7 @@ namespace Lsp.Tests.Integration
                     })
             );
 
-            await SettleNext().Take(2);
+            await Settle().Take(2);
 
             client.RegistrationManager.CurrentRegistrations.Should().Contain(x =>
                 x.Method == TextDocumentNames.Completion && SelectorMatches(x, z=> z.HasLanguage && z.Language == "vb")

--- a/test/Lsp.Tests/Integration/DynamicRegistrationTests.cs
+++ b/test/Lsp.Tests/Integration/DynamicRegistrationTests.cs
@@ -83,7 +83,7 @@ namespace Lsp.Tests.Integration
                     })
             );
 
-            await SettleNext();
+            await SettleNext().Take(2);
 
             client.RegistrationManager.CurrentRegistrations.Should().Contain(x =>
                 x.Method == TextDocumentNames.Completion && SelectorMatches(x, z=> z.HasLanguage && z.Language == "vb")

--- a/test/Lsp.Tests/Integration/ExecuteCommandTests.cs
+++ b/test/Lsp.Tests/Integration/ExecuteCommandTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -13,6 +14,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 using Serilog.Events;
 using Xunit;
 using Xunit.Abstractions;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Lsp.Tests.Integration
 {
@@ -161,7 +163,7 @@ namespace Lsp.Tests.Integration
                         return Task.FromResult(new CompletionList(new CompletionItem() {
                             Command = new Command() {
                                 Name = "execute-a",
-                                Arguments = JArray.FromObject(new object[] {1, "2", false})
+                                Arguments = JArray.FromObject(new object[] { 1, "2", false })
                             }
                         }));
                     }, new CompletionRegistrationOptions() {
@@ -187,6 +189,420 @@ namespace Lsp.Tests.Integration
 
             await commandc.Received(0).Invoke(Arg.Any<ExecuteCommandParams>());
             await commandb.Received(0).Invoke(Arg.Any<ExecuteCommandParams>());
+        }
+
+        [Fact]
+        public async Task Should_Execute_1_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] { 1 })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int>("execute-a", (i) => {
+                        i.Should().Be(1);
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_2_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] { 1, "2" })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string>("execute-a", (i, s) => {
+                        i.Should().Be(1);
+                        s.Should().Be("2");
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_3_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] { 1, "2", true })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string, bool>("execute-a", (i, s, arg3) => {
+                        i.Should().Be(1);
+                        s.Should().Be("2");
+                        arg3.Should().BeTrue();
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_4_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] { 1, "2", true, new Range((0, 1), (1, 1)) })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string, bool, Range>("execute-a", (i, s, arg3, arg4) => {
+                        i.Should().Be(1);
+                        s.Should().Be("2");
+                        arg3.Should().BeTrue();
+                        arg4.Should().Be(new Range((0, 1), (1, 1)));
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_5_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] { 1, "2", true, new Range((0, 1), (1, 1)), new Dictionary<string, string>() { ["a"] = "123", ["b"] = "456" } })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string, bool, Range, Dictionary<string, string>>("execute-a", (i, s, arg3, arg4, arg5) => {
+                        i.Should().Be(1);
+                        s.Should().Be("2");
+                        arg3.Should().BeTrue();
+                        arg4.Should().Be(new Range((0, 1), (1, 1)));
+                        arg5.Should().ContainKeys("a", "b");
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_6_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] { 1, "2", true, new Range((0, 1), (1, 1)), new Dictionary<string, string>() { ["a"] = "123", ["b"] = "456" }, Guid.NewGuid() })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string, bool, Range, Dictionary<string, string>, Guid>("execute-a", (i, s, arg3, arg4, arg5, arg6) => {
+                        i.Should().Be(1);
+                        s.Should().Be("2");
+                        arg3.Should().BeTrue();
+                        arg4.Should().Be(new Range((0, 1), (1, 1)));
+                        arg5.Should().ContainKeys("a", "b");
+                        arg6.Should().NotBeEmpty();
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_1_With_Missing_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] {})
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int>("execute-a", (i) => {
+                        i.Should().Be(default);
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_2_With_Missing_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] {  })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string>("execute-a", (i, s) => {
+                        i.Should().Be(default);
+                        s.Should().Be(default);
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_3_With_Missing_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] { })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string, bool>("execute-a", (i, s, arg3) => {
+                        i.Should().Be(default);
+                        s.Should().Be(default);
+                        arg3.Should().Be(default);
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_4_With_Missing_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] {  })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string, bool, Range>("execute-a", (i, s, arg3, arg4) => {
+                        i.Should().Be(default);
+                        s.Should().Be(default);
+                        arg3.Should().Be(default);
+                        arg4.Should().Be(default);
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_5_With_Missing_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] {  })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string, bool, Range, Dictionary<string, string>>("execute-a", (i, s, arg3, arg4, arg5) => {
+                        i.Should().Be(default);
+                        s.Should().Be(default);
+                        arg3.Should().Be(default);
+                        arg4.Should().Be(default);
+                        arg5.Should().BeNull();
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_6_With_Missing_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] {  })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string, bool, Range, Dictionary<string, string>, Guid>("execute-a", (i, s, arg3, arg4, arg5, arg6) => {
+                        i.Should().Be(default);
+                        s.Should().Be(default);
+                        arg3.Should().Be(default);
+                        arg4.Should().Be(default);
+                        arg5.Should().BeNull();
+                        arg6.Should().BeEmpty();
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
         }
     }
 }

--- a/test/Lsp.Tests/Integration/ExecuteCommandTests.cs
+++ b/test/Lsp.Tests/Integration/ExecuteCommandTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using OmniSharp.Extensions.JsonRpc.Server;
+using OmniSharp.Extensions.JsonRpc.Testing;
+using OmniSharp.Extensions.LanguageProtocol.Testing;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
+using Serilog.Events;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Lsp.Tests.Integration
+{
+    public class ExecuteCommandTests : LanguageProtocolTestBase
+    {
+        public ExecuteCommandTests(ITestOutputHelper outputHelper) : base(new JsonRpcTestOptions().ConfigureForXUnit(outputHelper, LogEventLevel.Verbose))
+        {
+        }
+
+        [Fact]
+        public async Task Should_Execute_A_Command()
+        {
+            var command = Substitute.For<Func<ExecuteCommandParams, Task>>();
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] { 1, "2", false })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand(command, new ExecuteCommandRegistrationOptions() {
+                        Commands = new Container<string>("execute-a")
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            await client.ExecuteCommand(item.Command);
+
+            await command.Received(1).Invoke(Arg.Any<ExecuteCommandParams>());
+        }
+
+        [Fact]
+        public async Task Should_Execute_The_Correct_Command()
+        {
+            var commanda = Substitute.For<Func<ExecuteCommandParams, Task>>();
+            var commandb = Substitute.For<Func<ExecuteCommandParams, Task>>();
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-b",
+                                Arguments = JArray.FromObject(new object[] { 1, "2", false })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand(commanda, new ExecuteCommandRegistrationOptions() {
+                        Commands = new Container<string>("execute-a")
+                    });
+
+                    options.OnExecuteCommand(commandb, new ExecuteCommandRegistrationOptions() {
+                        Commands = new Container<string>("execute-b")
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            await client.ExecuteCommand(item.Command);
+
+            await commanda.Received(0).Invoke(Arg.Any<ExecuteCommandParams>());
+            await commandb.Received(1).Invoke(Arg.Any<ExecuteCommandParams>());
+        }
+
+        [Fact]
+        public async Task Should_Fail_To_Execute_A_Command_When_No_Command_Is_Defined()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] { 1, "2", false })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().ThrowAsync<MethodNotSupportedException>();
+        }
+
+        [Fact]
+        public async Task Should_Fail_To_Execute_A_Command_When_No_Command_Name_Is_Given()
+        {
+            var command = Substitute.For<Func<ExecuteCommandParams, Task>>();
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Arguments = JArray.FromObject(new object[] { 1, "2", false })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand(command, new ExecuteCommandRegistrationOptions() {
+                        Commands = new Container<string>("execute-a")
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().ThrowAsync<MethodNotSupportedException>();
+
+            await command.Received(0).Invoke(Arg.Any<ExecuteCommandParams>());
+        }
+
+        [Fact]
+        public async Task Should_Fail_To_Execute_A_Command()
+        {
+            var commandc = Substitute.For<Func<ExecuteCommandParams, Task>>();
+            var commandb = Substitute.For<Func<ExecuteCommandParams, Task>>();
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a",
+                                Arguments = JArray.FromObject(new object[] {1, "2", false})
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand(commandb, new ExecuteCommandRegistrationOptions() {
+                        Commands = new Container<string>("execute-b")
+                    });
+
+                    options.OnExecuteCommand(commandc, new ExecuteCommandRegistrationOptions() {
+                        Commands = new Container<string>("execute-c")
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().ThrowAsync<MethodNotSupportedException>();
+
+            await commandc.Received(0).Invoke(Arg.Any<ExecuteCommandParams>());
+            await commandb.Received(0).Invoke(Arg.Any<ExecuteCommandParams>());
+        }
+    }
+}

--- a/test/Lsp.Tests/Integration/ExecuteCommandTests.cs
+++ b/test/Lsp.Tests/Integration/ExecuteCommandTests.cs
@@ -407,7 +407,7 @@ namespace Lsp.Tests.Integration
                         return Task.FromResult(new CompletionList(new CompletionItem() {
                             Command = new Command() {
                                 Name = "execute-a",
-                                Arguments = JArray.FromObject(new object[] {})
+                                Arguments = JArray.FromObject(new object[] { })
                             }
                         }));
                     }, new CompletionRegistrationOptions() {
@@ -439,7 +439,7 @@ namespace Lsp.Tests.Integration
                         return Task.FromResult(new CompletionList(new CompletionItem() {
                             Command = new Command() {
                                 Name = "execute-a",
-                                Arguments = JArray.FromObject(new object[] {  })
+                                Arguments = JArray.FromObject(new object[] { })
                             }
                         }));
                     }, new CompletionRegistrationOptions() {
@@ -506,7 +506,7 @@ namespace Lsp.Tests.Integration
                         return Task.FromResult(new CompletionList(new CompletionItem() {
                             Command = new Command() {
                                 Name = "execute-a",
-                                Arguments = JArray.FromObject(new object[] {  })
+                                Arguments = JArray.FromObject(new object[] { })
                             }
                         }));
                     }, new CompletionRegistrationOptions() {
@@ -541,7 +541,7 @@ namespace Lsp.Tests.Integration
                         return Task.FromResult(new CompletionList(new CompletionItem() {
                             Command = new Command() {
                                 Name = "execute-a",
-                                Arguments = JArray.FromObject(new object[] {  })
+                                Arguments = JArray.FromObject(new object[] { })
                             }
                         }));
                     }, new CompletionRegistrationOptions() {
@@ -577,7 +577,208 @@ namespace Lsp.Tests.Integration
                         return Task.FromResult(new CompletionList(new CompletionItem() {
                             Command = new Command() {
                                 Name = "execute-a",
-                                Arguments = JArray.FromObject(new object[] {  })
+                                Arguments = JArray.FromObject(new object[] { })
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string, bool, Range, Dictionary<string, string>, Guid>("execute-a", (i, s, arg3, arg4, arg5, arg6) => {
+                        i.Should().Be(default);
+                        s.Should().Be(default);
+                        arg3.Should().Be(default);
+                        arg4.Should().Be(default);
+                        arg5.Should().BeNull();
+                        arg6.Should().BeEmpty();
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_1_Null_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a"
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int>("execute-a", (i) => {
+                        i.Should().Be(default);
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_2_Null_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a"
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string>("execute-a", (i, s) => {
+                        i.Should().Be(default);
+                        s.Should().Be(default);
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_3_Null_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a"
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string, bool>("execute-a", (i, s, arg3) => {
+                        i.Should().Be(default);
+                        s.Should().Be(default);
+                        arg3.Should().Be(default);
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_4_Null_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a"
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string, bool, Range>("execute-a", (i, s, arg3, arg4) => {
+                        i.Should().Be(default);
+                        s.Should().Be(default);
+                        arg3.Should().Be(default);
+                        arg4.Should().Be(default);
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_5_Null_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a"
+                            }
+                        }));
+                    }, new CompletionRegistrationOptions() {
+                    });
+
+                    options.OnExecuteCommand<int, string, bool, Range, Dictionary<string, string>>("execute-a", (i, s, arg3, arg4, arg5) => {
+                        i.Should().Be(default);
+                        s.Should().Be(default);
+                        arg3.Should().Be(default);
+                        arg4.Should().Be(default);
+                        arg5.Should().BeNull();
+
+                        return Task.CompletedTask;
+                    });
+                });
+
+            var items = await client.RequestCompletion(new CompletionParams());
+
+            var item = items.Items.Single();
+
+            item.Command.Should().NotBeNull();
+
+            Func<Task> action = () => client.ExecuteCommand(item.Command);
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Should_Execute_6_Null_Args()
+        {
+            var (client, server) = await Initialize(
+                options => { }, options => {
+                    options.OnCompletion(x => {
+                        return Task.FromResult(new CompletionList(new CompletionItem() {
+                            Command = new Command() {
+                                Name = "execute-a"
                             }
                         }));
                     }, new CompletionRegistrationOptions() {

--- a/test/Lsp.Tests/Integration/InitializationTests.cs
+++ b/test/Lsp.Tests/Integration/InitializationTests.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using OmniSharp.Extensions.JsonRpc.Testing;
+using OmniSharp.Extensions.LanguageProtocol.Testing;
+using OmniSharp.Extensions.LanguageServer.Client;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
+using OmniSharp.Extensions.LanguageServer.Server;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Lsp.Tests.Integration
+{
+    public class InitializationTests : LanguageProtocolTestBase
+    {
+        public InitializationTests(ITestOutputHelper outputHelper) : base(new JsonRpcTestOptions().ConfigureForXUnit(outputHelper)) { }
+
+        [Fact]
+        public async Task Logs_should_be_allowed_during_startup()
+        {
+            var (client, server) = await Initialize(ConfigureClient, ConfigureServer);
+
+            _logs.Should().HaveCount(2);
+            _logs.Should().ContainInOrder("OnInitialize", "OnInitialized");
+        }
+
+        private List<string> _logs = new List<string>();
+
+        private void ConfigureClient(LanguageClientOptions options)
+        {
+            options.OnLogMessage(log => {
+                _logs.Add(log.Message);
+            });
+        }
+
+        private void ConfigureServer(LanguageServerOptions options)
+        {
+            options.OnInitialize((server, request, token) => {
+                server.Window.LogInfo("OnInitialize");
+                return Task.CompletedTask;
+            });
+            options.OnInitialized((server, request, response, token) => {
+                server.Window.LogInfo("OnInitialized");
+                return Task.CompletedTask;
+            });
+        }
+    }
+}

--- a/test/Lsp.Tests/Integration/RequestCancellationTests.cs
+++ b/test/Lsp.Tests/Integration/RequestCancellationTests.cs
@@ -13,7 +13,6 @@ using OmniSharp.Extensions.LanguageServer.Client;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Window;
 using OmniSharp.Extensions.LanguageServer.Server;
 using Xunit;
 using Xunit.Abstractions;
@@ -140,41 +139,6 @@ namespace Lsp.Tests.Integration
                 return new CompletionList();
             }, new CompletionRegistrationOptions());
             options.OnDidChangeTextDocument(async x => { await Task.Delay(20); }, new TextDocumentChangeRegistrationOptions());
-        }
-    }
-
-    public class InitializationTests : LanguageProtocolTestBase
-    {
-        public InitializationTests(ITestOutputHelper outputHelper) : base(new JsonRpcTestOptions().ConfigureForXUnit(outputHelper)) { }
-
-        [Fact]
-        public async Task Logs_should_be_allowed_during_startup()
-        {
-            var (client, server) = await Initialize(ConfigureClient, ConfigureServer);
-
-            _logs.Should().HaveCount(2);
-            _logs.Should().ContainInOrder("OnInitialize", "OnInitialized");
-        }
-
-        private List<string> _logs = new List<string>();
-
-        private void ConfigureClient(LanguageClientOptions options)
-        {
-            options.OnLogMessage(log => {
-                _logs.Add(log.Message);
-            });
-        }
-
-        private void ConfigureServer(LanguageServerOptions options)
-        {
-            options.OnInitialize((server, request, token) => {
-                server.Window.LogInfo("OnInitialize");
-                return Task.CompletedTask;
-            });
-            options.OnInitialized((server, request, response, token) => {
-                server.Window.LogInfo("OnInitialized");
-                return Task.CompletedTask;
-            });
         }
     }
 }

--- a/test/Lsp.Tests/LspRequestRouterTests.cs
+++ b/test/Lsp.Tests/LspRequestRouterTests.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 using ISerializer = OmniSharp.Extensions.LanguageServer.Protocol.Serialization.ISerializer;
 using Serializer = OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Serializer;
 using System.Reactive.Disposables;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.General;
@@ -267,11 +268,13 @@ namespace Lsp.Tests
                 .Handle(Arg.Any<CodeLensParams>(), Arg.Any<CancellationToken>())
                 .Returns(new CodeLensContainer());
 
+            var tdi = new TextDocumentIdentifiers();
             var collection =
-                new SharedHandlerCollection(SupportedCapabilitiesFixture.AlwaysTrue, new TextDocumentIdentifiers())
+                new SharedHandlerCollection(SupportedCapabilitiesFixture.AlwaysTrue, tdi)
                     {textDocumentSyncHandler, textDocumentSyncHandler2, codeActionHandler, codeActionHandler2};
             AutoSubstitute.Provide<IHandlerCollection>(collection);
             AutoSubstitute.Provide<IEnumerable<ILspHandlerDescriptor>>(collection);
+            AutoSubstitute.Provide<IHandlerMatcher>(new TextDocumentMatcher(LoggerFactory.CreateLogger<TextDocumentMatcher>(), tdi));
             var mediator = AutoSubstitute.Resolve<LspRequestRouter>();
 
             var id = Guid.NewGuid().ToString();


### PR DESCRIPTION
* Fixes a bug where if only one command is registered, it's called even if the command that is being executed has a different name.
* Fixes a bug where only one command handler could be registered at a time (effectively).
* Adds a method for executing a `Command` directory on the client (retrieved from completions for example)
* Adds `OnExecuteCommand<T[, [T2, [T3, [T4, [T5, [T6]]]]]>`
  * These handlers will automatically deserialize the arguments from the arguments JArray
