### PR TITLE
Remove jank

### DIFF
--- a/test/Generation.Tests/GenerationHelpers.cs
+++ b/test/Generation.Tests/GenerationHelpers.cs
@@ -107,7 +107,9 @@ namespace Generation.Tests
 
             var driver = new CSharpGeneratorDriver(compilation.SyntaxTrees[0].Options, ImmutableArray.Create(generator), default, ImmutableArray<AdditionalText>.Empty);
 
-            driver.RunFullGeneration(compilation, out var outputCompilation, out _);
+            driver.RunFullGeneration(compilation, out var outputCompilation, out diagnostics);
+            // Assert.Empty(diagnostics.Where(x => x.Severity >= DiagnosticSeverity.Warning));
+
             // the syntax tree added by the generator will be the last one in the compilation
             return outputCompilation.SyntaxTrees.Last();
         }

--- a/test/Generation.Tests/GenerationHelpers.cs
+++ b/test/Generation.Tests/GenerationHelpers.cs
@@ -103,55 +103,13 @@ namespace Generation.Tests
             var diagnostics = compilation.GetDiagnostics();
             Assert.Empty(diagnostics.Where(x => x.Severity >= DiagnosticSeverity.Warning));
 
-            // TODO: fix this junk
-            var optionsProvider = Substitute.For<AnalyzerConfigOptionsProvider>();
+            ISourceGenerator generator = new T();
 
-            var generator = new T();
-            var receiver = new GenerateHandlerMethodsGenerator.SyntaxReceiver();
-            var visitor = new NotSureWhatToCallYou(receiver);
+            var driver = new CSharpGeneratorDriver(compilation.SyntaxTrees[0].Options, ImmutableArray.Create(generator), default, ImmutableArray<AdditionalText>.Empty);
 
-            foreach (var compilationSyntaxTree in compilation.SyntaxTrees)
-            {
-                visitor.Visit(compilationSyntaxTree.GetRoot());
-            }
-
-            //, ISyntaxReceiver? syntaxReceiver, DiagnosticBag diagnostics, CancellationToken cancellationToken = default
-            var context = (SourceGeneratorContext) Activator.CreateInstance(
-                typeof(SourceGeneratorContext),
-                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.CreateInstance,
-                null,
-                new object[] {
-                    compilation,
-                    ImmutableArray<AdditionalText>.Empty,
-                    optionsProvider,
-                    // This needs to be generic somehow...
-                    receiver,
-                    // TODO: dynamic proxy... sigh
-                    Activator.CreateInstance(
-                        typeof(SourceGeneratorContext).Assembly.GetType("Microsoft.CodeAnalysis.DiagnosticBag")!,
-                        Array.Empty<object>()
-                    ),
-                    CancellationToken.None
-                },
-                CultureInfo.InvariantCulture
-            );
-
-            generator.Execute(context);
-
-            // WARNING JANK AHEAD
-            var additionalSourcesProperty = context.GetType().GetProperty("AdditionalSources", BindingFlags.NonPublic | BindingFlags.Instance);
-            var additionalSources = additionalSourcesProperty.GetValue(context);
-            var toImmutableAndFreeMethod = additionalSources.GetType().GetMethod("ToImmutableAndFree", BindingFlags.NonPublic | BindingFlags.Instance);
-            var generatedSourceTextArray = toImmutableAndFreeMethod.Invoke(additionalSources, Array.Empty<object>()) as IEnumerable;
-            var generatedSourceTextType = typeof(SourceGeneratorContext).Assembly.GetType("Microsoft.CodeAnalysis.GeneratedSourceText");
-            var generatedSourceTextProperty = generatedSourceTextType.GetProperty("Text");
-            var sourceTexts = generatedSourceTextArray
-                             .OfType<object>()
-                             .Select(z => generatedSourceTextProperty.GetValue(z) as SourceText)
-                             .ToArray();
-
-            var resultText = sourceTexts.Single();
-            return CSharpSyntaxTree.ParseText(resultText);
+            driver.RunFullGeneration(compilation, out var outputCompilation, out _);
+            // the syntax tree added by the generator will be the last one in the compilation
+            return outputCompilation.SyntaxTrees.Last();
         }
 
         public static Project CreateProject(params string[] sources)


### PR DESCRIPTION
Using GeneratorDriver means you don't need all of that jank.

This is slightly different because it will create a compilation, which the previous code didn't. I've left commented out the line that validates that resulting compilation because three of the tests fail with it left in, but I don't know enough about what the generator is supposed to do to know if thats valid or not.

Feel free to throw this away if it's not helpful :)