### PR TITLE
only emit warning if configuration is in use

### DIFF
--- a/src/Server/Configuration/DidChangeConfigurationProvider.cs
+++ b/src/Server/Configuration/DidChangeConfigurationProvider.cs
@@ -48,7 +48,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Configuration
             var builder = new ConfigurationBuilder()
                .Add(new DidChangeConfigurationSource(this));
             configurationBuilderAction(builder);
-            _configuration = (builder.Build() as ConfigurationRoot)!;
+            _configuration = ( builder.Build() as ConfigurationRoot )!;
 
             var triggerChange = new Subject<System.Reactive.Unit>();
             _compositeDisposable.Add(triggerChange);
@@ -86,9 +86,16 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Configuration
 
         private IObservable<System.Reactive.Unit> GetWorkspaceConfiguration()
         {
-            if (_capability == null || _configurationItems.Count == 0)
+            // do not warn if they are not using configuration
+            if (_capability == null)
+            {
+                return Empty<System.Reactive.Unit>();
+            }
+
+            if (_configurationItems.Count == 0)
             {
                 _logger.LogWarning("No ConfigurationItems have been defined, configuration won't surface any configuration from the client!");
+
                 OnReload();
                 return Empty<System.Reactive.Unit>();
             }
@@ -113,9 +120,8 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Configuration
                                    }
                                )
                               .Do(
-                                   _ => { }, () => {
-                                       Data = newData;
-                                   }
+                                   _ => { },
+                                   () => Data = newData
                                )
                               .Subscribe(observer);
                     }
@@ -150,7 +156,8 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Configuration
                         OnReload();
                         o.OnCompleted();
                         return Disposable.Empty;
-                    })
+                    }
+                )
             );
         }
 
@@ -217,7 +224,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Configuration
                 return EmptyDisposableConfiguration.Instance;
 
             var data = await GetConfigurationFromClient(scopes.Select(z => new ConfigurationItem { Section = z.Section, ScopeUri = scopeUri }))
-                            .Select(z => (z.scope.Section ?? string.Empty, z.settings))
+                            .Select(z => ( z.scope.Section ?? string.Empty, z.settings ))
                             .ToArray()
                             .ToTask(cancellationToken)
                             .ConfigureAwait(false);

--- a/src/Server/LanguageServerServiceCollectionExtensions.cs
+++ b/src/Server/LanguageServerServiceCollectionExtensions.cs
@@ -64,13 +64,12 @@ namespace OmniSharp.Extensions.LanguageServer.Server
                                 .Type<Action<IConfigurationBuilder>>(defaultValue: options.ConfigurationBuilderAction),
                 reuse: Reuse.Singleton
             );
-            container.RegisterMany<ConfigurationConverter>(nonPublicServiceTypes: true, reuse: Reuse.Singleton);
             container.RegisterInitializer<ILanguageServerConfiguration>(
                 (provider, context) => {
-                    var configurationItems = context.ResolveMany<ConfigurationItem>();
-                    provider.AddConfigurationItems(configurationItems);
+                    provider.AddConfigurationItems(context.ResolveMany<ConfigurationItem>());
                 }
             );
+            container.RegisterMany<ConfigurationConverter>(nonPublicServiceTypes: true, reuse: Reuse.Singleton);
 
 
             var providedConfiguration = options.Services.FirstOrDefault(z => z.ServiceType == typeof(IConfiguration) && z.ImplementationInstance is IConfiguration);


### PR DESCRIPTION
If you override configuration this removes the meaningless warning.