### PR TITLE
Use ConfigureAwait when booting up input stream.

### DIFF
--- a/src/Client/LanguageClient.cs
+++ b/src/Client/LanguageClient.cs
@@ -97,7 +97,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client
         public static async Task<LanguageClient> From(LanguageClientOptions options, IServiceProvider outerServiceProvider, CancellationToken cancellationToken)
         {
             var server = Create(options, outerServiceProvider);
-            await server.Initialize(cancellationToken);
+            await server.Initialize(cancellationToken).ConfigureAwait(false);
             return server;
         }
 
@@ -261,10 +261,10 @@ namespace OmniSharp.Extensions.LanguageServer.Client
                 (handler, ct) => handler.OnInitialize(this, @params, ct),
                 _concurrency,
                 token
-            );
+            ).ConfigureAwait(false);
 
             _connection.Open();
-            var serverParams = await SendRequest(ClientSettings, token);
+            var serverParams = await SendRequest(ClientSettings, token).ConfigureAwait(false);
             _receiver.Initialized();
 
             ServerSettings = serverParams;
@@ -276,7 +276,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client
                 (handler, ct) => handler.OnInitialized(this, @params, serverParams, ct),
                 _concurrency,
                 token
-            );
+            ).ConfigureAwait(false);
 
             // post init
 
@@ -290,7 +290,7 @@ namespace OmniSharp.Extensions.LanguageServer.Client
                 (handler, ct) => handler.OnStarted(this, ct),
                 _concurrency,
                 token
-            );
+            ).ConfigureAwait(false);
 
             _instanceHasStarted.Started = true;
 
@@ -361,11 +361,11 @@ namespace OmniSharp.Extensions.LanguageServer.Client
         {
             if (_connection.IsOpen)
             {
-                await this.RequestShutdown();
+                await this.RequestShutdown().ConfigureAwait(false);
                 this.SendExit();
             }
 
-            await _connection.StopAsync();
+            await _connection.StopAsync().ConfigureAwait(false);
             _connection.Dispose();
         }
 

--- a/src/Dap.Server/DebugAdapterServer.cs
+++ b/src/Dap.Server/DebugAdapterServer.cs
@@ -78,7 +78,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Server
         public static async Task<DebugAdapterServer> From(DebugAdapterServerOptions options, IServiceProvider outerServiceProvider, CancellationToken cancellationToken)
         {
             var server = Create(options, outerServiceProvider);
-            await server.Initialize(cancellationToken);
+            await server.Initialize(cancellationToken).ConfigureAwait(false);
             return server;
         }
 
@@ -125,7 +125,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Server
             {
                 try
                 {
-                    await _initializingTask;
+                    await _initializingTask.ConfigureAwait(false);
                 }
                 catch
                 {
@@ -139,7 +139,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Server
             try
             {
                 _initializingTask = _initializeComplete.ToTask(token);
-                await _initializingTask;
+                await _initializingTask.ConfigureAwait(false);
                 await DebugAdapterEventingHelper.Run(
                     _startedDelegates,
                     (handler, ct) => handler(this, ct),
@@ -147,7 +147,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Server
                     (handler, ct) => handler.OnStarted(this, ct),
                     _concurrency,
                     token
-                );
+                ).ConfigureAwait(false);
                 _instanceHasStarted.Started = true;
 
                 this.SendDebugAdapterInitialized(new InitializedEvent());
@@ -178,7 +178,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Server
                 (handler, ct) => handler.OnInitialize(this, request, ct),
                 _concurrency,
                 cancellationToken
-            );
+            ).ConfigureAwait(false);
 
             _receiver.Initialized();
 
@@ -230,7 +230,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Server
                 (handler, ct) => handler.OnInitialized(this, request, response, ct),
                 _concurrency,
                 cancellationToken
-            );
+            ).ConfigureAwait(false);
 
             _initializeComplete.OnNext(response);
             _initializeComplete.OnCompleted();

--- a/src/Dap.Shared/DapResponseRouter.cs
+++ b/src/Dap.Shared/DapResponseRouter.cs
@@ -117,7 +117,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Shared
 
                 try
                 {
-                    var result = await tcs.Task;
+                    var result = await tcs.Task.ConfigureAwait(false);
                     if (typeof(TResponse) == typeof(Unit))
                     {
                         return (TResponse) (object) Unit.Value;
@@ -131,7 +131,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Shared
                 }
             }
 
-            public async Task ReturningVoid(CancellationToken cancellationToken) => await Returning<Unit>(cancellationToken);
+            public async Task ReturningVoid(CancellationToken cancellationToken) => await Returning<Unit>(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Dap.Testing/DebugAdapterProtocolTestBase.cs
+++ b/src/Dap.Testing/DebugAdapterProtocolTestBase.cs
@@ -80,7 +80,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Testing
             return await Observable.FromAsync(_client.Initialize).ForkJoin(
                 Observable.FromAsync(_server.Initialize),
                 (a, b) => ( _client, _server )
-            ).ToTask(CancellationToken);
+            ).ToTask(CancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Dap.Testing/DebugAdapterServerTestBase.cs
+++ b/src/Dap.Testing/DebugAdapterServerTestBase.cs
@@ -46,7 +46,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Testing
 
             Disposable.Add(_client);
 
-            await _client.Initialize(CancellationToken);
+            await _client.Initialize(CancellationToken).ConfigureAwait(false);
 
             return _client;
         }

--- a/src/JsonRpc.Testing/JsonRpcServerTestBase.cs
+++ b/src/JsonRpc.Testing/JsonRpcServerTestBase.cs
@@ -71,7 +71,7 @@ namespace OmniSharp.Extensions.JsonRpc.Testing
                 }, CancellationToken
             );
 
-            await Task.WhenAll(clientTask, serverTask);
+            await Task.WhenAll(clientTask, serverTask).ConfigureAwait(false);
             _client = clientTask.Result;
             _server = serverTask.Result;
 

--- a/src/JsonRpc.Testing/SettlePipeline.cs
+++ b/src/JsonRpc.Testing/SettlePipeline.cs
@@ -16,7 +16,7 @@ namespace OmniSharp.Extensions.JsonRpc.Testing
             _settler.OnStartRequest();
             try
             {
-                return await next();
+                return await next().ConfigureAwait(false);
             }
             finally
             {

--- a/src/JsonRpc/DelegatingHandlers.cs
+++ b/src/JsonRpc/DelegatingHandlers.cs
@@ -39,7 +39,7 @@ namespace OmniSharp.Extensions.JsonRpc
             async Task<Unit> IRequestHandler<TParams, Unit>.
                 Handle(TParams request, CancellationToken cancellationToken)
             {
-                await _handler(request, cancellationToken);
+                await _handler(request, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
         }
@@ -62,7 +62,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
             async Task<Unit> IRequestHandler<TParams, Unit>.Handle(TParams request, CancellationToken cancellationToken)
             {
-                await _handler(request, cancellationToken);
+                await _handler(request, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
         }

--- a/src/JsonRpc/DelegatingJsonNotificationHandler.cs
+++ b/src/JsonRpc/DelegatingJsonNotificationHandler.cs
@@ -14,7 +14,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
         public async Task<Unit> Handle(DelegatingNotification<JToken> request, CancellationToken cancellationToken)
         {
-            await _handler.Invoke(request.Value, cancellationToken);
+            await _handler.Invoke(request.Value, cancellationToken).ConfigureAwait(false);
             return Unit.Value;
         }
     }

--- a/src/JsonRpc/DelegatingJsonRequestHandler.cs
+++ b/src/JsonRpc/DelegatingJsonRequestHandler.cs
@@ -13,7 +13,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
         public async Task<JToken> Handle(DelegatingRequest<JToken> request, CancellationToken cancellationToken)
         {
-            var response = await _handler.Invoke(request.Value, cancellationToken);
+            var response = await _handler.Invoke(request.Value, cancellationToken).ConfigureAwait(false);
             return response;
         }
     }

--- a/src/JsonRpc/DelegatingNotificationHandler.cs
+++ b/src/JsonRpc/DelegatingNotificationHandler.cs
@@ -18,7 +18,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
         public async Task<Unit> Handle(DelegatingNotification<T> request, CancellationToken cancellationToken)
         {
-            await _handler.Invoke(request.Value.ToObject<T>(_serializer.JsonSerializer), cancellationToken);
+            await _handler.Invoke(request.Value.ToObject<T>(_serializer.JsonSerializer), cancellationToken).ConfigureAwait(false);
             return Unit.Value;
         }
     }

--- a/src/JsonRpc/DelegatingRequestHandler.cs
+++ b/src/JsonRpc/DelegatingRequestHandler.cs
@@ -18,7 +18,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
         public async Task<JToken> Handle(DelegatingRequest<T> request, CancellationToken cancellationToken)
         {
-            var response = await _handler.Invoke(request.Value.ToObject<T>(_serializer.JsonSerializer), cancellationToken);
+            var response = await _handler.Invoke(request.Value.ToObject<T>(_serializer.JsonSerializer), cancellationToken).ConfigureAwait(false);
             return JToken.FromObject(response, _serializer.JsonSerializer);
         }
     }
@@ -36,7 +36,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
         public async Task<JToken> Handle(DelegatingRequest<T> request, CancellationToken cancellationToken)
         {
-            await _handler.Invoke(request.Value.ToObject<T>(_serializer.JsonSerializer), cancellationToken);
+            await _handler.Invoke(request.Value.ToObject<T>(_serializer.JsonSerializer), cancellationToken).ConfigureAwait(false);
             return JValue.CreateNull();
         }
     }

--- a/src/JsonRpc/InputHandler.cs
+++ b/src/JsonRpc/InputHandler.cs
@@ -284,7 +284,7 @@ namespace OmniSharp.Extensions.JsonRpc
                 long length = 0;
                 do
                 {
-                    var result = await _pipeReader.ReadAsync(cancellationToken);
+                    var result = await _pipeReader.ReadAsync(cancellationToken).ConfigureAwait(false);
                     buffer = result.Buffer;
 
                     var dataParsed = true;

--- a/src/JsonRpc/InputHandler.cs
+++ b/src/JsonRpc/InputHandler.cs
@@ -124,8 +124,8 @@ namespace OmniSharp.Extensions.JsonRpc
 
         public async Task StopAsync()
         {
-            await _outputHandler.StopAsync();
-            await _pipeReader.CompleteAsync();
+            await _outputHandler.StopAsync().ConfigureAwait(false);
+            await _pipeReader.CompleteAsync().ConfigureAwait(false);
         }
 
         public void Dispose()
@@ -337,8 +337,8 @@ namespace OmniSharp.Extensions.JsonRpc
             }
             finally
             {
-                await _outputHandler.StopAsync();
-                await _pipeReader.CompleteAsync();
+                await _outputHandler.StopAsync().ConfigureAwait(false);
+                await _pipeReader.CompleteAsync().ConfigureAwait(false);
             }
         }
 
@@ -504,7 +504,7 @@ namespace OmniSharp.Extensions.JsonRpc
                                                                     {
                                                                         return await _requestRouter.RouteRequest(
                                                                             descriptors, request, cts.Token
-                                                                        );
+                                                                        ).ConfigureAwait(false);
                                                                     }
                                                                     catch (OperationCanceledException)
                                                                     {
@@ -571,7 +571,7 @@ namespace OmniSharp.Extensions.JsonRpc
                             using var timer = _logger.TimeDebug("Processing notification {Method}", notification.Method);
                             try
                             {
-                                await _requestRouter.RouteNotification(descriptors, notification, ct);
+                                await _requestRouter.RouteNotification(descriptors, notification, ct).ConfigureAwait(false);
                             }
                             catch (OperationCanceledException)
                             {

--- a/src/JsonRpc/JsonRpcServer.cs
+++ b/src/JsonRpc/JsonRpcServer.cs
@@ -50,7 +50,7 @@ namespace OmniSharp.Extensions.JsonRpc
         public static async Task<JsonRpcServer> From(JsonRpcServerOptions options, IServiceProvider outerServiceProvider, CancellationToken cancellationToken)
         {
             var server = Create(options, outerServiceProvider);
-            await server.Initialize(cancellationToken);
+            await server.Initialize(cancellationToken).ConfigureAwait(false);
             return server;
         }
 

--- a/src/JsonRpc/OutputHandler.cs
+++ b/src/JsonRpc/OutputHandler.cs
@@ -70,7 +70,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
         public async Task StopAsync()
         {
-            await _pipeWriter.CompleteAsync();
+            await _pipeWriter.CompleteAsync().ConfigureAwait(false);
             _disposable.Dispose();
         }
 
@@ -81,8 +81,8 @@ namespace OmniSharp.Extensions.JsonRpc
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal async Task WriteAndFlush()
         {
-            await _pipeWriter.FlushAsync();
-            await _pipeWriter.CompleteAsync();
+            await _pipeWriter.FlushAsync().ConfigureAwait(false);
+            await _pipeWriter.CompleteAsync().ConfigureAwait(false);
         }
 
         private async Task ProcessOutputStream(object value, CancellationToken cancellationToken)
@@ -92,9 +92,9 @@ namespace OmniSharp.Extensions.JsonRpc
                 // TODO: this will be part of the serialization refactor to make streaming first class
                 var content = _serializer.SerializeObject(value);
                 var contentBytes = Encoding.UTF8.GetBytes(content).AsMemory();
-                await _pipeWriter.WriteAsync(Encoding.UTF8.GetBytes($"Content-Length: {contentBytes.Length}\r\n\r\n"), cancellationToken);
-                await _pipeWriter.WriteAsync(contentBytes, cancellationToken);
-                await _pipeWriter.FlushAsync(cancellationToken);
+                await _pipeWriter.WriteAsync(Encoding.UTF8.GetBytes($"Content-Length: {contentBytes.Length}\r\n\r\n"), cancellationToken).ConfigureAwait(false);
+                await _pipeWriter.WriteAsync(contentBytes, cancellationToken).ConfigureAwait(false);
+                await _pipeWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException ex) when (ex.CancellationToken != cancellationToken)
             {

--- a/src/JsonRpc/RequestRouterBase.cs
+++ b/src/JsonRpc/RequestRouterBase.cs
@@ -54,7 +54,7 @@ namespace OmniSharp.Extensions.JsonRpc
                 }
             }
 
-            await Task.WhenAll(descriptors.Select(descriptor => InnerRoute(_serviceScopeFactory, descriptor, @params, token)));
+            await Task.WhenAll(descriptors.Select(descriptor => InnerRoute(_serviceScopeFactory, descriptor, @params, token))).ConfigureAwait(false);
 
             static async Task InnerRoute(IServiceScopeFactory serviceScopeFactory, TDescriptor descriptor, object @params, CancellationToken token)
             {
@@ -63,7 +63,7 @@ namespace OmniSharp.Extensions.JsonRpc
                 context.Descriptor = descriptor;
                 var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
 
-                await HandleNotification(mediator, descriptor, @params ?? Activator.CreateInstance(descriptor.Params), token);
+                await HandleNotification(mediator, descriptor, @params ?? Activator.CreateInstance(descriptor.Params), token).ConfigureAwait(false);
             }
         }
 
@@ -107,7 +107,7 @@ namespace OmniSharp.Extensions.JsonRpc
             // TODO: Do we want to support more handlers as "aggregate"?
             if (typeof(IEnumerable<object>).IsAssignableFrom(descriptors.Default.Response) && !typeof(JToken).IsAssignableFrom(descriptors.Default.Response))
             {
-                var responses = await Task.WhenAll(descriptors.Select(descriptor => InnerRoute(_serviceScopeFactory, request, descriptor, @params, token, _logger)));
+                var responses = await Task.WhenAll(descriptors.Select(descriptor => InnerRoute(_serviceScopeFactory, request, descriptor, @params, token, _logger))).ConfigureAwait(false);
                 var errorResponse = responses.FirstOrDefault(x => x.IsError);
                 if (errorResponse.IsError) return errorResponse;
                 if (responses.Length == 1)
@@ -121,7 +121,7 @@ namespace OmniSharp.Extensions.JsonRpc
                 return new OutgoingResponse(request.Id, response, request);
             }
 
-            return await InnerRoute(_serviceScopeFactory, request, descriptors.Default, @params, token, _logger);
+            return await InnerRoute(_serviceScopeFactory, request, descriptors.Default, @params, token, _logger).ConfigureAwait(false);
 
             static async Task<ErrorResponse> InnerRoute(
                 IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, object @params, CancellationToken token,
@@ -136,7 +136,7 @@ namespace OmniSharp.Extensions.JsonRpc
                 token.ThrowIfCancellationRequested();
 
                 var result = HandleRequest(mediator, descriptor, @params ?? Activator.CreateInstance(descriptor.Params), token);
-                await result;
+                await result.ConfigureAwait(false);
 
                 token.ThrowIfCancellationRequested();
 

--- a/src/JsonRpc/ResponseRouter.cs
+++ b/src/JsonRpc/ResponseRouter.cs
@@ -97,7 +97,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
                 try
                 {
-                    var result = await tcs.Task;
+                    var result = await tcs.Task.ConfigureAwait(false);
                     if (typeof(TResponse) == typeof(Unit))
                     {
                         return (TResponse) (object) Unit.Value;
@@ -111,7 +111,7 @@ namespace OmniSharp.Extensions.JsonRpc
                 }
             }
 
-            public async Task ReturningVoid(CancellationToken cancellationToken) => await Returning<Unit>(cancellationToken);
+            public async Task ReturningVoid(CancellationToken cancellationToken) => await Returning<Unit>(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Protocol/AbstractHandlers.cs
+++ b/src/Protocol/AbstractHandlers.cs
@@ -132,7 +132,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
                                    )
                                   .ToTask(cancellationToken);
                 Handle(request, subject, cancellationToken);
-                return _factory(await task);
+                return _factory(await task.ConfigureAwait(false));
             }
 
             protected abstract void Handle(

--- a/src/Protocol/Document/ICodeLensHandler.cs
+++ b/src/Protocol/Document/ICodeLensHandler.cs
@@ -71,13 +71,13 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Document
 
         public sealed override async Task<CodeLensContainer> Handle(CodeLensParams request, CancellationToken cancellationToken)
         {
-            var response = await HandleParams(request, cancellationToken);
+            var response = await HandleParams(request, cancellationToken).ConfigureAwait(false);
             return response;
         }
 
         public sealed override async Task<CodeLens> Handle(CodeLens request, CancellationToken cancellationToken)
         {
-            var response = await HandleResolve(request, cancellationToken);
+            var response = await HandleResolve(request, cancellationToken).ConfigureAwait(false);
             return response;
         }
 
@@ -106,7 +106,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Document
 
         public sealed override async Task<CodeLens> Handle(CodeLens request, CancellationToken cancellationToken)
         {
-            var response = await HandleResolve(request, cancellationToken);
+            var response = await HandleResolve(request, cancellationToken).ConfigureAwait(false);
             return response;
         }
 

--- a/src/Protocol/Document/ICompletionHandler.cs
+++ b/src/Protocol/Document/ICompletionHandler.cs
@@ -72,13 +72,13 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Document
 
         public sealed override async Task<CompletionList> Handle(CompletionParams request, CancellationToken cancellationToken)
         {
-            var response = await HandleParams(request, cancellationToken);
+            var response = await HandleParams(request, cancellationToken).ConfigureAwait(false);
             return response;
         }
 
         public sealed override async Task<CompletionItem> Handle(CompletionItem request, CancellationToken cancellationToken)
         {
-            var response = await HandleResolve(request, cancellationToken);
+            var response = await HandleResolve(request, cancellationToken).ConfigureAwait(false);
             return response;
         }
 
@@ -107,7 +107,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Document
 
         public sealed override async Task<CompletionItem> Handle(CompletionItem request, CancellationToken cancellationToken)
         {
-            var response = await HandleResolve(request, cancellationToken);
+            var response = await HandleResolve(request, cancellationToken).ConfigureAwait(false);
             return response;
         }
 

--- a/src/Protocol/Document/IDocumentLinkHandler.cs
+++ b/src/Protocol/Document/IDocumentLinkHandler.cs
@@ -73,13 +73,13 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Document
 
         public sealed override async Task<DocumentLinkContainer> Handle(DocumentLinkParams request, CancellationToken cancellationToken)
         {
-            var response = await HandleParams(request, cancellationToken);
+            var response = await HandleParams(request, cancellationToken).ConfigureAwait(false);
             return response;
         }
 
         public sealed override async Task<DocumentLink> Handle(DocumentLink request, CancellationToken cancellationToken)
         {
-            var response = await HandleResolve(request, cancellationToken);
+            var response = await HandleResolve(request, cancellationToken).ConfigureAwait(false);
             return response;
         }
 
@@ -108,7 +108,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Document
 
         public sealed override async Task<DocumentLink> Handle(DocumentLink request, CancellationToken cancellationToken)
         {
-            var response = await HandleResolve(request, cancellationToken);
+            var response = await HandleResolve(request, cancellationToken).ConfigureAwait(false);
             return response;
         }
 

--- a/src/Protocol/Document/ITextDocumentSyncHandler.cs
+++ b/src/Protocol/Document/ITextDocumentSyncHandler.cs
@@ -277,7 +277,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Document
                 CancellationToken cancellationToken
             )
             {
-                await _onOpenHandler.Invoke(request, _capability, cancellationToken);
+                await _onOpenHandler.Invoke(request, _capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
 
@@ -286,7 +286,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Document
                 CancellationToken cancellationToken
             )
             {
-                await _onChangeHandler.Invoke(request, _capability, cancellationToken);
+                await _onChangeHandler.Invoke(request, _capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
 
@@ -295,7 +295,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Document
                 CancellationToken cancellationToken
             )
             {
-                await _onSaveHandler.Invoke(request, _capability, cancellationToken);
+                await _onSaveHandler.Invoke(request, _capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
 
@@ -304,7 +304,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Document
                 CancellationToken cancellationToken
             )
             {
-                await _onCloseHandler.Invoke(request, _capability, cancellationToken);
+                await _onCloseHandler.Invoke(request, _capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
 

--- a/src/Protocol/Document/Proposals/ISemanticTokensDeltaHandler.cs
+++ b/src/Protocol/Document/Proposals/ISemanticTokensDeltaHandler.cs
@@ -54,25 +54,25 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Document.Proposals
 
         public virtual async Task<SemanticTokens> Handle(SemanticTokensParams request, CancellationToken cancellationToken)
         {
-            var document = await GetSemanticTokensDocument(request, cancellationToken);
+            var document = await GetSemanticTokensDocument(request, cancellationToken).ConfigureAwait(false);
             var builder = document.Create();
-            await Tokenize(builder, request, cancellationToken);
+            await Tokenize(builder, request, cancellationToken).ConfigureAwait(false);
             return builder.Commit().GetSemanticTokens();
         }
 
         public virtual async Task<SemanticTokensFullOrDelta?> Handle(SemanticTokensDeltaParams request, CancellationToken cancellationToken)
         {
-            var document = await GetSemanticTokensDocument(request, cancellationToken);
+            var document = await GetSemanticTokensDocument(request, cancellationToken).ConfigureAwait(false);
             var builder = document.Edit(request);
-            await Tokenize(builder, request, cancellationToken);
+            await Tokenize(builder, request, cancellationToken).ConfigureAwait(false);
             return builder.Commit().GetSemanticTokensEdits();
         }
 
         public virtual async Task<SemanticTokens> Handle(SemanticTokensRangeParams request, CancellationToken cancellationToken)
         {
-            var document = await GetSemanticTokensDocument(request, cancellationToken);
+            var document = await GetSemanticTokensDocument(request, cancellationToken).ConfigureAwait(false);
             var builder = document.Create();
-            await Tokenize(builder, request, cancellationToken);
+            await Tokenize(builder, request, cancellationToken).ConfigureAwait(false);
             return builder.Commit().GetSemanticTokens(request.Range);
         }
 

--- a/src/Protocol/General/IExitHandler.cs
+++ b/src/Protocol/General/IExitHandler.cs
@@ -20,7 +20,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.General
     {
         public virtual async Task<Unit> Handle(ExitParams request, CancellationToken cancellationToken)
         {
-            await Handle(cancellationToken);
+            await Handle(cancellationToken).ConfigureAwait(false);
             return Unit.Value;
         }
 

--- a/src/Protocol/General/IShutdownHandler.cs
+++ b/src/Protocol/General/IShutdownHandler.cs
@@ -20,7 +20,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.General
     {
         public virtual async Task<Unit> Handle(ShutdownParams request, CancellationToken cancellationToken)
         {
-            await Handle(cancellationToken);
+            await Handle(cancellationToken).ConfigureAwait(false);
             return Unit.Value;
         }
 

--- a/src/Protocol/LanguageProtocolDelegatingHandlers.cs
+++ b/src/Protocol/LanguageProtocolDelegatingHandlers.cs
@@ -160,7 +160,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
             async Task<Unit> IRequestHandler<TParams, Unit>.Handle(TParams request, CancellationToken cancellationToken)
             {
-                await _handler(request, _capability, cancellationToken);
+                await _handler(request, _capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
 
@@ -244,7 +244,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             async Task<Unit> IRequestHandler<TParams, Unit>.
                 Handle(TParams request, CancellationToken cancellationToken)
             {
-                await _handler(request, cancellationToken);
+                await _handler(request, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
 
@@ -327,7 +327,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             async Task<Unit> IRequestHandler<TParams, Unit>.
                 Handle(TParams request, CancellationToken cancellationToken)
             {
-                await _handler(request, _capability, cancellationToken);
+                await _handler(request, _capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
 
@@ -401,7 +401,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
                 var subject = new AsyncSubject<TItem>();
                 _handler(request, subject, _capability, cancellationToken);
-                return await subject.Select(_factory);
+                return await subject.Select(_factory).ToTask(cancellationToken).ConfigureAwait(false);
             }
 
             TRegistrationOptions IRegistration<TRegistrationOptions>.GetRegistrationOptions() => _registrationOptions;
@@ -469,7 +469,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
                 var subject = new AsyncSubject<TItem>();
                 _handler(request, subject, cancellationToken);
-                return await subject.Select(_factory);
+                return await subject.Select(_factory).ToTask(cancellationToken).ConfigureAwait(false);
             }
 
             TRegistrationOptions IRegistration<TRegistrationOptions>.GetRegistrationOptions() => _registrationOptions;
@@ -529,7 +529,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
                 var subject = new AsyncSubject<TItem>();
                 _handler(request, _capability, subject, cancellationToken);
-                return await subject.Select(_factory);
+                return await subject.Select(_factory).ToTask(cancellationToken).ConfigureAwait(false);
             }
 
             void ICapability<TCapability>.SetCapability(TCapability capability) => _capability = capability;
@@ -585,7 +585,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
                 var subject = new AsyncSubject<TItem>();
                 _handler(request, subject, cancellationToken);
-                return await subject.Select(_factory);
+                return await subject.Select(_factory).ToTask(cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -661,7 +661,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
                                    )
                                   .ToTask(cancellationToken);
                 _handler(request, subject, _capability, cancellationToken);
-                var result = _factory(await task);
+                var result = _factory(await task.ConfigureAwait(false));
                 return result;
             }
 
@@ -739,7 +739,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
                                    )
                                   .ToTask(cancellationToken);
                 _handler(request, subject, cancellationToken);
-                var result = _factory(await task);
+                var result = _factory(await task.ConfigureAwait(false));
                 return result;
             }
 
@@ -812,7 +812,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
                                    )
                                   .ToTask(cancellationToken);
                 _handler(request, _capability, subject, cancellationToken);
-                var result = _factory(await task);
+                var result = _factory(await task.ConfigureAwait(false));
                 return result;
             }
 
@@ -880,7 +880,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
                                    )
                                   .ToTask(cancellationToken);
                 _handler(request, subject, cancellationToken);
-                var result = _factory(await task);
+                var result = _factory(await task.ConfigureAwait(false));
                 return result;
             }
         }
@@ -963,7 +963,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
             async Task<Unit> IRequestHandler<TParams, Unit>.Handle(TParams request, CancellationToken cancellationToken)
             {
-                await _handler(request, _capability, cancellationToken);
+                await _handler(request, _capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
 
@@ -1047,7 +1047,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
             async Task<Unit> IRequestHandler<TParams, Unit>.Handle(TParams request, CancellationToken cancellationToken)
             {
-                await _handler(request, cancellationToken);
+                await _handler(request, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
 
@@ -1108,7 +1108,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
             async Task<Unit> IRequestHandler<TParams, Unit>.Handle(TParams request, CancellationToken cancellationToken)
             {
-                await _handler(request, _capability, cancellationToken);
+                await _handler(request, _capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
 

--- a/src/Protocol/Progress/ProgressManager.cs
+++ b/src/Protocol/Progress/ProgressManager.cs
@@ -201,7 +201,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Progress
                 async (observer, ct) => {
                     try
                     {
-                        observer.OnNext(await _router.SendRequest(request, ct));
+                        observer.OnNext(await _router.SendRequest(request, ct).ConfigureAwait(false));
                         observer.OnCompleted();
                     }
                     catch (OperationCanceledException e)

--- a/src/Protocol/Server/WorkDone/LanguageServerWorkDoneManager.cs
+++ b/src/Protocol/Server/WorkDone/LanguageServerWorkDoneManager.cs
@@ -52,7 +52,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Server.WorkDone
                 return item;
             }
 
-            await _router.SendRequest(new WorkDoneProgressCreateParams { Token = progressToken }, cancellationToken);
+            await _router.SendRequest(new WorkDoneProgressCreateParams { Token = progressToken }, cancellationToken).ConfigureAwait(false);
 
             onError ??= error => new WorkDoneProgressEnd {
                 Message = error.ToString()

--- a/src/Protocol/Workspace/IExecuteCommandHandler.cs
+++ b/src/Protocol/Workspace/IExecuteCommandHandler.cs
@@ -210,7 +210,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 
             public override async Task<Unit> Handle(T arg1, CancellationToken cancellationToken)
             {
-                await _handler(arg1, Capability, cancellationToken);
+                await _handler(arg1, Capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
         }
@@ -246,7 +246,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 
             public override async Task<Unit> Handle(T arg1, T2 arg2, CancellationToken cancellationToken)
             {
-                await _handler(arg1, arg2, Capability, cancellationToken);
+                await _handler(arg1, arg2, Capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
         }
@@ -284,7 +284,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 
             public override async Task<Unit> Handle(T arg1, T2 arg2, T3 arg3, CancellationToken cancellationToken)
             {
-                await _handler(arg1, arg2, arg3, Capability, cancellationToken);
+                await _handler(arg1, arg2, arg3, Capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
         }
@@ -322,7 +322,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 
             public override async Task<Unit> Handle(T arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken cancellationToken)
             {
-                await _handler(arg1, arg2, arg3, arg4, Capability, cancellationToken);
+                await _handler(arg1, arg2, arg3, arg4, Capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
         }
@@ -360,7 +360,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 
             public override async Task<Unit> Handle(T arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken cancellationToken)
             {
-                await _handler(arg1, arg2, arg3, arg4, arg5, Capability, cancellationToken);
+                await _handler(arg1, arg2, arg3, arg4, arg5, Capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
         }
@@ -401,7 +401,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 
             public override async Task<Unit> Handle(T arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, CancellationToken cancellationToken)
             {
-                await _handler(arg1, arg2, arg3, arg4, arg5, arg6, Capability, cancellationToken);
+                await _handler(arg1, arg2, arg3, arg4, arg5, arg6, Capability, cancellationToken).ConfigureAwait(false);
                 return Unit.Value;
             }
         }

--- a/src/Server/Configuration/DidChangeConfigurationProvider.cs
+++ b/src/Server/Configuration/DidChangeConfigurationProvider.cs
@@ -199,7 +199,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Configuration
                 new ConfigurationParams {
                     Items = items
                 }
-            );
+            ).ConfigureAwait(false);
             var data = items.Zip(
                 configurations,
                 (scope, settings) => ( scope.Section, settings )
@@ -223,7 +223,8 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Configuration
             var data = await GetConfigurationFromClient(scopes.Select(z => new ConfigurationItem { Section = z.Section, ScopeUri = scopeUri }))
                             .Select(z => (z.scope.Section, z.settings))
                             .ToArray()
-                            .ToTask(cancellationToken);
+                            .ToTask(cancellationToken)
+                            .ConfigureAwait(false);
 
             var config = new ScopedConfiguration(
                 _configuration,

--- a/src/Server/LanguageServer.Shutdown.cs
+++ b/src/Server/LanguageServer.Shutdown.cs
@@ -34,7 +34,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             var result = _shutdownRequested ? 0 : 1;
             _exitSubject.OnNext(result);
             _exitSubject.OnCompleted();
-            await _connection.StopAsync();
+            await _connection.StopAsync().ConfigureAwait(false);
             return Unit.Value;
         }
 

--- a/src/Server/LanguageServer.cs
+++ b/src/Server/LanguageServer.cs
@@ -99,7 +99,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
         public static async Task<LanguageServer> From(LanguageServerOptions options, IServiceProvider outerServiceProvider, CancellationToken cancellationToken)
         {
             var server = Create(options, outerServiceProvider);
-            await server.Initialize(cancellationToken);
+            await server.Initialize(cancellationToken).ConfigureAwait(false);
             return server;
         }
 
@@ -224,7 +224,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             {
                 try
                 {
-                    await _initializingTask;
+                    await _initializingTask.ConfigureAwait(false);
                 }
                 catch
                 {
@@ -238,7 +238,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             try
             {
                 _initializingTask = _initializeComplete.ToTask(token);
-                await _initializingTask;
+                await _initializingTask.ConfigureAwait(false);
                 await LanguageProtocolEventingHelper.Run(
                     _startedDelegates,
                     (handler, ct) => handler(this, ct),
@@ -246,7 +246,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
                     (handler, ct) => handler.OnStarted(this, ct),
                     _concurrency,
                     token
-                );
+                ).ConfigureAwait(false);
 
                 _instanceHasStarted.Started = true;
             }
@@ -349,7 +349,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
                 (handler, ct) => handler.OnInitialize(this, ClientSettings, ct),
                 _concurrency,
                 token
-            );
+            ).ConfigureAwait(false);
 
             var ccp = new ClientCapabilityProvider(_collection, windowCapabilities.WorkDoneProgress.IsSupported);
 
@@ -462,7 +462,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
                 (handler, ct) => handler.OnInitialized(this, ClientSettings, result, ct),
                 _concurrency,
                 token
-            );
+            ).ConfigureAwait(false);
 
             // TODO:
             if (_clientVersion == ClientVersion.Lsp2)

--- a/src/Server/Pipelines/ResolveCommandPipeline.cs
+++ b/src/Server/Pipelines/ResolveCommandPipeline.cs
@@ -25,7 +25,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Pipelines
 
         public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
         {
-            var response = await next();
+            var response = await next().ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
 
             // Only pin the handler type, if we know the source handler (codelens) is also the resolver.

--- a/src/Server/Pipelines/SemanticTokensDeltaPipeline.cs
+++ b/src/Server/Pipelines/SemanticTokensDeltaPipeline.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Pipelines
         {
             if (request is SemanticTokensParams semanticTokensParams)
             {
-                var response = await next();
+                var response = await next().ConfigureAwait(false);
                 if (GetResponse(semanticTokensParams, response, out var result) && string.IsNullOrEmpty(result.ResultId))
                 {
                     result.ResultId = Guid.NewGuid().ToString();
@@ -22,7 +22,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Pipelines
 
             if (request is SemanticTokensDeltaParams semanticTokensDeltaParams)
             {
-                var response = await next();
+                var response = await next().ConfigureAwait(false);
                 if (GetResponse(semanticTokensDeltaParams, response, out var result))
                 {
                     if (result?.IsFull == true && string.IsNullOrEmpty(result.Value.Full.ResultId))
@@ -38,7 +38,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Pipelines
                 return response;
             }
 
-            return await next();
+            return await next().ConfigureAwait(false);
         }
 
         private bool GetResponse<TR>(IRequest<TR> request, object response, out TR result)

--- a/src/Testing/LanguageProtocolTestBase.cs
+++ b/src/Testing/LanguageProtocolTestBase.cs
@@ -88,7 +88,7 @@ namespace OmniSharp.Extensions.LanguageProtocol.Testing
             return await Observable.FromAsync(_client.Initialize).ForkJoin(
                 Observable.FromAsync(_server.Initialize),
                 (a, b) => ( _client, _server )
-            ).ToTask(CancellationToken);
+            ).ToTask(CancellationToken).ConfigureAwait(false);
         }
 
         protected virtual async Task<(ILanguageClient client, ILanguageServer server, TestConfigurationProvider configurationProvider)> InitializeWithConfiguration(
@@ -107,7 +107,7 @@ namespace OmniSharp.Extensions.LanguageProtocol.Testing
             return await Observable.FromAsync(client.Initialize).ForkJoin(
                 Observable.FromAsync(server.Initialize),
                 (a, b) => ( client, server, client.GetRequiredService<TestConfigurationProvider>() )
-            ).ToTask(CancellationToken);
+            ).ToTask(CancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Testing/LanguageServerTestBase.cs
+++ b/src/Testing/LanguageServerTestBase.cs
@@ -51,7 +51,7 @@ namespace OmniSharp.Extensions.LanguageProtocol.Testing
         protected virtual async Task<ILanguageClient> InitializeClient(Action<LanguageClientOptions> clientOptionsAction = null)
         {
             _client = CreateClient(clientOptionsAction);
-            await _client.Initialize(CancellationToken);
+            await _client.Initialize(CancellationToken).ConfigureAwait(false);
 
             return _client;
         }
@@ -68,7 +68,7 @@ namespace OmniSharp.Extensions.LanguageProtocol.Testing
                 }
             );
 
-            await client.Initialize(CancellationToken);
+            await client.Initialize(CancellationToken).ConfigureAwait(false);
 
             return ( client, client.GetRequiredService<TestConfigurationProvider>() );
         }

--- a/test/Lsp.Tests/Integration/LanguageServerConfigurationTests.cs
+++ b/test/Lsp.Tests/Integration/LanguageServerConfigurationTests.cs
@@ -31,6 +31,7 @@ namespace Lsp.Tests.Integration
             configuration.Update("mysection", new Dictionary<string, string> { ["key"] = "value" });
             configuration.Update("othersection", new Dictionary<string, string> { ["value"] = "key" });
             await server.Configuration.WaitForChange(CancellationToken);
+            await SettleNext();
 
             server.Configuration.AsEnumerable().Should().BeEmpty();
         }
@@ -44,6 +45,7 @@ namespace Lsp.Tests.Integration
             configuration.Update("mysection", new Dictionary<string, string> { ["key"] = "value" });
             configuration.Update("othersection", new Dictionary<string, string> { ["value"] = "key" });
             await server.Configuration.WaitForChange(CancellationToken);
+            await SettleNext();
 
             server.Configuration["mysection:key"].Should().Be("value");
             server.Configuration["othersection:value"].Should().Be("key");
@@ -59,6 +61,7 @@ namespace Lsp.Tests.Integration
             configuration.Update("mysection", new Dictionary<string, string> { ["key"] = "value" });
             configuration.Update("othersection", new Dictionary<string, string> { ["value"] = "key" });
             await server.Configuration.WaitForChange(CancellationToken);
+            await SettleNext();
 
             server.Configuration["mysection:key"].Should().Be("value");
             server.Configuration["othersection:value"].Should().Be("key");
@@ -73,12 +76,14 @@ namespace Lsp.Tests.Integration
             configuration.Update("mysection", new Dictionary<string, string> { ["key"] = "value" });
             configuration.Update("othersection", new Dictionary<string, string> { ["value"] = "key" });
             await server.Configuration.WaitForChange(CancellationToken);
+            await SettleNext();
 
             server.Configuration["mysection:key"].Should().Be("value");
             server.Configuration["othersection:value"].Should().Be("key");
 
             server.Configuration.RemoveSection("othersection");
             await server.Configuration.WaitForChange(CancellationToken);
+            await SettleNext();
 
             server.Configuration["mysection:key"].Should().Be("value");
             server.Configuration["othersection:value"].Should().BeNull();
@@ -93,9 +98,12 @@ namespace Lsp.Tests.Integration
             configuration.Update("mysection", new Dictionary<string, string> { ["key"] = "value" });
             configuration.Update("othersection", new Dictionary<string, string> { ["value"] = "key" });
             await server.Configuration.WaitForChange(CancellationToken);
+            await SettleNext();
+
             configuration.Update("mysection", DocumentUri.From("/my/file.cs"), new Dictionary<string, string> { ["key"] = "scopedvalue" });
             configuration.Update("othersection", DocumentUri.From("/my/file.cs"), new Dictionary<string, string> { ["value"] = "scopedkey" });
             await server.Configuration.WaitForChange(CancellationToken);
+            await SettleNext();
 
             server.Configuration["mysection:key"].Should().Be("value");
             scopedConfiguration["mysection:key"].Should().Be("scopedvalue");
@@ -112,9 +120,12 @@ namespace Lsp.Tests.Integration
             configuration.Update("mysection", new Dictionary<string, string> { ["key"] = "value" });
             configuration.Update("othersection", new Dictionary<string, string> { ["value"] = "key" });
             await server.Configuration.WaitForChange(CancellationToken);
+            await SettleNext();
+
             configuration.Update("mysection", DocumentUri.From("/my/file.cs"), new Dictionary<string, string> { ["key"] = "scopedvalue" });
             configuration.Update("othersection", DocumentUri.From("/my/file.cs"), new Dictionary<string, string> { ["value"] = "scopedkey" });
             await server.Configuration.WaitForChange(CancellationToken);
+            await SettleNext();
 
             server.Configuration["mysection:key"].Should().Be("value");
             scopedConfiguration["mysection:key"].Should().Be("scopedvalue");
@@ -124,6 +135,7 @@ namespace Lsp.Tests.Integration
             configuration.Update("mysection", DocumentUri.From("/my/file.cs"), new Dictionary<string, string>());
             configuration.Update("othersection", DocumentUri.From("/my/file.cs"), new Dictionary<string, string>());
             await scopedConfiguration.WaitForChange(CancellationToken);
+            await SettleNext();
 
             await Task.Delay(2000);
 
@@ -139,8 +151,11 @@ namespace Lsp.Tests.Integration
 
             configuration.Update("mysection", new Dictionary<string, string> { ["key"] = "value" });
             await server.Configuration.WaitForChange(CancellationToken);
+            await SettleNext();
+
             configuration.Update("notmysection", new Dictionary<string, string> { ["key"] = "value" });
             await server.Configuration.WaitForChange(CancellationToken);
+            await SettleNext();
 
             server.Configuration["mysection:key"].Should().Be("value");
             server.Configuration["notmysection:key"].Should().BeNull();


### PR DESCRIPTION
- Razor initializes O#'s language server in-proc in Visual Studio and because the `pipeReader.ReadAsync` doesn't utilize `ConfigureAwait(false)` it attempts to only ever read information on the main thread which is a problem if a feature such as light bulbs or go-to-definition require.