### PR TITLE
Fixed case where dynamic registration would fail if Register is called before Initialize

### DIFF
--- a/src/Server/LanguageServer.cs
+++ b/src/Server/LanguageServer.cs
@@ -332,15 +332,15 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             var windowCapabilities = ClientSettings.Capabilities.Window ??= new WindowClientCapabilities();
             WorkDoneManager.Initialized(windowCapabilities);
 
-            {
+            _disposable.Add(
                 LanguageServerHelpers.RegisterHandlers(
-                    _initializingTask,
+                    _initializeComplete.Select(z => System.Reactive.Unit.Default),
                     Client,
                     WorkDoneManager,
                     _supportedCapabilities,
                     _collection
-                );
-            }
+                )
+            );
 
             await LanguageProtocolEventingHelper.Run(
                 _initializeDelegates,
@@ -508,7 +508,8 @@ namespace OmniSharp.Extensions.LanguageServer.Server
                 LanguageServerHelpers.InitHandlers(this, result);
             }
 
-            return LanguageServerHelpers.RegisterHandlers(_initializingTask, Client, WorkDoneManager, _supportedCapabilities, result);
+            return LanguageServerHelpers.RegisterHandlers(_initializeComplete.Select(z => System.Reactive.Unit.Default), Client, WorkDoneManager, _supportedCapabilities, result);
+//            return LanguageServerHelpers.RegisterHandlers(_initializingTask ?? _initializeComplete.ToTask(), Client, WorkDoneManager, _supportedCapabilities, result);
         }
 
         object IServiceProvider.GetService(Type serviceType) => Services.GetService(serviceType);

--- a/test/Lsp.Tests/Integration/WorkspaceFolderTests.cs
+++ b/test/Lsp.Tests/Integration/WorkspaceFolderTests.cs
@@ -26,6 +26,8 @@ namespace Lsp.Tests.Integration
     {
         public WorkspaceFolderTests(ITestOutputHelper outputHelper) : base(
             new JsonRpcTestOptions().ConfigureForXUnit(outputHelper, LogEventLevel.Verbose)
+                                    .WithTimeout(TimeSpan.FromMilliseconds(1200))
+                                    .WithWaitTime(TimeSpan.FromMilliseconds(600))
         )
         {
         }


### PR DESCRIPTION
Turns out there is a race condition anyway where supported capabilities aren't loaded yet, and wouldn't be detected.