### PR TITLE
Added support for custom handlers that can replace / work side-by-side with existing handlers

### DIFF
--- a/src/Client/LanguageClientRegistrationManager.cs
+++ b/src/Client/LanguageClientRegistrationManager.cs
@@ -65,16 +65,16 @@ namespace OmniSharp.Extensions.LanguageServer.Client
                 serverCapabilities
             ))
             {
-                var descriptor = LspHandlerTypeDescriptorHelper.GetHandlerTypeForRegistrationOptions(registrationOptions);
-                if (descriptor == null)
+                var method = LspHandlerTypeDescriptorHelper.GetMethodForRegistrationOptions(registrationOptions);
+                if (method == null)
                 {
-                    _logger.LogWarning("Unable to find handler type descriptor for the given {@RegistrationOptions}", registrationOptions);
+                    _logger.LogWarning("Unable to find method for given {@RegistrationOptions}", registrationOptions);
                     continue;
                 }
 
                 var reg = new Registration {
                     Id = registrationOptions.Id,
-                    Method = descriptor.Method,
+                    Method = method,
                     RegisterOptions = registrationOptions
                 };
                 _registrations.AddOrUpdate(registrationOptions.Id, x => reg, (a, b) => reg);
@@ -91,8 +91,8 @@ namespace OmniSharp.Extensions.LanguageServer.Client
                    .Workspace
             ))
             {
-                var descriptor = LspHandlerTypeDescriptorHelper.GetHandlerTypeForRegistrationOptions(registrationOptions);
-                if (descriptor == null)
+                var method = LspHandlerTypeDescriptorHelper.GetMethodForRegistrationOptions(registrationOptions);
+                if (method == null)
                 {
                     // TODO: Log this
                     continue;
@@ -100,7 +100,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client
 
                 var reg = new Registration {
                     Id = registrationOptions.Id,
-                    Method = descriptor.Method,
+                    Method = method,
                     RegisterOptions = registrationOptions
                 };
                 _registrations.AddOrUpdate(registrationOptions.Id, x => reg, (a, b) => reg);
@@ -117,8 +117,8 @@ namespace OmniSharp.Extensions.LanguageServer.Client
 
         private void Register(Registration registration)
         {
-            var typeDescriptor = LspHandlerTypeDescriptorHelper.GetHandlerTypeDescriptor(registration.Method);
-            if (typeDescriptor == null)
+            var registrationType = LspHandlerTypeDescriptorHelper.GetRegistrationType(registration.Method);
+            if (registrationType == null)
             {
                 _registrations.AddOrUpdate(registration.Id, x => registration, (a, b) => registration);
                 return;
@@ -128,7 +128,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client
                 Id = registration.Id,
                 Method = registration.Method,
                 RegisterOptions = registration.RegisterOptions is JToken token
-                    ? token.ToObject(typeDescriptor.RegistrationType, _serializer.JsonSerializer)
+                    ? token.ToObject(registrationType, _serializer.JsonSerializer)
                     : registration.RegisterOptions
             };
             _registrations.AddOrUpdate(deserializedRegistration.Id, x => deserializedRegistration, (a, b) => deserializedRegistration);

--- a/src/Dap.Protocol/Requests/IAttachHandler.cs
+++ b/src/Dap.Protocol/Requests/IAttachHandler.cs
@@ -22,7 +22,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
         public abstract Task<AttachResponse> Handle(T request, CancellationToken cancellationToken);
     }
 
-    public abstract class AttachHandler : AttachHandlerBase<AttachRequestArguments>
+    public abstract class AttachHandler : AttachHandlerBase<AttachRequestArguments>, IAttachHandler
     {
     }
 }

--- a/src/Dap.Protocol/Requests/ILaunchHandler.cs
+++ b/src/Dap.Protocol/Requests/ILaunchHandler.cs
@@ -22,7 +22,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol.Requests
         public abstract Task<LaunchResponse> Handle(T request, CancellationToken cancellationToken);
     }
 
-    public abstract class LaunchHandler : LaunchHandlerBase<LaunchRequestArguments>
+    public abstract class LaunchHandler : LaunchHandlerBase<LaunchRequestArguments>, ILaunchHandler
     {
     }
 }

--- a/src/Dap.Protocol/Serialization/OptionalAttribute.cs
+++ b/src/Dap.Protocol/Serialization/OptionalAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace OmniSharp.Extensions.DebugAdapter.Protocol.Serialization
 {
     [AttributeUsage(AttributeTargets.Property)]
-    internal class OptionalAttribute : Attribute
+    public class OptionalAttribute : Attribute
     {
     }
 }

--- a/src/Dap.Shared/DebugAdapterHandlerCollection.cs
+++ b/src/Dap.Shared/DebugAdapterHandlerCollection.cs
@@ -122,7 +122,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Shared
 
         private HandlerDescriptor GetDescriptor(string method, Type handlerType, IJsonRpcHandler handler, JsonRpcHandlerOptions options)
         {
-            var typeDescriptor = HandlerTypeDescriptorHelper.GetHandlerTypeDescriptor(method);
+            var typeDescriptor = HandlerTypeDescriptorHelper.GetHandlerTypeDescriptor(handlerType);
             var @interface = HandlerTypeDescriptorHelper.GetHandlerInterface(handlerType);
 
             return GetDescriptor(method, handlerType, handler, options, typeDescriptor, @interface);

--- a/src/Protocol/Models/ExecuteCommandParams.cs
+++ b/src/Protocol/Models/ExecuteCommandParams.cs
@@ -6,7 +6,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
 {
     [Method(WorkspaceNames.ExecuteCommand, Direction.ClientToServer)]
-    public class ExecuteCommandParams : IRequest, IWorkDoneProgressParams
+    public class ExecuteCommandParams : IRequest, IWorkDoneProgressParams, IExecuteCommandParams
     {
         /// <summary>
         /// The identifier of the actual command handler.

--- a/src/Protocol/Models/IExecuteCommandParams.cs
+++ b/src/Protocol/Models/IExecuteCommandParams.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
+{
+    public interface IExecuteCommandParams
+    {
+        /// <summary>
+        /// The identifier of the actual command handler.
+        /// </summary>
+        string Command { get; set; }
+
+        /// <summary>
+        /// Arguments that the command should be invoked with.
+        /// </summary>
+        JArray Arguments { get; set; }
+    }
+}

--- a/src/Protocol/Serialization/OptionalAttribute.cs
+++ b/src/Protocol/Serialization/OptionalAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization
 {
     [AttributeUsage(AttributeTargets.Property)]
-    internal class OptionalAttribute : Attribute
+    public class OptionalAttribute : Attribute
     {
     }
 }

--- a/src/Server/Matchers/ExecuteCommandMatcher.cs
+++ b/src/Server/Matchers/ExecuteCommandMatcher.cs
@@ -21,7 +21,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Matchers
         /// <returns></returns>
         public IEnumerable<ILspHandlerDescriptor> FindHandler(object parameters, IEnumerable<ILspHandlerDescriptor> descriptors)
         {
-            if (parameters is ExecuteCommandParams executeCommandParams)
+            if (parameters is IExecuteCommandParams executeCommandParams)
             {
                 _logger.LogTrace("Registration options {OptionsName}", executeCommandParams.GetType().FullName);
                 foreach (var descriptor in descriptors)

--- a/src/Shared/LspRequestRouter.cs
+++ b/src/Shared/LspRequestRouter.cs
@@ -71,7 +71,7 @@ namespace OmniSharp.Extensions.LanguageServer.Shared
             // execute command is a special case
             // if no command was found to execute this must error
             // this is not great coupling but other options require api changes
-            if (paramsValue is ExecuteCommandParams) return new RequestDescriptor<ILspHandlerDescriptor>();
+            if (paramsValue is IExecuteCommandParams) return new RequestDescriptor<ILspHandlerDescriptor>();
             if (lspHandlerDescriptors.Count > 0) return new RequestDescriptor<ILspHandlerDescriptor>(lspHandlerDescriptors);
             return new RequestDescriptor<ILspHandlerDescriptor>();
         }

--- a/src/Shared/SharedHandlerCollection.cs
+++ b/src/Shared/SharedHandlerCollection.cs
@@ -215,7 +215,7 @@ namespace OmniSharp.Extensions.LanguageServer.Shared
 
         private LspHandlerDescriptor GetDescriptor(string method, Type handlerType, IJsonRpcHandler handler, JsonRpcHandlerOptions options)
         {
-            var typeDescriptor = LspHandlerTypeDescriptorHelper.GetHandlerTypeDescriptor(method);
+            var typeDescriptor = LspHandlerTypeDescriptorHelper.GetHandlerTypeDescriptor(handlerType);
             var @interface = HandlerTypeDescriptorHelper.GetHandlerInterface(handlerType);
             var registrationType = typeDescriptor?.RegistrationType ??
                                    HandlerTypeDescriptorHelper.UnwrapGenericType(typeof(IRegistration<>), handlerType);

--- a/test/Lsp.Tests/Integration/OverrideHandlerTests.cs
+++ b/test/Lsp.Tests/Integration/OverrideHandlerTests.cs
@@ -1,0 +1,112 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MediatR;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.JsonRpc.Testing;
+using OmniSharp.Extensions.LanguageProtocol.Testing;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
+using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Lsp.Tests.Integration
+{
+    public class OverrideHandlerTests : LanguageProtocolTestBase
+    {
+        public OverrideHandlerTests(ITestOutputHelper testOutputHelper) : base(new JsonRpcTestOptions().ConfigureForXUnit(testOutputHelper))
+        {
+        }
+
+        [Fact]
+        public async Task Should_Support_Custom_Execute_Command_Handlers()
+        {
+            var (client, server) = await Initialize(
+                options => {
+
+                }, options => {
+                    options.AddHandler<CustomExecuteCommandHandler>();
+                }
+            );
+
+            var response = await client.SendRequest(
+                new CustomExecuteCommandParams() {
+                    Command = "mycommand",
+                }, CancellationToken
+            );
+
+            response.Should().BeEquivalentTo(JToken.FromObject(new { someValue = "custom" }));
+        }
+
+        [Fact]
+        public async Task Should_Support_Mixed_Execute_Command_Handlers()
+        {
+            var (client, server) = await Initialize(
+                options => {
+
+                }, options => {
+                    options.AddHandler<CustomExecuteCommandHandler>();
+                    options.OnExecuteCommand<JObject>("myothercommand", (a, ct) => Unit.Task);
+                }
+            );
+
+            var normalResponse = await client.SendRequest(
+                new ExecuteCommandParams() {
+                    Command = "myothercommand",
+                    Arguments = new JArray(new JObject())
+                }, CancellationToken
+            );
+
+            var customResponse = await client.SendRequest(
+                new CustomExecuteCommandParams() {
+                    Command = "mycommand",
+                }, CancellationToken
+            );
+
+            normalResponse.Should().Be(Unit.Value);
+            customResponse.Should().BeEquivalentTo(JToken.FromObject(new { someValue = "custom" }));
+        }
+
+        [Method(WorkspaceNames.ExecuteCommand)]
+        public class CustomExecuteCommandHandler : IJsonRpcRequestHandler<CustomExecuteCommandParams, JToken>, IRegistration<ExecuteCommandRegistrationOptions>, ICapability<ExecuteCommandCapability>
+        {
+            private ExecuteCommandCapability _capability;
+            private readonly ExecuteCommandRegistrationOptions _executeCommandRegistrationOptions = new ExecuteCommandRegistrationOptions() {
+                WorkDoneProgress = true,
+                Commands = new Container<string>("mycommand")
+            };
+
+            public Task<JToken> Handle(CustomExecuteCommandParams request, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(JToken.FromObject(new { someValue = "custom" }));
+            }
+
+            public ExecuteCommandRegistrationOptions GetRegistrationOptions() { return _executeCommandRegistrationOptions; }
+            public void SetCapability(ExecuteCommandCapability capability) => _capability = capability;
+        }
+
+        [Method(WorkspaceNames.ExecuteCommand, Direction.ClientToServer)]
+        public class CustomExecuteCommandParams : IRequest<JToken>, IWorkDoneProgressParams, IExecuteCommandParams // required for routing
+        {
+            /// <summary>
+            /// The identifier of the actual command handler.
+            /// </summary>
+            public string Command { get; set; }
+
+            /// <summary>
+            /// Arguments that the command should be invoked with.
+            /// </summary>
+            [Optional]
+            public JArray Arguments { get; set; }
+
+            /// <inheritdoc />
+            [Optional]
+            public ProgressToken WorkDoneToken { get; set; }
+        }
+    }
+}

--- a/test/Lsp.Tests/Lsp.Tests.csproj
+++ b/test/Lsp.Tests/Lsp.Tests.csproj
@@ -7,8 +7,6 @@
     <ItemGroup>
         <None Remove="**\*.json" />
         <EmbeddedResource Include="**\*.json" />
-        <EmbeddedResource Remove="Integration\**" />
-        <None Remove="Integration\**" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\JsonRpc.Generators\JsonRpc.Generators.csproj" OutputItemType="CodeGenerationRoslynPlugin" />

--- a/test/Lsp.Tests/Lsp.Tests.csproj
+++ b/test/Lsp.Tests/Lsp.Tests.csproj
@@ -7,6 +7,8 @@
     <ItemGroup>
         <None Remove="**\*.json" />
         <EmbeddedResource Include="**\*.json" />
+        <EmbeddedResource Remove="Integration\**" />
+        <None Remove="Integration\**" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\JsonRpc.Generators\JsonRpc.Generators.csproj" OutputItemType="CodeGenerationRoslynPlugin" />
@@ -14,8 +16,5 @@
         <ProjectReference Include="..\..\src\Server\Server.csproj" />
         <ProjectReference Include="..\..\src\Testing\Testing.csproj" />
         <ProjectReference Include="..\TestingUtils\TestingUtils.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-        <Folder Include="obj\Release\netcoreapp3.1\" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Added support for class based handlers to HandlerTypeDescriptorHelper/LspHandlerTypeDescriptorHelper.
Added unit test demonstrating a custom params / handler pair for Execute Command
Made the OptionalAttribute's public
Added IExecuteCommandParams to allow for custom command execution handlers to work correctly.

fixes: #308

