### PR TITLE
Breaking: LSP ISerializer interface is now deprecated, and marked obsolete

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
+    <PropertyGroup>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Condition="'$(DesignTimeBuild)' == 'true' and '$(IDEA_INITIAL_DIRECTORY)' != ''" Include="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
+    </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Rocket.Surgery.MSBuild.CI" Version="1.1.0" PrivateAssets="All" />

--- a/src/Protocol/LanguageProtocolRpcOptionsBase.cs
+++ b/src/Protocol/LanguageProtocolRpcOptionsBase.cs
@@ -24,16 +24,16 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
                 Services.AddSingleton(typeof(ITextDocumentIdentifier), item);
             }
 
-            return (T) (object) this;
+            return (T)(object)this;
         }
 
         public T AddTextDocumentIdentifier<TI>() where TI : ITextDocumentIdentifier
         {
             Services.AddSingleton(typeof(ITextDocumentIdentifier), typeof(TI));
-            return (T) (object) this;
+            return (T)(object)this;
         }
 
-        public ISerializer Serializer { get; set; } = new Serializer(ClientVersion.Lsp3);
+        public ISerializer Serializer { get; set; } = new LspSerializer(ClientVersion.Lsp3);
         internal bool AddDefaultLoggingProvider { get; set; }
         internal Action<ILoggingBuilder>? LoggingBuilderAction { get; set; } = _ => { };
         internal Action<IConfigurationBuilder>? ConfigurationBuilderAction { get; set; } = _ => { };

--- a/src/Protocol/Models/CodeActionKind.cs
+++ b/src/Protocol/Models/CodeActionKind.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
 using Newtonsoft.Json;
 using OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters;
 
@@ -12,6 +15,19 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models
     [JsonConverter(typeof(EnumLikeStringConverter))]
     public readonly struct CodeActionKind : IEquatable<CodeActionKind>, IEnumLikeString
     {
+        private static readonly Lazy<IReadOnlyList<CodeActionKind>> _defaults =
+            new Lazy<IReadOnlyList<CodeActionKind>>(
+                () => {
+                    return typeof(CodeActionKind)
+                          .GetFields(BindingFlags.Static | BindingFlags.Public)
+                          .Select(z => z.GetValue(null))
+                          .Cast<CodeActionKind>()
+                          .ToArray();
+                }
+            );
+
+        public static IEnumerable<CodeActionKind> Defaults => _defaults.Value;
+
         /// <summary>
         /// Base kind for quickfix actions: ''
         /// </summary>

--- a/src/Protocol/Models/Proposals/SemanticTokensLegend.cs
+++ b/src/Protocol/Models/Proposals/SemanticTokensLegend.cs
@@ -14,43 +14,15 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals
         private ImmutableDictionary<SemanticTokenModifier, int>? _tokenModifiersData;
         private ImmutableDictionary<SemanticTokenType, int>? _tokenTypesData;
 
-        private Container<string> _tokenTypes = new Container<string>(
-            SemanticTokenType
-               .Defaults
-               .Select(z => (string) z)
-               .ToArray()
-        );
-
-        private Container<string> _tokenModifiers = new Container<string>(
-            SemanticTokenModifier
-               .Defaults
-               .Select(z => (string) z)
-               .ToArray()
-        );
-
         /// <summary>
         /// The token types a server uses.
         /// </summary>
-        public Container<string> TokenTypes
-        {
-            get => _tokenTypes;
-            set {
-                _tokenTypes = value;
-                _tokenTypesData = null;
-            }
-        }
+        public Container<SemanticTokenType> TokenTypes { get; set; } = new Container<SemanticTokenType>(SemanticTokenType.Defaults);
 
         /// <summary>
         /// The token modifiers a server uses.
         /// </summary>
-        public Container<string> TokenModifiers
-        {
-            get => _tokenModifiers;
-            set {
-                _tokenModifiers = value;
-                _tokenModifiersData = null;
-            }
-        }
+        public Container<SemanticTokenModifier> TokenModifiers { get; set; } = new Container<SemanticTokenModifier>(SemanticTokenModifier.Defaults);
 
         public int GetTokenTypeIdentity(string tokenType)
         {

--- a/src/Protocol/Protocol.csproj
+++ b/src/Protocol/Protocol.csproj
@@ -7,11 +7,6 @@
         <PackageDescription>Language Server Protocol models, classes, interfaces and helper methods</PackageDescription>
     </PropertyGroup>
 
-    <PropertyGroup>
-        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-        <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
-    </PropertyGroup>
-
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration" />
         <!--
@@ -19,6 +14,13 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
         -->
+    </ItemGroup>
+    <PropertyGroup>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Condition="'$(DesignTimeBuild)' == 'true' and '$(IDEA_INITIAL_DIRECTORY)' != ''" Include="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Protocol/Serialization/ISerializer.cs
+++ b/src/Protocol/Serialization/ISerializer.cs
@@ -2,8 +2,8 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization
 {
+    [System.Obsolete("This interface is deprecated and will be removed in the future")]
     public interface ISerializer : JsonRpc.ISerializer
     {
-        void SetClientCapabilities(ClientVersion clientVersion, ClientCapabilities clientCapabilities);
     }
 }

--- a/src/Server/LanguageServer.cs
+++ b/src/Server/LanguageServer.cs
@@ -21,6 +21,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.General;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Progress;
+using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.WorkDone;
@@ -29,7 +30,6 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 using OmniSharp.Extensions.LanguageServer.Server.Abstractions;
 using OmniSharp.Extensions.LanguageServer.Server.Logging;
 using OmniSharp.Extensions.LanguageServer.Shared;
-using ISerializer = OmniSharp.Extensions.LanguageServer.Protocol.Serialization.ISerializer;
 
 // ReSharper disable SuspiciousTypeConversion.Global
 
@@ -41,7 +41,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
         private ClientVersion? _clientVersion;
         private readonly ServerInfo _serverInfo;
         private readonly ILspServerReceiver _serverReceiver;
-        private readonly ISerializer _serializer;
+        private readonly LspSerializer _serializer;
         private readonly TextDocumentIdentifiers _textDocumentIdentifiers;
         private readonly IHandlerCollection _collection;
         private readonly IEnumerable<OnLanguageServerInitializeDelegate> _initializeDelegates;
@@ -128,7 +128,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             ILanguageServerConfiguration configuration,
             ServerInfo serverInfo,
             ILspServerReceiver receiver,
-            ISerializer serializer,
+            LspSerializer serializer,
             IResolverContext resolverContext,
             ISupportedCapabilities supportedCapabilities,
             TextDocumentIdentifiers textDocumentIdentifiers,
@@ -299,7 +299,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             }
 
             _clientVersion = clientCapabilities.GetClientVersion();
-            _serializer.SetClientCapabilities(_clientVersion.Value, clientCapabilities);
+            _serializer.SetClientCapabilities(clientCapabilities);
 
             var supportedCapabilities = new List<ISupports>();
             if (_clientVersion == ClientVersion.Lsp3)
@@ -410,7 +410,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
                     var kinds = _collection
                                .Select(x => x.Handler)
                                .OfType<IDidChangeTextDocumentHandler>()
-                               .Select(x => ( (TextDocumentChangeRegistrationOptions?) x.GetRegistrationOptions() )?.SyncKind ?? TextDocumentSyncKind.None)
+                               .Select(x => ( (TextDocumentChangeRegistrationOptions?)x.GetRegistrationOptions() )?.SyncKind ?? TextDocumentSyncKind.None)
                                .Where(x => x != TextDocumentSyncKind.None)
                                .ToArray();
                     if (kinds.Any())
@@ -506,7 +506,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
             }
 
             return LanguageServerHelpers.RegisterHandlers(_initializeComplete.Select(z => System.Reactive.Unit.Default), Client, WorkDoneManager, _supportedCapabilities, result);
-//            return LanguageServerHelpers.RegisterHandlers(_initializingTask ?? _initializeComplete.ToTask(), Client, WorkDoneManager, _supportedCapabilities, result);
+            //            return LanguageServerHelpers.RegisterHandlers(_initializingTask ?? _initializeComplete.ToTask(), Client, WorkDoneManager, _supportedCapabilities, result);
         }
 
         object IServiceProvider.GetService(Type serviceType) => Services.GetService(serviceType);

--- a/test/Lsp.Tests/Capabilities/Client/ClientCapabilitiesTests.cs
+++ b/test/Lsp.Tests/Capabilities/Client/ClientCapabilitiesTests.cs
@@ -84,7 +84,7 @@ namespace Lsp.Tests.Capabilities.Client
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ClientCapabilities>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ClientCapabilities>(expected);
             deresult.Should().BeEquivalentTo(
                 model, o => o
                    .ConfigureForSupports(Logger)
@@ -95,7 +95,7 @@ namespace Lsp.Tests.Capabilities.Client
         [JsonFixture]
         public void Github_Issue_75(string expected)
         {
-            Action a = () => JObject.Parse(expected).ToObject(typeof(ClientCapabilities), new Serializer(ClientVersion.Lsp3).JsonSerializer);
+            Action a = () => JObject.Parse(expected).ToObject(typeof(ClientCapabilities), new LspSerializer(ClientVersion.Lsp3).JsonSerializer);
             a.Should().NotThrow();
         }
     }

--- a/test/Lsp.Tests/Capabilities/Client/CompletionCapabilityTests.cs
+++ b/test/Lsp.Tests/Capabilities/Client/CompletionCapabilityTests.cs
@@ -16,7 +16,7 @@ namespace Lsp.Tests.Capabilities.Client
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CompletionCapability>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CompletionCapability>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Client/CompletionItemCapabilityTests.cs
+++ b/test/Lsp.Tests/Capabilities/Client/CompletionItemCapabilityTests.cs
@@ -20,14 +20,14 @@ namespace Lsp.Tests.Capabilities.Client
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CompletionItemCapabilityOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CompletionItemCapabilityOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
         [Fact]
         public void TagSupportTrue()
         {
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CompletionItemCapabilityOptions>("{\"tagSupport\":true}");
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CompletionItemCapabilityOptions>("{\"tagSupport\":true}");
             deresult.Should().BeEquivalentTo(
                 new CompletionItemCapabilityOptions {
                     TagSupport = new Supports<CompletionItemTagSupportCapabilityOptions?>(true)
@@ -38,7 +38,7 @@ namespace Lsp.Tests.Capabilities.Client
         [Fact]
         public void TagSupportObject()
         {
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CompletionItemCapabilityOptions>("{\"tagSupport\":{\"valueSet\": [1]}}");
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CompletionItemCapabilityOptions>("{\"tagSupport\":{\"valueSet\": [1]}}");
             deresult.TagSupport.IsSupported.Should().Be(true);
             deresult.TagSupport.Value!.ValueSet.Should().Contain(CompletionItemTag.Deprecated);
         }

--- a/test/Lsp.Tests/Capabilities/Client/DynamicCapabilityTests.cs
+++ b/test/Lsp.Tests/Capabilities/Client/DynamicCapabilityTests.cs
@@ -16,7 +16,7 @@ namespace Lsp.Tests.Capabilities.Client
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DynamicCapability>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DynamicCapability>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Client/PublishDiagnosticsCapabilityTests.cs
+++ b/test/Lsp.Tests/Capabilities/Client/PublishDiagnosticsCapabilityTests.cs
@@ -12,7 +12,7 @@ namespace Lsp.Tests.Capabilities.Client
         [Fact]
         public void TagSupportTrue()
         {
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<PublishDiagnosticsCapability>("{\"tagSupport\":true}");
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<PublishDiagnosticsCapability>("{\"tagSupport\":true}");
             deresult.Should().BeEquivalentTo(
                 new PublishDiagnosticsCapability {
                     TagSupport = new Supports<PublishDiagnosticsTagSupportCapabilityOptions?>(true)
@@ -23,7 +23,7 @@ namespace Lsp.Tests.Capabilities.Client
         [Fact]
         public void TagSupportObject()
         {
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<PublishDiagnosticsCapability>("{\"tagSupport\":{\"valueSet\": [2,1]}}");
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<PublishDiagnosticsCapability>("{\"tagSupport\":{\"valueSet\": [2,1]}}");
             deresult.TagSupport.IsSupported.Should().Be(true);
             deresult.TagSupport.Value!.ValueSet.Should().ContainInOrder(DiagnosticTag.Deprecated, DiagnosticTag.Unnecessary);
         }

--- a/test/Lsp.Tests/Capabilities/Client/SynchronizationCapabilityTests.cs
+++ b/test/Lsp.Tests/Capabilities/Client/SynchronizationCapabilityTests.cs
@@ -21,7 +21,7 @@ namespace Lsp.Tests.Capabilities.Client
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<SynchronizationCapability>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<SynchronizationCapability>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Client/TextDocumentClientCapabilitiesTests.cs
+++ b/test/Lsp.Tests/Capabilities/Client/TextDocumentClientCapabilitiesTests.cs
@@ -48,7 +48,7 @@ namespace Lsp.Tests.Capabilities.Client
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentClientCapabilities>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentClientCapabilities>(expected);
             deresult.Should().BeEquivalentTo(model, o => o.ConfigureForSupports(Logger));
         }
 
@@ -61,7 +61,7 @@ namespace Lsp.Tests.Capabilities.Client
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentClientCapabilities>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentClientCapabilities>(expected);
             deresult.Should().BeEquivalentTo(model, o => o.ConfigureForSupports(Logger));
         }
     }

--- a/test/Lsp.Tests/Capabilities/Client/WorkspaceClientCapabilitiesTests.cs
+++ b/test/Lsp.Tests/Capabilities/Client/WorkspaceClientCapabilitiesTests.cs
@@ -30,7 +30,7 @@ namespace Lsp.Tests.Capabilities.Client
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<WorkspaceClientCapabilities>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<WorkspaceClientCapabilities>(expected);
             deresult.Should().BeEquivalentTo(model, o => o.ConfigureForSupports(Logger));
         }
 
@@ -44,7 +44,7 @@ namespace Lsp.Tests.Capabilities.Client
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<WorkspaceClientCapabilities>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<WorkspaceClientCapabilities>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Server/CodeActionOptionsTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/CodeActionOptionsTests.cs
@@ -14,13 +14,13 @@ namespace Lsp.Tests.Capabilities.Server
         {
             var model = new CodeActionRegistrationOptions.StaticOptions {
                 ResolveProvider = true,
-                CodeActionKinds = new [] { CodeActionKind.QuickFix, CodeActionKind.Refactor }
+                CodeActionKinds = new[] { CodeActionKind.QuickFix, CodeActionKind.Refactor }
             };
             var result = Fixture.SerializeObject(model);
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CodeActionRegistrationOptions.StaticOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CodeActionRegistrationOptions.StaticOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Server/CodeLensOptionsTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/CodeLensOptionsTests.cs
@@ -19,7 +19,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CodeLensRegistrationOptions.StaticOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CodeLensRegistrationOptions.StaticOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Server/CompletionOptionsTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/CompletionOptionsTests.cs
@@ -19,7 +19,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CompletionRegistrationOptions.StaticOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CompletionRegistrationOptions.StaticOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Server/DocumentLinkOptionsTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/DocumentLinkOptionsTests.cs
@@ -19,7 +19,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentLinkRegistrationOptions.StaticOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentLinkRegistrationOptions.StaticOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Server/DocumentOnTypeFormattingOptionsTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/DocumentOnTypeFormattingOptionsTests.cs
@@ -21,7 +21,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentOnTypeFormattingRegistrationOptions.StaticOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentOnTypeFormattingRegistrationOptions.StaticOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -36,7 +36,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentOnTypeFormattingRegistrationOptions.StaticOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentOnTypeFormattingRegistrationOptions.StaticOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Server/ExecuteCommandOptionsTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/ExecuteCommandOptionsTests.cs
@@ -19,7 +19,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ExecuteCommandRegistrationOptions.StaticOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ExecuteCommandRegistrationOptions.StaticOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Server/SaveOptionsTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/SaveOptionsTests.cs
@@ -19,7 +19,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<SaveOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<SaveOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Server/ServerCapabilitiesTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/ServerCapabilitiesTests.cs
@@ -69,7 +69,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ServerCapabilities>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ServerCapabilities>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -85,7 +85,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ServerCapabilities>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ServerCapabilities>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -97,7 +97,7 @@ namespace Lsp.Tests.Capabilities.Server
                 TextDocumentSync = new TextDocumentSync(new TextDocumentSyncOptions())
             };
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ServerCapabilities>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ServerCapabilities>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Server/SignatureHelpOptionsTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/SignatureHelpOptionsTests.cs
@@ -19,7 +19,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<SignatureHelpRegistrationOptions.StaticOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<SignatureHelpRegistrationOptions.StaticOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Server/TextDocumentSyncKindTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/TextDocumentSyncKindTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSyncKind>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSyncKind>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Server/TextDocumentSyncOptionsTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/TextDocumentSyncOptionsTests.cs
@@ -25,7 +25,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSyncOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSyncOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Capabilities/Server/TextDocumentSyncTests.cs
+++ b/test/Lsp.Tests/Capabilities/Server/TextDocumentSyncTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSync>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSync>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -30,7 +30,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSync>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSync>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -43,7 +43,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSync>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSync>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -66,7 +66,7 @@ namespace Lsp.Tests.Capabilities.Server
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSync>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSync>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/CompletionItemKindTests.cs
+++ b/test/Lsp.Tests/CompletionItemKindTests.cs
@@ -12,7 +12,7 @@ namespace Lsp.Tests
         [Fact]
         public void DefaultBehavior_Should_Only_Support_InitialCompletionItemKinds()
         {
-            var serializer = new Serializer();
+            var serializer = new LspSerializer();
             var json = serializer.SerializeObject(
                 new CompletionItem {
                     Kind = CompletionItemKind.Event
@@ -26,7 +26,7 @@ namespace Lsp.Tests
         [Fact]
         public void DefaultBehavior_Should_Only_Support_InitialCompletionItemTags()
         {
-            var serializer = new Serializer();
+            var serializer = new LspSerializer();
             var json = serializer.SerializeObject(
                 new CompletionItem {
                     Tags = new Container<CompletionItemTag>(CompletionItemTag.Deprecated)
@@ -40,9 +40,9 @@ namespace Lsp.Tests
         [Fact]
         public void CustomBehavior_When_CompletionItemKinds_Defined_By_Client()
         {
-            var serializer = new Serializer();
+            var serializer = new LspSerializer();
             serializer.SetClientCapabilities(
-                ClientVersion.Lsp3, new ClientCapabilities {
+                new ClientCapabilities {
                     TextDocument = new TextDocumentClientCapabilities {
                         Completion = new Supports<CompletionCapability?>(
                             true, new CompletionCapability {
@@ -64,37 +64,6 @@ namespace Lsp.Tests
 
             var result = serializer.DeserializeObject<CompletionItem>(json);
             result.Kind.Should().Be(CompletionItemKind.Class);
-        }
-
-        [Fact]
-        public void CustomBehavior_When_CompletionItemTags_Defined_By_Client()
-        {
-            var serializer = new Serializer();
-            serializer.SetClientCapabilities(
-                ClientVersion.Lsp3, new ClientCapabilities {
-                    TextDocument = new TextDocumentClientCapabilities {
-                        Completion = new Supports<CompletionCapability?>(
-                            true, new CompletionCapability {
-                                DynamicRegistration = true,
-                                CompletionItem = new CompletionItemCapabilityOptions {
-                                    TagSupport = new CompletionItemTagSupportCapabilityOptions {
-                                        ValueSet = new Container<CompletionItemTag>()
-                                    }
-                                }
-                            }
-                        )
-                    }
-                }
-            );
-
-            var json = serializer.SerializeObject(
-                new CompletionItem {
-                    Tags = new Container<CompletionItemTag>(CompletionItemTag.Deprecated)
-                }
-            );
-
-            var result = serializer.DeserializeObject<CompletionItem>(json);
-            result.Tags.Should().BeEmpty();
         }
     }
 }

--- a/test/Lsp.Tests/DiagnosticKindTests.cs
+++ b/test/Lsp.Tests/DiagnosticKindTests.cs
@@ -12,7 +12,7 @@ namespace Lsp.Tests
         [Fact]
         public void DefaultBehavior_Should_Only_Support_InitialDiagnosticTags()
         {
-            var serializer = new Serializer();
+            var serializer = new LspSerializer();
             var json = serializer.SerializeObject(
                 new Diagnostic {
                     Tags = new Container<DiagnosticTag>(DiagnosticTag.Deprecated)
@@ -21,34 +21,6 @@ namespace Lsp.Tests
 
             var result = serializer.DeserializeObject<Diagnostic>(json);
             result.Tags.Should().Contain(DiagnosticTag.Deprecated);
-        }
-
-        [Fact]
-        public void CustomBehavior_When_DiagnosticTag_Defined_By_Client()
-        {
-            var serializer = new Serializer();
-            serializer.SetClientCapabilities(
-                ClientVersion.Lsp3, new ClientCapabilities {
-                    TextDocument = new TextDocumentClientCapabilities {
-                        PublishDiagnostics = new Supports<PublishDiagnosticsCapability?>(
-                            true, new PublishDiagnosticsCapability {
-                                TagSupport = new PublishDiagnosticsTagSupportCapabilityOptions {
-                                    ValueSet = new Container<DiagnosticTag>()
-                                }
-                            }
-                        )
-                    }
-                }
-            );
-
-            var json = serializer.SerializeObject(
-                new Diagnostic {
-                    Tags = new Container<DiagnosticTag>(DiagnosticTag.Deprecated)
-                }
-            );
-
-            var result = serializer.DeserializeObject<Diagnostic>(json);
-            result.Tags.Should().BeEmpty();
         }
     }
 }

--- a/test/Lsp.Tests/DocumentSymbolKindTests.cs
+++ b/test/Lsp.Tests/DocumentSymbolKindTests.cs
@@ -14,7 +14,7 @@ namespace Lsp.Tests
         [Fact]
         public void DefaultBehavior_Should_Only_Support_InitialSymbolKinds()
         {
-            var serializer = new Serializer();
+            var serializer = new LspSerializer();
             var json = serializer.SerializeObject(
                 new SymbolInformation {
                     Kind = SymbolKind.Event
@@ -28,7 +28,7 @@ namespace Lsp.Tests
         [Fact]
         public void DefaultBehavior_Should_Only_Support_InitialSymbolTags()
         {
-            var serializer = new Serializer();
+            var serializer = new LspSerializer();
             var json = serializer.SerializeObject(
                 new SymbolInformation {
                     Tags = new Container<SymbolTag>(SymbolTag.Deprecated)
@@ -42,9 +42,9 @@ namespace Lsp.Tests
         [Fact]
         public void CustomBehavior_When_SymbolKind_Defined_By_Client()
         {
-            var serializer = new Serializer();
+            var serializer = new LspSerializer();
             serializer.SetClientCapabilities(
-                ClientVersion.Lsp3, new ClientCapabilities {
+                new ClientCapabilities {
                     TextDocument = new TextDocumentClientCapabilities {
                         DocumentSymbol = new Supports<DocumentSymbolCapability?>(
                             true, new DocumentSymbolCapability {
@@ -66,35 +66,6 @@ namespace Lsp.Tests
 
             var result = serializer.DeserializeObject<DocumentSymbol>(json);
             result.Kind.Should().Be(SymbolKind.Class);
-        }
-
-        [Fact]
-        public void CustomBehavior_When_SymbolTag_Defined_By_Client()
-        {
-            var serializer = new Serializer();
-            serializer.SetClientCapabilities(
-                ClientVersion.Lsp3, new ClientCapabilities {
-                    TextDocument = new TextDocumentClientCapabilities {
-                        DocumentSymbol = new Supports<DocumentSymbolCapability?>(
-                            true, new DocumentSymbolCapability {
-                                DynamicRegistration = true,
-                                TagSupport = new TagSupportCapabilityOptions {
-                                    ValueSet = new Container<SymbolTag>()
-                                }
-                            }
-                        )
-                    }
-                }
-            );
-
-            var json = serializer.SerializeObject(
-                new DocumentSymbol {
-                    Tags = new Container<SymbolTag>(SymbolTag.Deprecated)
-                }
-            );
-
-            var result = serializer.DeserializeObject<DocumentSymbol>(json);
-            result.Tags.Should().BeEmpty();
         }
     }
 }

--- a/test/Lsp.Tests/Fixture.cs
+++ b/test/Lsp.Tests/Fixture.cs
@@ -15,7 +15,7 @@ namespace Lsp.Tests
 
         public static string SerializeObject(object value, Type? type, JsonSerializerSettings? settings, ClientVersion version = ClientVersion.Lsp3)
         {
-            var jsonSerializer = new Serializer(version);
+            var jsonSerializer = new LspSerializer(version);
 
             return SerializeObjectInternal(value, type, jsonSerializer);
         }

--- a/test/Lsp.Tests/JsonRpcTestContainer.cs
+++ b/test/Lsp.Tests/JsonRpcTestContainer.cs
@@ -20,7 +20,7 @@ namespace Lsp.Tests
                                                                .WithUndefinedTestDependenciesResolver(request => Substitute.For(new[] { request.ServiceType }, null))
                                                                .WithConcreteTypeDynamicRegistrations((type, o) => true, Reuse.Transient)
                                                    );
-            container.RegisterInstanceMany(new Serializer(ClientVersion.Lsp3));
+            container.RegisterInstanceMany(new LspSerializer(ClientVersion.Lsp3));
             return container;
         }
     }

--- a/test/Lsp.Tests/Lsp.Tests.csproj
+++ b/test/Lsp.Tests/Lsp.Tests.csproj
@@ -4,6 +4,13 @@
         <WarningsAsErrors>true</WarningsAsErrors>
         <PlatformTarget>AnyCPU</PlatformTarget>
     </PropertyGroup>
+    <PropertyGroup>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Condition="'$(DesignTimeBuild)' == 'true' and '$(IDEA_INITIAL_DIRECTORY)' != ''" Include="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
+    </ItemGroup>
     <ItemGroup>
         <None Remove="**\*.json" />
         <EmbeddedResource Include="**\*.json" />

--- a/test/Lsp.Tests/LspRequestRouterTests.cs
+++ b/test/Lsp.Tests/LspRequestRouterTests.cs
@@ -70,7 +70,7 @@ namespace Lsp.Tests
 
             var request = new Notification(
                 TextDocumentNames.DidSave,
-                JObject.Parse(JsonConvert.SerializeObject(@params, new Serializer(ClientVersion.Lsp3).Settings))
+                JObject.Parse(JsonConvert.SerializeObject(@params, new LspSerializer(ClientVersion.Lsp3).Settings))
             );
 
             await mediator.RouteNotification(mediator.GetDescriptors(request), request, CancellationToken.None);
@@ -115,7 +115,7 @@ namespace Lsp.Tests
 
             var request = new Notification(
                 TextDocumentNames.DidSave,
-                JObject.Parse(JsonConvert.SerializeObject(@params, new Serializer(ClientVersion.Lsp3).Settings))
+                JObject.Parse(JsonConvert.SerializeObject(@params, new LspSerializer(ClientVersion.Lsp3).Settings))
             );
 
             await mediator.RouteNotification(mediator.GetDescriptors(request), request, CancellationToken.None);
@@ -162,7 +162,7 @@ namespace Lsp.Tests
 
             var request = new Request(
                 id, TextDocumentNames.CodeAction,
-                JObject.Parse(JsonConvert.SerializeObject(@params, new Serializer(ClientVersion.Lsp3).Settings))
+                JObject.Parse(JsonConvert.SerializeObject(@params, new LspSerializer(ClientVersion.Lsp3).Settings))
             );
 
             await mediator.RouteRequest(mediator.GetDescriptors(request), request, CancellationToken.None);
@@ -223,7 +223,7 @@ namespace Lsp.Tests
 
             var request = new Request(
                 id, TextDocumentNames.CodeAction,
-                JObject.Parse(JsonConvert.SerializeObject(@params, new Serializer(ClientVersion.Lsp3).Settings))
+                JObject.Parse(JsonConvert.SerializeObject(@params, new LspSerializer(ClientVersion.Lsp3).Settings))
             );
 
             await mediator.RouteRequest(mediator.GetDescriptors(request), request, CancellationToken.None);
@@ -280,7 +280,7 @@ namespace Lsp.Tests
 
             var request = new Request(
                 id, TextDocumentNames.CodeLens,
-                JObject.Parse(JsonConvert.SerializeObject(@params, new Serializer(ClientVersion.Lsp3).Settings))
+                JObject.Parse(JsonConvert.SerializeObject(@params, new LspSerializer(ClientVersion.Lsp3).Settings))
             );
 
             await mediator.RouteRequest(mediator.GetDescriptors(request), request, CancellationToken.None);

--- a/test/Lsp.Tests/MediatorTestsRequestHandlerOfTRequestTResponse.cs
+++ b/test/Lsp.Tests/MediatorTestsRequestHandlerOfTRequestTResponse.cs
@@ -51,7 +51,7 @@ namespace Lsp.Tests
                 );
 
             var collection = new SharedHandlerCollection(SupportedCapabilitiesFixture.AlwaysTrue, new TextDocumentIdentifiers(), Substitute.For<IResolverContext>(),
-                                                         new LspHandlerTypeDescriptorProvider(new [] { typeof(FoundationTests).Assembly, typeof(LanguageServer).Assembly, typeof(LanguageClient).Assembly, typeof(IRegistrationManager).Assembly, typeof(LspRequestRouter).Assembly }))
+                                                         new LspHandlerTypeDescriptorProvider(new[] { typeof(FoundationTests).Assembly, typeof(LanguageServer).Assembly, typeof(LanguageClient).Assembly, typeof(IRegistrationManager).Assembly, typeof(LspRequestRouter).Assembly }))
                 { textDocumentSyncHandler, codeActionHandler };
             AutoSubstitute.Provide<IHandlerCollection>(collection);
             AutoSubstitute.Provide<IEnumerable<ILspHandlerDescriptor>>(collection);
@@ -66,12 +66,12 @@ namespace Lsp.Tests
                 }
             };
 
-            var request = new Request(id, "textDocument/codeAction", JObject.Parse(JsonConvert.SerializeObject(@params, new Serializer(ClientVersion.Lsp3).Settings)));
+            var request = new Request(id, "textDocument/codeAction", JObject.Parse(JsonConvert.SerializeObject(@params, new LspSerializer(ClientVersion.Lsp3).Settings)));
             var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            ( (IRequestRouter<ILspHandlerDescriptor>) mediator ).RouteRequest(mediator.GetDescriptors(request), request, cts.Token);
-            Func<Task> action = () => ( (IRequestRouter<ILspHandlerDescriptor>) mediator ).RouteRequest(mediator.GetDescriptors(request), request, cts.Token);
+            ( (IRequestRouter<ILspHandlerDescriptor>)mediator ).RouteRequest(mediator.GetDescriptors(request), request, cts.Token);
+            Func<Task> action = () => ( (IRequestRouter<ILspHandlerDescriptor>)mediator ).RouteRequest(mediator.GetDescriptors(request), request, cts.Token);
             await action.Should().ThrowAsync<OperationCanceledException>();
         }
     }

--- a/test/Lsp.Tests/Messages/ServerNotInitializedTests.cs
+++ b/test/Lsp.Tests/Messages/ServerNotInitializedTests.cs
@@ -18,7 +18,7 @@ namespace Lsp.Tests.Messages
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<RpcError>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<RpcError>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Messages/UnknownErrorCodeTests.cs
+++ b/test/Lsp.Tests/Messages/UnknownErrorCodeTests.cs
@@ -18,7 +18,7 @@ namespace Lsp.Tests.Messages
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<RpcError>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<RpcError>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/ApplyWorkspaceEditParamsTests.cs
+++ b/test/Lsp.Tests/Models/ApplyWorkspaceEditParamsTests.cs
@@ -38,7 +38,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ApplyWorkspaceEditParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ApplyWorkspaceEditParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -69,7 +69,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ApplyWorkspaceEditParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ApplyWorkspaceEditParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -141,7 +141,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ApplyWorkspaceEditParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ApplyWorkspaceEditParams>(expected);
             deresult.Should().BeEquivalentTo(
                 model, x => x
                    .ComparingByMembers<WorkspaceEditDocumentChange>()

--- a/test/Lsp.Tests/Models/ApplyWorkspaceEditResponseTests.cs
+++ b/test/Lsp.Tests/Models/ApplyWorkspaceEditResponseTests.cs
@@ -19,7 +19,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ApplyWorkspaceEditResponse>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ApplyWorkspaceEditResponse>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/BooleanNumberStringTests.cs
+++ b/test/Lsp.Tests/Models/BooleanNumberStringTests.cs
@@ -16,7 +16,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be("null");
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<BooleanNumberString>("null");
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<BooleanNumberString>("null");
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -28,7 +28,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be("1");
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<BooleanNumberString>("1");
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<BooleanNumberString>("1");
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -40,7 +40,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be("true");
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<BooleanNumberString>("true");
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<BooleanNumberString>("true");
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -52,7 +52,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be("\"abc\"");
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<BooleanNumberString>("\"abc\"");
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<BooleanNumberString>("\"abc\"");
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/CancelParamsTests.cs
+++ b/test/Lsp.Tests/Models/CancelParamsTests.cs
@@ -19,7 +19,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CancelParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CancelParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/CodeActionContextTests.cs
+++ b/test/Lsp.Tests/Models/CodeActionContextTests.cs
@@ -27,7 +27,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CodeActionContext>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CodeActionContext>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/CodeActionParamsTests.cs
+++ b/test/Lsp.Tests/Models/CodeActionParamsTests.cs
@@ -35,7 +35,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CodeActionParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CodeActionParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -65,7 +65,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CodeActionParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CodeActionParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/CodeActionRegistrationOptionsTests.cs
+++ b/test/Lsp.Tests/Models/CodeActionRegistrationOptionsTests.cs
@@ -38,7 +38,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CodeActionRegistrationOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CodeActionRegistrationOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/CodeLensParamsTests.cs
+++ b/test/Lsp.Tests/Models/CodeLensParamsTests.cs
@@ -21,7 +21,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CodeLensParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CodeLensParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -37,7 +37,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CodeLensParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CodeLensParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/CodeLensRegistrationOptionsTests.cs
+++ b/test/Lsp.Tests/Models/CodeLensRegistrationOptionsTests.cs
@@ -30,7 +30,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CodeLensRegistrationOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CodeLensRegistrationOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/CodeLensTests.cs
+++ b/test/Lsp.Tests/Models/CodeLensTests.cs
@@ -32,7 +32,7 @@ namespace Lsp.Tests.Models
             result.Should().Be(expected);
 
             // TODO: Come back and fix this...
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CodeLens>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CodeLens>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/CommandTests.cs
+++ b/test/Lsp.Tests/Models/CommandTests.cs
@@ -22,7 +22,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<Command>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<Command>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/CompletionItemKindTests.cs
+++ b/test/Lsp.Tests/Models/CompletionItemKindTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CompletionItemKind>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CompletionItemKind>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/CompletionItemTests.cs
+++ b/test/Lsp.Tests/Models/CompletionItemTests.cs
@@ -25,7 +25,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CompletionItem>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CompletionItem>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/CompletionListTests.cs
+++ b/test/Lsp.Tests/Models/CompletionListTests.cs
@@ -25,7 +25,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CompletionList>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CompletionList>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -45,7 +45,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CompletionList>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CompletionList>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/CompletionRegistrationOptionsTests.cs
+++ b/test/Lsp.Tests/Models/CompletionRegistrationOptionsTests.cs
@@ -25,7 +25,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<CompletionRegistrationOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<CompletionRegistrationOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DiagnosticCodeTests.cs
+++ b/test/Lsp.Tests/Models/DiagnosticCodeTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DiagnosticCode>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DiagnosticCode>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DiagnosticSeverityTests.cs
+++ b/test/Lsp.Tests/Models/DiagnosticSeverityTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DiagnosticSeverity>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DiagnosticSeverity>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DiagnosticTests.cs
+++ b/test/Lsp.Tests/Models/DiagnosticTests.cs
@@ -25,7 +25,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<Diagnostic>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<Diagnostic>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -61,7 +61,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<Diagnostic>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<Diagnostic>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -74,7 +74,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<Diagnostic>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<Diagnostic>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DidChangeConfigurationParamsTests.cs
+++ b/test/Lsp.Tests/Models/DidChangeConfigurationParamsTests.cs
@@ -27,7 +27,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DidChangeConfigurationParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DidChangeConfigurationParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DidChangeTextDocumentParamsTests.cs
+++ b/test/Lsp.Tests/Models/DidChangeTextDocumentParamsTests.cs
@@ -29,7 +29,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DidChangeTextDocumentParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DidChangeTextDocumentParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -53,7 +53,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DidChangeTextDocumentParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DidChangeTextDocumentParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DidChangeWatchedFilesParamsTests.cs
+++ b/test/Lsp.Tests/Models/DidChangeWatchedFilesParamsTests.cs
@@ -25,7 +25,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DidChangeWatchedFilesParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DidChangeWatchedFilesParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -46,7 +46,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DidChangeWatchedFilesParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DidChangeWatchedFilesParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DidCloseTextDocumentParamsTests.cs
+++ b/test/Lsp.Tests/Models/DidCloseTextDocumentParamsTests.cs
@@ -20,7 +20,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DidCloseTextDocumentParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DidCloseTextDocumentParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DidOpenTextDocumentParamsTests.cs
+++ b/test/Lsp.Tests/Models/DidOpenTextDocumentParamsTests.cs
@@ -25,7 +25,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DidOpenTextDocumentParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DidOpenTextDocumentParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DidSaveTextDocumentParamsTests.cs
+++ b/test/Lsp.Tests/Models/DidSaveTextDocumentParamsTests.cs
@@ -21,7 +21,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DidSaveTextDocumentParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DidSaveTextDocumentParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DocumentFilterTests.cs
+++ b/test/Lsp.Tests/Models/DocumentFilterTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentFilter>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentFilter>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -32,7 +32,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentFilter>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentFilter>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -47,7 +47,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentFilter>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentFilter>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -62,7 +62,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentFilter>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentFilter>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -78,7 +78,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentFilter>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentFilter>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -95,7 +95,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentFilter>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentFilter>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DocumentFormattingParamsTests.cs
+++ b/test/Lsp.Tests/Models/DocumentFormattingParamsTests.cs
@@ -23,7 +23,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentFormattingParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentFormattingParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DocumentHighlightKindTests.cs
+++ b/test/Lsp.Tests/Models/DocumentHighlightKindTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentHighlightKind>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentHighlightKind>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DocumentHighlightTests.cs
+++ b/test/Lsp.Tests/Models/DocumentHighlightTests.cs
@@ -20,7 +20,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentHighlight>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentHighlight>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DocumentLinkParamsTests.cs
+++ b/test/Lsp.Tests/Models/DocumentLinkParamsTests.cs
@@ -20,7 +20,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentLinkParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentLinkParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DocumentLinkRegistrationOptionsTests.cs
+++ b/test/Lsp.Tests/Models/DocumentLinkRegistrationOptionsTests.cs
@@ -24,7 +24,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentLinkRegistrationOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentLinkRegistrationOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DocumentLinkTests.cs
+++ b/test/Lsp.Tests/Models/DocumentLinkTests.cs
@@ -22,7 +22,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentLink>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentLink>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DocumentOnTypeFormattingParamsTests.cs
+++ b/test/Lsp.Tests/Models/DocumentOnTypeFormattingParamsTests.cs
@@ -25,7 +25,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentOnTypeFormattingParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentOnTypeFormattingParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DocumentOnTypeFormattingRegistrationOptionsTests.cs
+++ b/test/Lsp.Tests/Models/DocumentOnTypeFormattingRegistrationOptionsTests.cs
@@ -25,7 +25,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentOnTypeFormattingRegistrationOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentOnTypeFormattingRegistrationOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DocumentSelectorTests.cs
+++ b/test/Lsp.Tests/Models/DocumentSelectorTests.cs
@@ -25,7 +25,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentSelector>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentSelector>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DocumentSymbolInformationTests.cs
+++ b/test/Lsp.Tests/Models/DocumentSymbolInformationTests.cs
@@ -27,7 +27,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<SymbolInformation>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<SymbolInformation>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/DocumentSymbolParamsTests.cs
+++ b/test/Lsp.Tests/Models/DocumentSymbolParamsTests.cs
@@ -20,7 +20,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<DocumentSymbolParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<DocumentSymbolParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/ExecuteCommandParamsTests.cs
+++ b/test/Lsp.Tests/Models/ExecuteCommandParamsTests.cs
@@ -21,7 +21,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ExecuteCommandParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ExecuteCommandParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/ExecuteCommandRegistrationOptionsTests.cs
+++ b/test/Lsp.Tests/Models/ExecuteCommandRegistrationOptionsTests.cs
@@ -19,7 +19,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ExecuteCommandRegistrationOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ExecuteCommandRegistrationOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/FileChangeTypeTests.cs
+++ b/test/Lsp.Tests/Models/FileChangeTypeTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<FileChangeType>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<FileChangeType>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/FileEventTests.cs
+++ b/test/Lsp.Tests/Models/FileEventTests.cs
@@ -21,7 +21,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<FileEvent>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<FileEvent>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/FoldingRangeKindTests.cs
+++ b/test/Lsp.Tests/Models/FoldingRangeKindTests.cs
@@ -10,7 +10,7 @@ namespace Lsp.Tests.Models
         [Fact]
         public void CommentTest()
         {
-            var serializer = new Serializer();
+            var serializer = new LspSerializer();
             var json = serializer.SerializeObject(FoldingRangeKind.Comment);
             json.Should().Be("\"comment\"");
         }
@@ -18,7 +18,7 @@ namespace Lsp.Tests.Models
         [Fact]
         public void ImportsTest()
         {
-            var serializer = new Serializer();
+            var serializer = new LspSerializer();
             var json = serializer.SerializeObject(FoldingRangeKind.Imports);
             json.Should().Be("\"imports\"");
         }
@@ -26,7 +26,7 @@ namespace Lsp.Tests.Models
         [Fact]
         public void RegionTest()
         {
-            var serializer = new Serializer();
+            var serializer = new LspSerializer();
             var json = serializer.SerializeObject(FoldingRangeKind.Region);
             json.Should().Be("\"region\"");
         }

--- a/test/Lsp.Tests/Models/FormattingOptionsTests.cs
+++ b/test/Lsp.Tests/Models/FormattingOptionsTests.cs
@@ -21,7 +21,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<FormattingOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<FormattingOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 

--- a/test/Lsp.Tests/Models/HoverTests.cs
+++ b/test/Lsp.Tests/Models/HoverTests.cs
@@ -20,7 +20,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<Hover>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<Hover>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/InitializeErrorTests.cs
+++ b/test/Lsp.Tests/Models/InitializeErrorTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<InitializeError>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<InitializeError>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/InitializeParamsTests.cs
+++ b/test/Lsp.Tests/Models/InitializeParamsTests.cs
@@ -74,7 +74,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<InitializeParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<InitializeParams>(expected);
             deresult.Should().BeEquivalentTo(model, o => o.ConfigureForSupports(Logger));
         }
     }

--- a/test/Lsp.Tests/Models/InitializeResultTests.cs
+++ b/test/Lsp.Tests/Models/InitializeResultTests.cs
@@ -67,7 +67,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<InitializeResult>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<InitializeResult>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -111,7 +111,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<InitializeResult>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<InitializeResult>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/InsertTextFormatTests.cs
+++ b/test/Lsp.Tests/Models/InsertTextFormatTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<InsertTextFormat>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<InsertTextFormat>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/LocationOrLocationLinksTests.cs
+++ b/test/Lsp.Tests/Models/LocationOrLocationLinksTests.cs
@@ -19,7 +19,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<LocationOrLocationLinks>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<LocationOrLocationLinks>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -36,7 +36,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<LocationOrLocationLinks>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<LocationOrLocationLinks>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -55,7 +55,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<LocationOrLocationLinks>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<LocationOrLocationLinks>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -75,7 +75,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<LocationOrLocationLinks>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<LocationOrLocationLinks>(expected);
             deresult.Should().BeEquivalentTo(
                 model, x => x
                    .ComparingByMembers<LocationOrLocationLink>()
@@ -104,7 +104,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<LocationOrLocationLinks>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<LocationOrLocationLinks>(expected);
             deresult.Should().BeEquivalentTo(
                 model, x => x
                            .ComparingByMembers<LocationOrLocationLink>()

--- a/test/Lsp.Tests/Models/LocationTests.cs
+++ b/test/Lsp.Tests/Models/LocationTests.cs
@@ -22,7 +22,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<Location>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<Location>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/LogMessageParamsTests.cs
+++ b/test/Lsp.Tests/Models/LogMessageParamsTests.cs
@@ -20,7 +20,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<LogMessageParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<LogMessageParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/MarkedStringTests.cs
+++ b/test/Lsp.Tests/Models/MarkedStringTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<MarkedString>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<MarkedString>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/MessageActionItemTests.cs
+++ b/test/Lsp.Tests/Models/MessageActionItemTests.cs
@@ -19,7 +19,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<MessageActionItem>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<MessageActionItem>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/MessageTypeTests.cs
+++ b/test/Lsp.Tests/Models/MessageTypeTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<MessageType>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<MessageType>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/ParameterInformationTests.cs
+++ b/test/Lsp.Tests/Models/ParameterInformationTests.cs
@@ -20,7 +20,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ParameterInformation>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ParameterInformation>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/PositionTests.cs
+++ b/test/Lsp.Tests/Models/PositionTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<Position>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<Position>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -62,7 +62,7 @@ namespace Lsp.Tests.Models
             a = a.Delta(deltaCharacter: -1);
             a.Character.Should().Be(0);
             a = a.Delta(-1, 1);
-            a.Should().Be(( 1, 1 ));
+            a.Should().Be((1, 1));
         }
     }
 }

--- a/test/Lsp.Tests/Models/PublishDiagnosticsParamsTests.cs
+++ b/test/Lsp.Tests/Models/PublishDiagnosticsParamsTests.cs
@@ -30,7 +30,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<PublishDiagnosticsParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<PublishDiagnosticsParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/RangeTests.cs
+++ b/test/Lsp.Tests/Models/RangeTests.cs
@@ -18,7 +18,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<Range>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<Range>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -69,7 +69,7 @@ namespace Lsp.Tests.Models
                 "lt" => Range.CompareRangesUsingEnds(a, b) < 0,
                 "eq" => Range.CompareRangesUsingEnds(a, b) == 0,
                 "gt" => Range.CompareRangesUsingEnds(a, b) > 0,
-                _    => false
+                _ => false
             } ).Should().BeTrue(because);
 
         }
@@ -93,7 +93,7 @@ namespace Lsp.Tests.Models
                 "lt" => Range.CompareRangesUsingStarts(a, b) < 0,
                 "eq" => Range.CompareRangesUsingStarts(a, b) == 0,
                 "gt" => Range.CompareRangesUsingStarts(a, b) > 0,
-                _    => false
+                _ => false
             } ).Should().BeTrue(because);
 
         }
@@ -169,7 +169,7 @@ namespace Lsp.Tests.Models
         public void Ranges_Can_Be_Added()
         {
             var a = new Range(1, 1, 2, 2);
-            var b = new Range(3,3, 4,0);
+            var b = new Range(3, 3, 4, 0);
 
             ( a + b ).Should().Be(new Range(1, 1, 4, 0));
         }
@@ -178,7 +178,7 @@ namespace Lsp.Tests.Models
         public void Ranges_Can_Span_Lines()
         {
             var a = new Range(1, 1, 1, 2);
-            var b = new Range(3,3, 4,0);
+            var b = new Range(3, 3, 4, 0);
 
             a.SpansMultipleLines().Should().BeFalse();
             b.SpansMultipleLines().Should().BeTrue();
@@ -198,7 +198,7 @@ namespace Lsp.Tests.Models
         {
             var a = new Range(1, 1, 1, 3);
             var b = new Range(2, 1, 2, 2);
-            var c = new Range(1,2, 4, 0);
+            var c = new Range(1, 2, 4, 0);
 
             a.Intersection(b).Should().BeNull();
             b.Intersection(a).Should().BeNull();
@@ -206,8 +206,8 @@ namespace Lsp.Tests.Models
 
             c.Intersection(b).Should().Be(b);
             b.Intersection(c).Should().Be(b);
-            c.Intersection(a).Should().Be(new Range(1,2, 1, 3));
-            a.Intersection(c).Should().Be(new Range(1,2, 1, 3));
+            c.Intersection(a).Should().Be(new Range(1, 2, 1, 3));
+            a.Intersection(c).Should().Be(new Range(1, 2, 1, 3));
         }
 
         [Fact]

--- a/test/Lsp.Tests/Models/ReferenceContextTests.cs
+++ b/test/Lsp.Tests/Models/ReferenceContextTests.cs
@@ -19,7 +19,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ReferenceContext>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ReferenceContext>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/ReferenceParamsTests.cs
+++ b/test/Lsp.Tests/Models/ReferenceParamsTests.cs
@@ -24,7 +24,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ReferenceParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ReferenceParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/RegistrationParamsTests.cs
+++ b/test/Lsp.Tests/Models/RegistrationParamsTests.cs
@@ -26,7 +26,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<RegistrationParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<RegistrationParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/RegistrationTests.cs
+++ b/test/Lsp.Tests/Models/RegistrationTests.cs
@@ -22,7 +22,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<Registration>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<Registration>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/RenameParamsTests.cs
+++ b/test/Lsp.Tests/Models/RenameParamsTests.cs
@@ -22,7 +22,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<RenameParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<RenameParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/ShowMessageParamsTests.cs
+++ b/test/Lsp.Tests/Models/ShowMessageParamsTests.cs
@@ -20,7 +20,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ShowMessageParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ShowMessageParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/ShowMessageRequestParamsTests.cs
+++ b/test/Lsp.Tests/Models/ShowMessageRequestParamsTests.cs
@@ -25,7 +25,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<ShowMessageRequestParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<ShowMessageRequestParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/SignatureHelpRegistrationOptionsTests.cs
+++ b/test/Lsp.Tests/Models/SignatureHelpRegistrationOptionsTests.cs
@@ -24,7 +24,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<SignatureHelpRegistrationOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<SignatureHelpRegistrationOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/SignatureHelpTests.cs
+++ b/test/Lsp.Tests/Models/SignatureHelpTests.cs
@@ -32,7 +32,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<SignatureHelp>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<SignatureHelp>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -45,7 +45,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<SignatureHelp>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<SignatureHelp>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/SignatureInformationTests.cs
+++ b/test/Lsp.Tests/Models/SignatureInformationTests.cs
@@ -27,7 +27,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<SignatureInformation>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<SignatureInformation>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -49,7 +49,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<SignatureInformation>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<SignatureInformation>(expected);
             deresult.Should().BeEquivalentTo(
                 model, x => x
                            .ComparingByMembers<ValueTuple<int, int>>()
@@ -80,7 +80,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<SignatureInformation>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<SignatureInformation>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/SymbolKindTests.cs
+++ b/test/Lsp.Tests/Models/SymbolKindTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<SymbolKind>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<SymbolKind>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/TextDocumentChangeRegistrationOptionsTests.cs
+++ b/test/Lsp.Tests/Models/TextDocumentChangeRegistrationOptionsTests.cs
@@ -25,7 +25,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentChangeRegistrationOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentChangeRegistrationOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/TextDocumentContentChangeEventTests.cs
+++ b/test/Lsp.Tests/Models/TextDocumentContentChangeEventTests.cs
@@ -21,7 +21,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentContentChangeEvent>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentContentChangeEvent>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/TextDocumentEditTests.cs
+++ b/test/Lsp.Tests/Models/TextDocumentEditTests.cs
@@ -34,7 +34,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentEdit>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentEdit>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/TextDocumentIdentifierTests.cs
+++ b/test/Lsp.Tests/Models/TextDocumentIdentifierTests.cs
@@ -19,14 +19,14 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentIdentifier>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentIdentifier>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
         [Fact]
         public void Should_Deserialize_For_Example_Value()
         {
-            var serializer = new Serializer(ClientVersion.Lsp3);
+            var serializer = new LspSerializer(ClientVersion.Lsp3);
             var result = serializer.DeserializeObject<TextDocumentIdentifier>(
                 @"{
                 ""uri"":""file:///Users/tyler/Code/PowerShell/vscode/PowerShellEditorServices/test/PowerShellEditorServices.Test.E2E/bin/Debug/netcoreapp3.1/0b0jnxg2.kgh.ps1""

--- a/test/Lsp.Tests/Models/TextDocumentItemTests.cs
+++ b/test/Lsp.Tests/Models/TextDocumentItemTests.cs
@@ -23,7 +23,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentItem>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentItem>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/TextDocumentPositionParamsTests.cs
+++ b/test/Lsp.Tests/Models/TextDocumentPositionParamsTests.cs
@@ -21,7 +21,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentPositionParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentPositionParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/TextDocumentRegistrationOptionsTests.cs
+++ b/test/Lsp.Tests/Models/TextDocumentRegistrationOptionsTests.cs
@@ -23,7 +23,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentRegistrationOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentRegistrationOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/TextDocumentSaveReasonTests.cs
+++ b/test/Lsp.Tests/Models/TextDocumentSaveReasonTests.cs
@@ -17,7 +17,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSaveReason>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSaveReason>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/TextDocumentSaveRegistrationOptionsTests.cs
+++ b/test/Lsp.Tests/Models/TextDocumentSaveRegistrationOptionsTests.cs
@@ -24,7 +24,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSaveRegistrationOptions>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextDocumentSaveRegistrationOptions>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/TextEditTests.cs
+++ b/test/Lsp.Tests/Models/TextEditTests.cs
@@ -20,7 +20,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<TextEdit>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<TextEdit>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/UnregistrationParamsTests.cs
+++ b/test/Lsp.Tests/Models/UnregistrationParamsTests.cs
@@ -24,7 +24,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<UnregistrationParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<UnregistrationParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/UnregistrationTests.cs
+++ b/test/Lsp.Tests/Models/UnregistrationTests.cs
@@ -20,7 +20,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<Unregistration>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<Unregistration>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/VersionedTextDocumentIdentifierTests.cs
+++ b/test/Lsp.Tests/Models/VersionedTextDocumentIdentifierTests.cs
@@ -21,7 +21,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<VersionedTextDocumentIdentifier>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<VersionedTextDocumentIdentifier>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/WillSaveTextDocumentParamsTests.cs
+++ b/test/Lsp.Tests/Models/WillSaveTextDocumentParamsTests.cs
@@ -21,7 +21,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<WillSaveTextDocumentParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<WillSaveTextDocumentParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/WorkspaceEditTests.cs
+++ b/test/Lsp.Tests/Models/WorkspaceEditTests.cs
@@ -36,7 +36,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<WorkspaceEdit>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<WorkspaceEdit>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
 
@@ -106,7 +106,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<WorkspaceEdit>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<WorkspaceEdit>(expected);
             deresult.Should().BeEquivalentTo(
                 model, x => x
                    .ComparingByMembers<WorkspaceEditDocumentChange>()

--- a/test/Lsp.Tests/Models/WorkspaceSymbolInformationTests.cs
+++ b/test/Lsp.Tests/Models/WorkspaceSymbolInformationTests.cs
@@ -27,7 +27,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<SymbolInformation>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<SymbolInformation>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/Models/WorkspaceSymbolParamsTests.cs
+++ b/test/Lsp.Tests/Models/WorkspaceSymbolParamsTests.cs
@@ -19,7 +19,7 @@ namespace Lsp.Tests.Models
 
             result.Should().Be(expected);
 
-            var deresult = new Serializer(ClientVersion.Lsp3).DeserializeObject<WorkspaceSymbolParams>(expected);
+            var deresult = new LspSerializer(ClientVersion.Lsp3).DeserializeObject<WorkspaceSymbolParams>(expected);
             deresult.Should().BeEquivalentTo(model);
         }
     }

--- a/test/Lsp.Tests/SemanticTokensDocumentTests.cs
+++ b/test/Lsp.Tests/SemanticTokensDocumentTests.cs
@@ -42,7 +42,6 @@ namespace Lsp.Tests
                                      new SemanticTokenModifier("modification"),
                                      new SemanticTokenModifier("defaultLibrary")
                                  }
-                                .Select(z => z.ToString())
                                 .ToArray(),
                 TokenTypes = new[] {
                                  new SemanticTokenType("comment"),
@@ -69,7 +68,6 @@ namespace Lsp.Tests
                                  new SemanticTokenType("event"),
                                  new SemanticTokenType("enumMember"),
                              }
-                            .Select(x => x.ToString())
                             .ToArray(),
             };
         }
@@ -278,7 +276,7 @@ namespace Lsp.Tests
                                            .OrNull(f, 0.2f)
                         );
 
-            foreach (var (line, text) in document.Split('\n').Select((text, line) => ( line, text )))
+            foreach (var (line, text) in document.Split('\n').Select((text, line) => (line, text)))
             {
                 var parts = text.TrimEnd().Split(';', ' ', '.', '"', '(', ')');
                 var index = 0;
@@ -297,7 +295,7 @@ namespace Lsp.Tests
                     else
                     {
                         // ensure range gets some love
-                        builder.Push(( ( line, index ), ( line, part.Length + index ) ), item.Type, item.Modifiers);
+                        builder.Push(((line, index), (line, part.Length + index)), item.Type, item.Modifiers);
                     }
                 }
             }
@@ -341,7 +339,7 @@ namespace Lsp.Tests
             {
                 if (obj is null) return false;
                 if (ReferenceEquals(this, obj)) return true;
-                return obj.GetType() == GetType() && Equals((NormalizedToken) obj);
+                return obj.GetType() == GetType() && Equals((NormalizedToken)obj);
             }
 
             public override int GetHashCode() => HashCode.Combine(Text, Type, Modifiers);
@@ -434,7 +432,7 @@ namespace Lsp.Tests
         {
             for (var i = 0; i < values.Count; i += 5)
             {
-                yield return ( values[i], values[i + 1], values[i + 2], values[i + 3], values[i + 4] );
+                yield return (values[i], values[i + 1], values[i + 2], values[i + 3], values[i + 4]);
             }
         }
 

--- a/test/Lsp.Tests/SemanticTokensLegendTests.cs
+++ b/test/Lsp.Tests/SemanticTokensLegendTests.cs
@@ -1,0 +1,84 @@
+using System.Linq;
+using FluentAssertions;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals;
+using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
+using Xunit;
+
+namespace Lsp.Tests
+{
+    public class SemanticTokensLegendTests
+    {
+        [Fact]
+        public void CustomBehavior_When_SymbolKind_Defined_By_Client()
+        {
+            var serializer = new LspSerializer();
+            serializer.SetClientCapabilities(
+                new ClientCapabilities {
+                    TextDocument = new TextDocumentClientCapabilities {
+                        SemanticTokens = new SemanticTokensCapability() {
+                            DynamicRegistration = true,
+                            Formats = new Container<SemanticTokenFormat>(SemanticTokenFormat.Relative),
+                            MultilineTokenSupport = true,
+                            OverlappingTokenSupport = true,
+                            TokenModifiers = new Container<SemanticTokenModifier>(SemanticTokenModifier.Deprecated),
+                            TokenTypes = new Container<SemanticTokenType>(SemanticTokenType.Comment),
+                            Requests = new SemanticTokensCapabilityRequests() {
+                                Full = new SemanticTokensCapabilityRequestFull() {
+                                    Delta = true
+                                },
+                                Range = new SemanticTokensCapabilityRequestRange() {
+                                }
+                            }
+                        },
+
+                    }
+                }
+            );
+
+            var json = serializer.SerializeObject(
+                new SemanticTokensLegend {
+                    TokenModifiers = new Container<SemanticTokenModifier>(SemanticTokenModifier.Deprecated),
+                    TokenTypes = new Container<SemanticTokenType>(SemanticTokenType.Comment),
+                }
+            );
+
+            var result = serializer.DeserializeObject<SemanticTokensLegend>(json);
+            result.TokenModifiers.FirstOrDefault().Should().Be(SemanticTokenModifier.Deprecated);
+            result.TokenTypes.FirstOrDefault().Should().Be(SemanticTokenType.Comment);
+        }
+
+        [Fact]
+        public void CustomBehavior_When_SymbolKind_Defined_By_Server()
+        {
+            var serializer = new LspSerializer();
+            serializer.SetServerCapabilities(
+                new ServerCapabilities {
+                    SemanticTokensProvider = new SemanticTokensRegistrationOptions.StaticOptions() {
+                        Full = new SemanticTokensCapabilityRequestFull {
+                            Delta = true
+                        },
+                        Legend = new SemanticTokensLegend {
+                            TokenModifiers = new Container<SemanticTokenModifier>(SemanticTokenModifier.Deprecated),
+                            TokenTypes = new Container<SemanticTokenType>(SemanticTokenType.Comment),
+                        },
+                        Range = new SemanticTokensCapabilityRequestRange(),
+                    }
+                }
+            );
+
+            var json = serializer.SerializeObject(
+                new SemanticTokensLegend {
+                    TokenModifiers = new Container<SemanticTokenModifier>(SemanticTokenModifier.Deprecated),
+                    TokenTypes = new Container<SemanticTokenType>(SemanticTokenType.Comment),
+                }
+            );
+
+            var result = serializer.DeserializeObject<SemanticTokensLegend>(json);
+            result.TokenModifiers.FirstOrDefault().Should().Be(SemanticTokenModifier.Deprecated);
+            result.TokenTypes.FirstOrDefault().Should().Be(SemanticTokenType.Comment);
+        }
+    }
+}

--- a/test/Lsp.Tests/WorkspaceSymbolKindTests.cs
+++ b/test/Lsp.Tests/WorkspaceSymbolKindTests.cs
@@ -14,7 +14,7 @@ namespace Lsp.Tests
         [Fact]
         public void DefaultBehavior_Should_Only_Support_InitialSymbolKinds()
         {
-            var serializer = new Serializer();
+            var serializer = new LspSerializer();
             var json = serializer.SerializeObject(
                 new SymbolInformation {
                     Kind = SymbolKind.Event
@@ -28,7 +28,7 @@ namespace Lsp.Tests
         [Fact]
         public void DefaultBehavior_Should_Only_Support_InitialSymbolTags()
         {
-            var serializer = new Serializer();
+            var serializer = new LspSerializer();
             var json = serializer.SerializeObject(
                 new SymbolInformation {
                     Tags = new Container<SymbolTag>(SymbolTag.Deprecated)
@@ -42,9 +42,9 @@ namespace Lsp.Tests
         [Fact]
         public void CustomBehavior_When_SymbolKind_Defined_By_Client()
         {
-            var serializer = new Serializer();
+            var serializer = new LspSerializer();
             serializer.SetClientCapabilities(
-                ClientVersion.Lsp3, new ClientCapabilities {
+                new ClientCapabilities {
                     Workspace = new WorkspaceClientCapabilities {
                         Symbol = new Supports<WorkspaceSymbolCapability?>(
                             true, new WorkspaceSymbolCapability {
@@ -65,35 +65,6 @@ namespace Lsp.Tests
 
             var result = serializer.DeserializeObject<SymbolInformation>(json);
             result.Kind.Should().Be(SymbolKind.Class);
-        }
-
-        [Fact]
-        public void CustomBehavior_When_SymbolTag_Defined_By_Client()
-        {
-            var serializer = new Serializer();
-            serializer.SetClientCapabilities(
-                ClientVersion.Lsp3, new ClientCapabilities {
-                    Workspace = new WorkspaceClientCapabilities {
-                        Symbol = new Supports<WorkspaceSymbolCapability?>(
-                            true, new WorkspaceSymbolCapability {
-                                DynamicRegistration = true,
-                                TagSupport = new TagSupportCapabilityOptions {
-                                    ValueSet = new Container<SymbolTag>()
-                                }
-                            }
-                        )
-                    }
-                }
-            );
-
-            var json = serializer.SerializeObject(
-                new SymbolInformation {
-                    Tags = new Container<SymbolTag>(SymbolTag.Deprecated)
-                }
-            );
-
-            var result = serializer.DeserializeObject<SymbolInformation>(json);
-            result.Tags.Should().BeEmpty();
         }
     }
 }


### PR DESCRIPTION
* LSP Serializer renamed to LSPSerializer
* Added serialization rules for client
  * Ensure code actions are provided properly.
* Updated serialization rules for server