### PR TITLE
Reduce use of Assembly.GetTypes() or ExportedTypes

### DIFF
--- a/src/Dap.Shared/DebugAdapterProtocolServiceCollectionExtensions.cs
+++ b/src/Dap.Shared/DebugAdapterProtocolServiceCollectionExtensions.cs
@@ -15,7 +15,15 @@ namespace OmniSharp.Extensions.DebugAdapter.Shared
             }
 
             container = container.AddJsonRpcServerCore(options);
-            container.RegisterInstanceMany(new HandlerTypeDescriptorProvider(options.Assemblies), nonPublicServiceTypes: true);
+
+            if (options.UseAssemblyAttributeScanning)
+            {
+                container.RegisterInstanceMany(new AssemblyAttributeHandlerTypeDescriptorProvider(options.Assemblies), nonPublicServiceTypes: true);
+            }
+            else
+            {
+                container.RegisterInstanceMany(new AssemblyScanningHandlerTypeDescriptorProvider(options.Assemblies), nonPublicServiceTypes: true);
+            }
 
             container.RegisterInstanceMany(options.Serializer);
             container.RegisterInstance(options.RequestProcessIdentifier);

--- a/src/JsonRpc.Generators/AssemblyCapabilityKeyAttributeGenerator.cs
+++ b/src/JsonRpc.Generators/AssemblyCapabilityKeyAttributeGenerator.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using OmniSharp.Extensions.JsonRpc.Generators.Cache;
+
+namespace OmniSharp.Extensions.JsonRpc.Generators
+{
+    [Generator]
+    public class AssemblyCapabilityKeyAttributeGenerator : CachedSourceGenerator<AssemblyCapabilityKeyAttributeGenerator.SyntaxReceiver, TypeDeclarationSyntax>
+    {
+        protected override void Execute(
+            GeneratorExecutionContext context, SyntaxReceiver syntaxReceiver, AddCacheSource<TypeDeclarationSyntax> addCacheSource,
+            ReportCacheDiagnostic<TypeDeclarationSyntax> cacheDiagnostic
+        )
+        {
+            var namespaces = new HashSet<string>() { "OmniSharp.Extensions.LanguageServer.Protocol" };
+            var types = syntaxReceiver.FoundNodes
+                                      .Concat(syntaxReceiver.Handlers)
+                                      .Select(
+                                           options => {
+                                               var semanticModel = context.Compilation.GetSemanticModel(options.SyntaxTree);
+                                               foreach (var item in options.SyntaxTree.GetCompilationUnitRoot()
+                                                                           .Usings
+                                                                           .Where(z => z.Alias == null)
+                                                                           .Select(z => z.Name.ToFullString()))
+                                               {
+                                                   namespaces.Add(item);
+                                               }
+
+                                               var typeSymbol = semanticModel.GetDeclaredSymbol(options)!;
+
+                                               return SyntaxFactory.Attribute(
+                                                   SyntaxFactory.IdentifierName("AssemblyCapabilityKey"), SyntaxFactory.AttributeArgumentList(
+                                                       SyntaxFactory.SeparatedList(
+                                                           new[] {
+                                                               SyntaxFactory.AttributeArgument(SyntaxFactory.TypeOfExpression(SyntaxFactory.ParseName(typeSymbol.ToDisplayString()))),
+                                                           }.Concat(options.AttributeLists.GetAttribute("CapabilityKey")!.ArgumentList!.Arguments)
+                                                       )
+                                                   )
+                                               );
+                                           }
+                                       )
+                                      .ToArray();
+            if (types.Any())
+            {
+                var cu = SyntaxFactory.CompilationUnit()
+                                      .WithUsings(SyntaxFactory.List(namespaces.OrderBy(z => z).Select(z => SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(z)))))
+                                      .AddAttributeLists(SyntaxFactory.AttributeList(target: SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword)), SyntaxFactory.SeparatedList(types)))
+                                      .WithLeadingTrivia(SyntaxFactory.Comment(Preamble.GeneratedByATool))
+                                      .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+
+                context.AddSource("AssemblyCapabilityKeys.cs", cu.NormalizeWhitespace().GetText(Encoding.UTF8));
+            }
+        }
+
+        public AssemblyCapabilityKeyAttributeGenerator() : base(() => new SyntaxReceiver(Cache))
+        {
+        }
+
+        public static CacheContainer<TypeDeclarationSyntax> Cache = new();
+
+        public class SyntaxReceiver : SyntaxReceiverCache<TypeDeclarationSyntax>
+        {
+            public List<TypeDeclarationSyntax> Handlers { get; } = new();
+
+            public override string? GetKey(TypeDeclarationSyntax syntax)
+            {
+                var hasher = new CacheKeyHasher();
+                hasher.Append(syntax.SyntaxTree.FilePath);
+                hasher.Append(syntax.Keyword.Text);
+                hasher.Append(syntax.Identifier.Text);
+                hasher.Append(syntax.TypeParameterList);
+                hasher.Append(syntax.AttributeLists);
+                hasher.Append(syntax.BaseList);
+
+                return hasher;
+            }
+
+            /// <summary>
+            /// Called for every syntax node in the compilation, we can inspect the nodes and save any information useful for generation
+            /// </summary>
+            public override void OnVisitNode(TypeDeclarationSyntax syntaxNode)
+            {
+                if (syntaxNode.Parent is TypeDeclarationSyntax) return;
+                if (syntaxNode is ClassDeclarationSyntax or RecordDeclarationSyntax
+                 && syntaxNode.Arity == 0
+                 && !syntaxNode.Modifiers.Any(SyntaxKind.AbstractKeyword)
+                 && syntaxNode.AttributeLists.ContainsAttribute("CapabilityKey")
+                 && syntaxNode.BaseList is { } bl && bl.Types.Any(
+                        z => z.Type switch {
+                            SimpleNameSyntax { Identifier: { Text: "ICapability" }, Arity: 0 } => true,
+                            _                                                                  => false
+                        }
+                    ))
+                {
+                    Handlers.Add(syntaxNode);
+                }
+            }
+
+            public SyntaxReceiver(CacheContainer<TypeDeclarationSyntax> cache) : base(cache)
+            {
+            }
+        }
+    }
+}

--- a/src/JsonRpc.Generators/AssemblyJsonRpcHandlersAttributeGenerator.cs
+++ b/src/JsonRpc.Generators/AssemblyJsonRpcHandlersAttributeGenerator.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using OmniSharp.Extensions.JsonRpc.Generators.Cache;
+using OmniSharp.Extensions.JsonRpc.Generators.Contexts;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace OmniSharp.Extensions.JsonRpc.Generators
+{
+    [Generator]
+    public class AssemblyJsonRpcHandlersAttributeGenerator : CachedSourceGenerator<AssemblyJsonRpcHandlersAttributeGenerator.SyntaxReceiver, TypeDeclarationSyntax>
+    {
+        protected override void Execute(
+            GeneratorExecutionContext context, SyntaxReceiver syntaxReceiver, AddCacheSource<TypeDeclarationSyntax> addCacheSource,
+            ReportCacheDiagnostic<TypeDeclarationSyntax> cacheDiagnostic
+        )
+        {
+            var namespaces = new HashSet<string>() { "OmniSharp.Extensions.JsonRpc" };
+            var types = syntaxReceiver.FoundNodes
+                                      .Concat(syntaxReceiver.Handlers)
+                                      .Select(
+                                           options => {
+                                               var semanticModel = context.Compilation.GetSemanticModel(options.SyntaxTree);
+                                               var typeSymbol = semanticModel.GetDeclaredSymbol(options)!;
+
+                                               return AttributeArgument(TypeOfExpression(ParseName(typeSymbol.ToDisplayString())));
+                                           }
+                                       )
+                                      .ToArray();
+            if (types.Any())
+            {
+                var cu = CompilationUnit()
+                        .WithUsings(List(namespaces.OrderBy(z => z).Select(z => UsingDirective(ParseName(z)))))
+                        .AddAttributeLists(
+                             AttributeList(
+                                 target: AttributeTargetSpecifier(Token(SyntaxKind.AssemblyKeyword)),
+                                 SingletonSeparatedList(Attribute(IdentifierName("AssemblyJsonRpcHandlers"), AttributeArgumentList(SeparatedList(types))))
+                             )
+                         )
+                        .WithLeadingTrivia(Comment(Preamble.GeneratedByATool))
+                        .WithTrailingTrivia(CarriageReturnLineFeed);
+
+                context.AddSource("AssemblyJsonRpcHandlers.cs", cu.NormalizeWhitespace().GetText(Encoding.UTF8));
+            }
+        }
+
+        public AssemblyJsonRpcHandlersAttributeGenerator() : base(() => new SyntaxReceiver(Cache))
+        {
+        }
+
+        public static CacheContainer<TypeDeclarationSyntax> Cache = new();
+
+        public class SyntaxReceiver : SyntaxReceiverCache<TypeDeclarationSyntax>
+        {
+            public List<TypeDeclarationSyntax> Handlers { get; } = new();
+
+            public override string? GetKey(TypeDeclarationSyntax syntax)
+            {
+                var hasher = new CacheKeyHasher();
+                hasher.Append(syntax.SyntaxTree.FilePath);
+                hasher.Append(syntax.Keyword.Text);
+                hasher.Append(syntax.Identifier.Text);
+                hasher.Append(syntax.TypeParameterList);
+                hasher.Append(syntax.AttributeLists);
+                hasher.Append(syntax.BaseList);
+                return hasher;
+            }
+
+            /// <summary>
+            /// Called for every syntax node in the compilation, we can inspect the nodes and save any information useful for generation
+            /// </summary>
+            public override void OnVisitNode(TypeDeclarationSyntax syntaxNode)
+            {
+                if (syntaxNode.Parent is TypeDeclarationSyntax) return;
+                if (syntaxNode is ClassDeclarationSyntax or RecordDeclarationSyntax
+                 && syntaxNode.Arity == 0
+                 && !syntaxNode.Modifiers.Any(SyntaxKind.AbstractKeyword)
+                 && syntaxNode.AttributeLists.ContainsAttribute("Method")
+                 && syntaxNode.BaseList is { } bl && bl.Types.Any(
+                        z => z.Type switch {
+                            SimpleNameSyntax { Identifier: { Text: "IJsonRpcNotificationHandler" }, Arity: 0 or 1 } => true,
+                            SimpleNameSyntax { Identifier: { Text: "IJsonRpcRequestHandler" }, Arity: 1 or 2 }      => true,
+                            SimpleNameSyntax { Identifier: { Text: "IJsonRpcHandler" }, Arity: 0 }                  => true,
+                            _                                                                                       => false
+                        }
+                    ))
+                {
+                    Handlers.Add(syntaxNode);
+                }
+
+                if (syntaxNode is InterfaceDeclarationSyntax
+                 && syntaxNode.Arity == 0
+                 && syntaxNode.AttributeLists.ContainsAttribute("Method")
+                 && syntaxNode.BaseList is { } bl2 && bl2.Types.Any(
+                        z => z.Type switch {
+                            SimpleNameSyntax { Identifier: { Text: "IJsonRpcNotificationHandler" }, Arity: 0 or 1 } => true,
+                            SimpleNameSyntax { Identifier: { Text: "IJsonRpcRequestHandler" }, Arity: 1 or 2 }      => true,
+                            SimpleNameSyntax { Identifier: { Text: "IJsonRpcHandler" }, Arity: 0 }                  => true,
+                            _                                                                                       => false
+                        }
+                    ))
+                {
+                    Handlers.Add(syntaxNode);
+                }
+            }
+
+            public SyntaxReceiver(CacheContainer<TypeDeclarationSyntax> cache) : base(cache)
+            {
+            }
+        }
+    }
+}

--- a/src/JsonRpc.Generators/Cache/CacheKeyHasher.cs
+++ b/src/JsonRpc.Generators/Cache/CacheKeyHasher.cs
@@ -29,6 +29,14 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Cache
             {
                 Append(a);
             }
+
+            if (typeSyntax is GenericNameSyntax gns)
+            {
+                foreach (var item in gns.TypeArgumentList.Arguments)
+                {
+                    Append(item);
+                }
+            }
         }
 
         public void Append(TypeParameterListSyntax? typeParameterListSyntax)

--- a/src/JsonRpc.Generators/Cache/CachedSourceGenerator.cs
+++ b/src/JsonRpc.Generators/Cache/CachedSourceGenerator.cs
@@ -50,6 +50,7 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Cache
             {
                 context.AddSource(item.Name, item.SourceText);
             }
+
             foreach (var item in syntaxReceiver.CachedDiagnostics)
             {
                 context.ReportDiagnostic(item);
@@ -58,6 +59,8 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Cache
             syntaxReceiver.Finish(context);
         }
 
-        protected abstract void Execute(GeneratorExecutionContext context, T syntaxReceiver, AddCacheSource<TSyntax> addCacheSource, ReportCacheDiagnostic<TSyntax> cacheDiagnostic);
+        protected abstract void Execute(
+            GeneratorExecutionContext context, T syntaxReceiver, AddCacheSource<TSyntax> addCacheSource, ReportCacheDiagnostic<TSyntax> cacheDiagnostic
+        );
     }
 }

--- a/src/JsonRpc.Generators/Cache/SyntaxReceiverCache.cs
+++ b/src/JsonRpc.Generators/Cache/SyntaxReceiverCache.cs
@@ -14,6 +14,7 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Cache
         private readonly ImmutableDictionary<string, ImmutableArray<CacheDiagnosticFactory<T>>.Builder>.Builder _foundDiagnosticFactories;
         private readonly List<SourceTextCache> _cachedSources = new();
         private readonly List<Diagnostic> _cachedDiagnostics = new();
+        private readonly List<T> _foundNodes = new();
 
         protected SyntaxReceiverCache(CacheContainer<T> cache)
         {
@@ -62,6 +63,7 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Cache
 
         public IEnumerable<SourceTextCache> CachedSources => _cachedSources;
         public IEnumerable<Diagnostic> CachedDiagnostics => _cachedDiagnostics;
+        public IEnumerable<T> FoundNodes => _foundNodes;
 
         public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
         {
@@ -78,10 +80,13 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Cache
                 {
                     _foundDiagnosticFactories.Add(key, diagnostics.ToBuilder());
                     _cachedDiagnostics.AddRange(diagnostics.Select(f => f(v)));
-                    return;
                 }
 
-                if (_foundSourceTexts.ContainsKey(key)) return;
+                if (_foundSourceTexts.ContainsKey(key) || _foundDiagnosticFactories.ContainsKey(key))
+                {
+                    _foundNodes.Add(v);
+                    return;
+                }
             }
 
             OnVisitNode(v);

--- a/src/JsonRpc.Generators/Contexts/GeneratorData.cs
+++ b/src/JsonRpc.Generators/Contexts/GeneratorData.cs
@@ -19,6 +19,7 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Contexts
         SyntaxSymbol? Capability,
         SyntaxSymbol? RegistrationOptions,
         HashSet<string> AdditionalUsings,
+        List<AttributeArgumentSyntax> AssemblyJsonRpcHandlersAttributeArguments,
         SemanticModel Model,
         GeneratorExecutionContext Context
     )
@@ -73,6 +74,7 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Contexts
                     GetPartialItem(candidateClass, symbol, requestType),
                     GetPartialItems(candidateClass, symbol, requestType),
                     additionalUsings,
+                    new List<AttributeArgumentSyntax>(),
                     model,
                     context
                 ) { CacheDiagnosticDelegate = cacheDiagnostic, AddCacheSourceDelegate = addCacheSource };
@@ -90,6 +92,7 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Contexts
                     GetCapability(candidateClass, symbol, lspAttributes),
                     GetRegistrationOptions(candidateClass, symbol, lspAttributes),
                     additionalUsings,
+                    new List<AttributeArgumentSyntax>(),
                     model,
                     context
                 ) { CacheDiagnosticDelegate = cacheDiagnostic, AddCacheSourceDelegate = addCacheSource };

--- a/src/JsonRpc.Generators/Contexts/NotificationItem.cs
+++ b/src/JsonRpc.Generators/Contexts/NotificationItem.cs
@@ -14,11 +14,12 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Contexts
         SyntaxSymbol? Capability,
         SyntaxSymbol? RegistrationOptions,
         HashSet<string> AdditionalUsings,
+        List<AttributeArgumentSyntax> AssemblyJsonRpcHandlersAttributeArguments,
         SemanticModel Model,
         GeneratorExecutionContext Context
     ) : GeneratorData(
         TypeDeclaration, TypeSymbol, JsonRpcAttributes, LspAttributes,
         DapAttributes, Request, Capability, RegistrationOptions,
-        AdditionalUsings, Model, Context
+        AdditionalUsings, AssemblyJsonRpcHandlersAttributeArguments, Model, Context
     );
 }

--- a/src/JsonRpc.Generators/Contexts/RegistrationOptionAttributes.cs
+++ b/src/JsonRpc.Generators/Contexts/RegistrationOptionAttributes.cs
@@ -6,7 +6,8 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Contexts
 {
     record RegistrationOptionAttributes(
         SyntaxAttributeData? GenerateRegistrationOptions,
-        string? ServerCapabilityKey,
+        string? Key,
+        ExpressionSyntax? KeyExpression,
         bool SupportsWorkDoneProgress,
         bool SupportsDocumentSelector,
         bool SupportsStaticRegistrationOptions,
@@ -81,14 +82,17 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Contexts
             }
 
             string? value = null;
+            ExpressionSyntax? valueSyntax = null;
             if (data is { ConstructorArguments: { Length: > 0 } arguments } && arguments[0].Kind is TypedConstantKind.Primitive && arguments[0].Value is string)
             {
                 value = arguments[0].Value as string;
+                valueSyntax = attributeSyntax.ArgumentList!.Arguments[0].Expression;
             }
 
             return new RegistrationOptionAttributes(
                 new SyntaxAttributeData(attributeSyntax, data),
                 value,
+                valueSyntax,
                 supportsWorkDoneProgress,
                 supportsDocumentSelector,
                 supportsStaticRegistrationOptions,

--- a/src/JsonRpc.Generators/Contexts/RequestItem.cs
+++ b/src/JsonRpc.Generators/Contexts/RequestItem.cs
@@ -18,12 +18,13 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Contexts
         SyntaxSymbol? PartialItem,
         SyntaxSymbol? PartialItems,
         HashSet<string> AdditionalUsings,
+        List<AttributeArgumentSyntax> AssemblyJsonRpcHandlersAttributeArguments,
         SemanticModel Model,
         GeneratorExecutionContext Context
     ) : GeneratorData(
         TypeDeclaration, TypeSymbol,
         JsonRpcAttributes, LspAttributes, DapAttributes, Request, Capability, RegistrationOptions,
-        AdditionalUsings, Model, Context
+        AdditionalUsings, AssemblyJsonRpcHandlersAttributeArguments, Model, Context
     );
 
 //    record PartialItem(TypeSyntax Syntax, INamedTypeSymbol Symbol, SyntaxSymbol Item) : SyntaxSymbol(Syntax, Symbol);

--- a/src/JsonRpc.Generators/Helpers.cs
+++ b/src/JsonRpc.Generators/Helpers.cs
@@ -530,44 +530,6 @@ namespace OmniSharp.Extensions.JsonRpc.Generators
             );
         }
 
-        public static ArrowExpressionClauseSyntax GetRequestHandlerExpression(ExpressionSyntax nameExpression, ITypeSymbol requestType, ITypeSymbol responseType)
-        {
-            var requestName = ResolveTypeName(requestType);
-            var responseName = ResolveTypeName(responseType);
-            return ArrowExpressionClause(
-                AddHandler(
-                    Argument(nameExpression),
-                    Argument(
-                        CreateHandlerArgument(
-                                IdentifierName("LanguageProtocolDelegatingHandlers"),
-                                "Request",
-                                requestName,
-                                responseName
-                            )
-                           .WithArgumentList(GetHandlerArgumentList())
-                    )
-                )
-            );
-        }
-
-        public static ArrowExpressionClauseSyntax GetRequestHandlerExpression(ExpressionSyntax nameExpression, ITypeSymbol requestType)
-        {
-            var requestName = ResolveTypeName(requestType);
-            return ArrowExpressionClause(
-                AddHandler(
-                    Argument(nameExpression),
-                    Argument(
-                        CreateHandlerArgument(
-                                IdentifierName("LanguageProtocolDelegatingHandlers"),
-                                "Request",
-                                requestName
-                            )
-                           .WithArgumentList(GetHandlerArgumentList())
-                    )
-                )
-            );
-        }
-
         public static ArrowExpressionClauseSyntax GetPartialResultCapabilityHandlerExpression(
             ExpressionSyntax nameExpression, TypeSyntax requestName, TypeSyntax itemType, TypeSyntax responseType,
             TypeSyntax capabilityName

--- a/src/JsonRpc.Generators/Strategies/HandlerGeneratorStrategy.cs
+++ b/src/JsonRpc.Generators/Strategies/HandlerGeneratorStrategy.cs
@@ -25,7 +25,9 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Strategies
                 )
             );
 
-            var handlerInterface = InterfaceDeclaration(Identifier($"I{item.JsonRpcAttributes.HandlerName}Handler"))
+            var interfaceName = $"I{item.JsonRpcAttributes.HandlerName}Handler";
+            item.AssemblyJsonRpcHandlersAttributeArguments.Add(AttributeArgument(TypeOfExpression(ParseName($"{item.JsonRpcAttributes.HandlerNamespace}.{interfaceName}"))));
+            var handlerInterface = InterfaceDeclaration(Identifier(interfaceName))
                                   .WithAttributeLists(
                                        List(
                                            new[] {

--- a/src/JsonRpc/JsonRpcServerOptionsBase.cs
+++ b/src/JsonRpc/JsonRpcServerOptionsBase.cs
@@ -30,6 +30,7 @@ namespace OmniSharp.Extensions.JsonRpc
         }
 
         public IEnumerable<Assembly> Assemblies { get; set; } = Enumerable.Empty<Assembly>();
+        public bool UseAssemblyAttributeScanning { get; set; } = true;
         public IRequestProcessIdentifier? RequestProcessIdentifier { get; set; }
         public int? Concurrency { get; set; }
         public IScheduler InputScheduler { get; set; } = TaskPoolScheduler.Default;

--- a/src/JsonRpc/JsonRpcServerOptionsExtensions.cs
+++ b/src/JsonRpc/JsonRpcServerOptionsExtensions.cs
@@ -10,6 +10,12 @@ namespace OmniSharp.Extensions.JsonRpc
             return options;
         }
 
+        public static JsonRpcServerOptions WithAssemblyAttributeScanning(this JsonRpcServerOptions options, bool value)
+        {
+            options.UseAssemblyAttributeScanning = value;
+            return options;
+        }
+
         /// <summary>
         /// Sets both input and output schedulers to the same scheduler
         /// </summary>

--- a/src/JsonRpc/JsonRpcServerServiceCollectionExtensions.cs
+++ b/src/JsonRpc/JsonRpcServerServiceCollectionExtensions.cs
@@ -147,7 +147,16 @@ namespace OmniSharp.Extensions.JsonRpc
             }
 
             container = container.AddJsonRpcServerCore(options);
-            container.RegisterInstanceMany(new HandlerTypeDescriptorProvider(options.Assemblies), nonPublicServiceTypes: true);
+
+            if (options.UseAssemblyAttributeScanning)
+            {
+                container.RegisterInstanceMany(new AssemblyAttributeHandlerTypeDescriptorProvider(options.Assemblies), nonPublicServiceTypes: true);
+            }
+            else
+            {
+                container.RegisterInstanceMany(new AssemblyScanningHandlerTypeDescriptorProvider(options.Assemblies), nonPublicServiceTypes: true);
+            }
+
 
             container.RegisterInstance(options.Serializer);
             if (options.Receiver == null)

--- a/src/JsonRpc/ProcessAttribute.cs
+++ b/src/JsonRpc/ProcessAttribute.cs
@@ -9,4 +9,18 @@ namespace OmniSharp.Extensions.JsonRpc
 
         public RequestProcessType Type { get; }
     }
+
+    /// <summary>
+    /// Used by source generation to known handlers to the assembly metadata
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public class AssemblyJsonRpcHandlersAttribute : Attribute
+    {
+        public Type[] Types { get; }
+
+        public AssemblyJsonRpcHandlersAttribute(params Type[] handlerTypes)
+        {
+            Types = handlerTypes;
+        }
+    }
 }

--- a/src/Protocol/AssemblyCapabilityKeyAttribute.cs
+++ b/src/Protocol/AssemblyCapabilityKeyAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace OmniSharp.Extensions.LanguageServer.Protocol
+{
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public sealed class AssemblyCapabilityKeyAttribute : Attribute
+    {
+        public Type CapabilityType { get; }
+        public string CapabilityKey { get; }
+
+        public AssemblyCapabilityKeyAttribute(Type capabilityType, params string[] keys)
+        {
+            CapabilityType = capabilityType;
+            CapabilityKey = string.Join(".", keys);
+        }
+    }
+}

--- a/src/Protocol/AssemblyRegistrationOptionsAttribute.cs
+++ b/src/Protocol/AssemblyRegistrationOptionsAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace OmniSharp.Extensions.LanguageServer.Protocol
+{
+    /// <summary>
+    /// Used by source generation to add generation options to a given assembly.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public class AssemblyRegistrationOptionsAttribute : Attribute
+    {
+        public Type[] Types { get; }
+
+        public AssemblyRegistrationOptionsAttribute(params Type[] registrationOptionsTypes)
+        {
+            Types = registrationOptionsTypes;
+        }
+    }
+}

--- a/src/Protocol/CapabilityKeyAttribute.cs
+++ b/src/Protocol/CapabilityKeyAttribute.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
+    // TODO: maybe?
+    // [Conditional("GeneratedCode")]
     public sealed class CapabilityKeyAttribute : Attribute
     {
         public IEnumerable<string> Keys { get; }

--- a/src/Protocol/Features/Document/CodeActionFeature.cs
+++ b/src/Protocol/Features/Document/CodeActionFeature.cs
@@ -296,7 +296,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             {
                 private readonly IHandlersManager _handlersManager;
 
-                public CodeActionRegistrationOptionsConverter(IHandlersManager handlersManager) : base(nameof(ServerCapabilities.CodeActionProvider))
+                public CodeActionRegistrationOptionsConverter(IHandlersManager handlersManager)
                 {
                     _handlersManager = handlersManager;
                 }

--- a/src/Protocol/Features/Document/CodeLensFeature.cs
+++ b/src/Protocol/Features/Document/CodeLensFeature.cs
@@ -93,7 +93,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             {
                 private readonly IHandlersManager _handlersManager;
 
-                public CodeLensRegistrationOptionsConverter(IHandlersManager handlersManager) : base(nameof(ServerCapabilities.CodeLensProvider))
+                public CodeLensRegistrationOptionsConverter(IHandlersManager handlersManager)
                 {
                     _handlersManager = handlersManager;
                 }

--- a/src/Protocol/Features/Document/CompletionFeature.cs
+++ b/src/Protocol/Features/Document/CompletionFeature.cs
@@ -292,7 +292,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             {
                 private readonly IHandlersManager _handlersManager;
 
-                public CompletionRegistrationOptionsConverter(IHandlersManager handlersManager) : base(nameof(ServerCapabilities.CompletionProvider))
+                public CompletionRegistrationOptionsConverter(IHandlersManager handlersManager)
                 {
                     _handlersManager = handlersManager;
                 }

--- a/src/Protocol/Features/Document/DocumentLinkFeature.cs
+++ b/src/Protocol/Features/Document/DocumentLinkFeature.cs
@@ -100,7 +100,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             {
                 private readonly IHandlersManager _handlersManager;
 
-                public DocumentLinkRegistrationOptionsConverter(IHandlersManager handlersManager) : base(nameof(ServerCapabilities.DocumentLinkProvider))
+                public DocumentLinkRegistrationOptionsConverter(IHandlersManager handlersManager)
                 {
                     _handlersManager = handlersManager;
                 }

--- a/src/Protocol/Features/Document/Proposals/SemanticTokensFeature.cs
+++ b/src/Protocol/Features/Document/Proposals/SemanticTokensFeature.cs
@@ -586,7 +586,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             {
                 private readonly IHandlersManager _handlersManager;
 
-                public SemanticTokensRegistrationOptionsConverter(IHandlersManager handlersManager) : base(nameof(ServerCapabilities.SemanticTokensProvider))
+                public SemanticTokensRegistrationOptionsConverter(IHandlersManager handlersManager)
                 {
                     _handlersManager = handlersManager;
                 }

--- a/src/Protocol/Features/Document/TextDocumentSyncFeature.cs
+++ b/src/Protocol/Features/Document/TextDocumentSyncFeature.cs
@@ -203,7 +203,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             {
                 private readonly IHandlersManager _handlersManager;
 
-                public Converter(IHandlersManager handlersManager) : base(nameof(ServerCapabilities.TextDocumentSync))
+                public Converter(IHandlersManager handlersManager)
                 {
                     _handlersManager = handlersManager;
                 }

--- a/src/Protocol/Features/Workspace/ExecuteCommandFeature.cs
+++ b/src/Protocol/Features/Workspace/ExecuteCommandFeature.cs
@@ -59,7 +59,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             {
                 private readonly IHandlersManager _handlersManager;
 
-                public ExecuteCommandRegistrationOptionsConverter(IHandlersManager handlersManager) : base(nameof(ServerCapabilities.ExecuteCommandProvider))
+                public ExecuteCommandRegistrationOptionsConverter(IHandlersManager handlersManager)
                 {
                     _handlersManager = handlersManager;
                 }

--- a/src/Protocol/IRegistrationOptionsConverter.cs
+++ b/src/Protocol/IRegistrationOptionsConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol
 {
@@ -6,7 +7,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
     {
         Type SourceType { get; }
         Type DestinationType { get; }
-        string Key { get; }
+        string? Key { get; }
         object? Convert(object source);
     }
 
@@ -21,14 +22,14 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         where TSource : IRegistrationOptions
         where TDestination : class
     {
-        public RegistrationOptionsConverterBase(string key)
+        public RegistrationOptionsConverterBase()
         {
-            Key = key;
+            Key = typeof(TSource).GetCustomAttribute<RegistrationOptionsKeyAttribute>()?.Key;
         }
 
         public Type SourceType { get; } = typeof(TSource);
         public Type DestinationType { get; }= typeof(TDestination);
-        public string Key { get; }
+        public string? Key { get; }
         public object? Convert(object source) => source is TSource value ? Convert(value) : null;
         public abstract TDestination Convert(TSource source);
     }

--- a/src/Protocol/RegistrationOptionsKeyAttribute.cs
+++ b/src/Protocol/RegistrationOptionsKeyAttribute.cs
@@ -8,11 +8,11 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
     [AttributeUsage(AttributeTargets.Class)]
     public class RegistrationOptionsKeyAttribute : Attribute
     {
-        public RegistrationOptionsKeyAttribute(string serverCapabilitiesKey)
+        public RegistrationOptionsKeyAttribute(string key)
         {
-            ServerCapabilitiesKey = serverCapabilitiesKey;
+            Key = key;
         }
 
-        public string ServerCapabilitiesKey { get; }
+        public string Key { get; }
     }
 }

--- a/src/Protocol/Shared/LspHandlerTypeDescriptorProvider.cs
+++ b/src/Protocol/Shared/LspHandlerTypeDescriptorProvider.cs
@@ -19,12 +19,16 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Shared
 
         internal readonly ILookup<string, ILspHandlerTypeDescriptor> KnownHandlers;
 
-        internal LspHandlerTypeDescriptorProvider(IEnumerable<Assembly> assemblies)
+        internal LspHandlerTypeDescriptorProvider(IEnumerable<Assembly> assemblies, bool useAssemblyAttributeScanning = false)
         {
-            KnownHandlers = HandlerTypeDescriptorProvider
-                           .GetDescriptors(assemblies)
-                           .Select(x => new LspHandlerTypeDescriptor(x.HandlerType) as ILspHandlerTypeDescriptor)
-                           .ToLookup(x => x.Method, x => x, StringComparer.Ordinal);
+            KnownHandlers =
+                ( useAssemblyAttributeScanning
+                    ? AssemblyAttributeHandlerTypeDescriptorProvider.GetDescriptors(assemblies)
+                    : AssemblyScanningHandlerTypeDescriptorProvider
+                       .GetDescriptors(assemblies)
+                )
+               .Select(x => new LspHandlerTypeDescriptor(x.HandlerType) as ILspHandlerTypeDescriptor)
+               .ToLookup(x => x.Method, x => x, StringComparer.Ordinal);
         }
 
         public string? GetMethodForRegistrationOptions(object registrationOptions)

--- a/src/Testing/ClientCapabilityExtensions.cs
+++ b/src/Testing/ClientCapabilityExtensions.cs
@@ -10,12 +10,14 @@ namespace OmniSharp.Extensions.LanguageProtocol.Testing
     {
         public static LanguageClientOptions EnableAllCapabilities(this LanguageClientOptions options)
         {
-            var capabilities = typeof(ICapability).Assembly.GetExportedTypes()
-                                                  .Where(z => typeof(ICapability).IsAssignableFrom(z))
-                                                  .Where(z => z.IsClass && !z.IsAbstract);
+            var capabilities = options.Assemblies
+                                      .Union(new[] { typeof(ICapability).Assembly })
+                                      .SelectMany(z => z.ExportedTypes)
+                                      .Where(z => typeof(ICapability).IsAssignableFrom(z))
+                                      .Where(z => z.IsClass && !z.IsAbstract);
             foreach (var item in capabilities)
             {
-                options.WithCapability((Activator.CreateInstance(item, Array.Empty<object>()) as ICapability)!);
+                options.WithCapability(( Activator.CreateInstance(item, Array.Empty<object>()) as ICapability )!);
             }
 
             return options;

--- a/test/Dap.Tests/FoundationTests.cs
+++ b/test/Dap.Tests/FoundationTests.cs
@@ -459,9 +459,9 @@ namespace Dap.Tests
         {
             public TypeHandlerData()
             {
-                var handlerTypeDescriptorProvider = new HandlerTypeDescriptorProvider(
+                var handlerTypeDescriptorProvider = new AssemblyScanningHandlerTypeDescriptorProvider(
                     new[] {
-                        typeof(HandlerTypeDescriptorProvider).Assembly,
+                        typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly,
                         typeof(DebugAdapterRpcOptionsBase<>).Assembly,
                         typeof(DebugAdapterClient).Assembly,
                         typeof(DebugAdapterServer).Assembly,
@@ -485,9 +485,9 @@ namespace Dap.Tests
         {
             public TypeHandlerExtensionData()
             {
-                var handlerTypeDescriptorProvider = new HandlerTypeDescriptorProvider(
+                var handlerTypeDescriptorProvider = new AssemblyScanningHandlerTypeDescriptorProvider(
                     new[] {
-                        typeof(HandlerTypeDescriptorProvider).Assembly,
+                        typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly,
                         typeof(DebugAdapterRpcOptionsBase<>).Assembly,
                         typeof(DebugAdapterClient).Assembly,
                         typeof(DebugAdapterServer).Assembly,

--- a/test/Generation.Tests/GeneratedRegistrationOptionsTests.cs
+++ b/test/Generation.Tests/GeneratedRegistrationOptionsTests.cs
@@ -29,6 +29,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 #nullable enable
 namespace Test
 {
+    [RegistrationOptionsKey(nameof(ServerCapabilities.WorkspaceSymbolProvider))]
     [RegistrationOptionsConverterAttribute(typeof(WorkspaceSymbolRegistrationOptionsConverter))]
     public partial class WorkspaceSymbolRegistrationOptions : OmniSharp.Extensions.LanguageServer.Protocol.IRegistrationOptions, OmniSharp.Extensions.LanguageServer.Protocol.Models.IWorkDoneProgressOptions
     {
@@ -41,7 +42,7 @@ namespace Test
 
         class WorkspaceSymbolRegistrationOptionsConverter : RegistrationOptionsConverterBase<WorkspaceSymbolRegistrationOptions, StaticOptions>
         {
-            public WorkspaceSymbolRegistrationOptionsConverter(): base(nameof(ServerCapabilities.WorkspaceSymbolProvider))
+            public WorkspaceSymbolRegistrationOptionsConverter()
             {
             }
 
@@ -51,6 +52,7 @@ namespace Test
             }
         }
 
+        [RegistrationOptionsKey(nameof(ServerCapabilities.WorkspaceSymbolProvider))]
         public partial class StaticOptions : OmniSharp.Extensions.LanguageServer.Protocol.Models.IWorkDoneProgressOptions
         {
             [Optional]
@@ -91,6 +93,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 #nullable enable
 namespace Test
 {
+    [RegistrationOptionsKey(nameof(ServerCapabilities.WorkspaceSymbolProvider))]
     [RegistrationOptionsConverterAttribute(typeof(WorkspaceSymbolRegistrationOptionsConverter))]
     public partial class WorkspaceSymbolRegistrationOptions : OmniSharp.Extensions.LanguageServer.Protocol.IRegistrationOptions
     {
@@ -103,7 +106,7 @@ namespace Test
 
         class WorkspaceSymbolRegistrationOptionsConverter : RegistrationOptionsConverterBase<WorkspaceSymbolRegistrationOptions, StaticOptions>
         {
-            public WorkspaceSymbolRegistrationOptionsConverter(): base(nameof(ServerCapabilities.WorkspaceSymbolProvider))
+            public WorkspaceSymbolRegistrationOptionsConverter()
             {
             }
 
@@ -113,6 +116,7 @@ namespace Test
             }
         }
 
+        [RegistrationOptionsKey(nameof(ServerCapabilities.WorkspaceSymbolProvider))]
         public partial class StaticOptions : IWorkDoneProgressOptions
         {
             [Optional]
@@ -199,6 +203,7 @@ using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 #nullable enable
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Test
 {
+    [RegistrationOptionsKey(nameof(ServerCapabilities.CodeActionProvider))]
     [RegistrationOptionsConverterAttribute(typeof(CodeActionRegistrationOptionsConverter))]
     public partial class CodeActionRegistrationOptions : OmniSharp.Extensions.LanguageServer.Protocol.IRegistrationOptions, OmniSharp.Extensions.LanguageServer.Protocol.Models.ITextDocumentRegistrationOptions, OmniSharp.Extensions.LanguageServer.Protocol.Models.IWorkDoneProgressOptions
     {
@@ -217,7 +222,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Test
 
         class CodeActionRegistrationOptionsConverter : RegistrationOptionsConverterBase<CodeActionRegistrationOptions, StaticOptions>
         {
-            public CodeActionRegistrationOptionsConverter(): base(nameof(ServerCapabilities.CodeActionProvider))
+            public CodeActionRegistrationOptionsConverter()
             {
             }
 
@@ -227,6 +232,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Test
             }
         }
 
+        [RegistrationOptionsKey(nameof(ServerCapabilities.CodeActionProvider))]
         public partial class StaticOptions : OmniSharp.Extensions.LanguageServer.Protocol.Models.IWorkDoneProgressOptions
         {
             /// <summary>
@@ -319,7 +325,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Test
         {
             private readonly IHandlersManager _handlersManager;
 
-            public Converter(IHandlersManager handlersManager) : base(nameof(ServerCapabilities.CodeActionProvider))
+            public Converter(IHandlersManager handlersManager)
             {
                 _handlersManager = handlersManager;
             }
@@ -359,6 +365,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
 #nullable enable
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Test
 {
+    [RegistrationOptionsKey(nameof(ServerCapabilities.CodeActionProvider))]
     public partial class CodeActionRegistrationOptions : OmniSharp.Extensions.LanguageServer.Protocol.IRegistrationOptions
     {
         public DocumentSelector? DocumentSelector
@@ -374,6 +381,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Test
             set;
         }
 
+        [RegistrationOptionsKey(nameof(ServerCapabilities.CodeActionProvider))]
         public partial class StaticOptions : IWorkDoneProgressOptions
         {
             /// <summary>

--- a/test/Generation.Tests/GenerationHelpers.cs
+++ b/test/Generation.Tests/GenerationHelpers.cs
@@ -110,7 +110,7 @@ namespace Generation.Tests
             Assert.Empty(diagnostics.Where(x => x.Severity >= DiagnosticSeverity.Warning));
 
             // the syntax tree added by the generator will be the last one in the compilation
-            return outputCompilation.SyntaxTrees.Last();
+            return outputCompilation.SyntaxTrees.Last(z => !z.FilePath.Contains("AssemblyRegistrationOptions") && !z.FilePath.Contains("GeneratedAssemblyJsonRpcHandlers"));
         }
 
         public static Project CreateProject(params string[] sources)

--- a/test/Generation.Tests/JsonRpcGenerationTests.cs
+++ b/test/Generation.Tests/JsonRpcGenerationTests.cs
@@ -725,6 +725,88 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol.Bogus
             await AssertGeneratedAsExpected<GenerateHandlerMethodsGenerator>(source, expected);
         }
 
+        [FactWithSkipOn(SkipOnPlatform.Windows)]
+        public async Task Supports_Allow_Derived_Requests_Nullable()
+        {
+            var source = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.JsonRpc.Generation;
+using System.Collections.Generic;
+using MediatR;
+
+namespace OmniSharp.Extensions.DebugAdapter.Protocol.Bogus
+{
+    public class LaunchResponse { }
+    [Method(""launch"", Direction.ClientToServer)]
+    [GenerateHandler(AllowDerivedRequests = true), GenerateHandlerMethods, GenerateRequestMethods]
+    public class LaunchRequestArguments: IRequest<LaunchResponse?> { }
+}";
+            var expected = @"
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using OmniSharp.Extensions.DebugAdapter.Protocol;
+using OmniSharp.Extensions.DebugAdapter.Protocol.Bogus;
+using OmniSharp.Extensions.DebugAdapter.Protocol.Client;
+using OmniSharp.Extensions.DebugAdapter.Protocol.Events;
+using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
+using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
+using OmniSharp.Extensions.DebugAdapter.Protocol.Server;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.JsonRpc.Generation;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+namespace OmniSharp.Extensions.DebugAdapter.Protocol.Bogus
+{
+    [Method(""launch"", Direction.ClientToServer)]
+    [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+    public partial interface ILaunchRequestHandler<in T> : IJsonRpcRequestHandler<T, LaunchResponse?> where T : LaunchRequestArguments
+    {
+    }
+
+    [System.Runtime.CompilerServices.CompilerGeneratedAttribute, System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
+    abstract public partial class LaunchRequestHandlerBase<T> : AbstractHandlers.Request<T, LaunchResponse?>, ILaunchRequestHandler<T> where T : LaunchRequestArguments
+    {
+    }
+
+    public partial interface ILaunchRequestHandler : ILaunchRequestHandler<LaunchRequestArguments>
+    {
+    }
+
+    [System.Runtime.CompilerServices.CompilerGeneratedAttribute, System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
+    abstract public partial class LaunchRequestHandlerBase : LaunchRequestHandlerBase<LaunchRequestArguments>, ILaunchRequestHandler
+    {
+    }
+}
+#nullable restore
+
+namespace OmniSharp.Extensions.DebugAdapter.Protocol.Bogus
+{
+#nullable enable
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute, System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+    public static partial class LaunchRequestExtensions
+    {
+        public static IDebugAdapterServerRegistry OnLaunchRequest(this IDebugAdapterServerRegistry registry, Func<LaunchRequestArguments, Task<LaunchResponse?>> handler) => registry.AddHandler(""launch"", RequestHandler.For(handler));
+        public static IDebugAdapterServerRegistry OnLaunchRequest(this IDebugAdapterServerRegistry registry, Func<LaunchRequestArguments, CancellationToken, Task<LaunchResponse?>> handler) => registry.AddHandler(""launch"", RequestHandler.For(handler));
+        public static IDebugAdapterServerRegistry OnLaunchRequest<T>(this IDebugAdapterServerRegistry registry, Func<T, Task<LaunchResponse?>> handler)
+            where T : LaunchRequestArguments => registry.AddHandler(""launch"", RequestHandler.For(handler));
+        public static IDebugAdapterServerRegistry OnLaunchRequest<T>(this IDebugAdapterServerRegistry registry, Func<T, CancellationToken, Task<LaunchResponse?>> handler)
+            where T : LaunchRequestArguments => registry.AddHandler(""launch"", RequestHandler.For(handler));
+        public static Task<LaunchResponse?> LaunchRequest(this IDebugAdapterClient mediator, LaunchRequestArguments request, CancellationToken cancellationToken = default) => mediator.SendRequest(request, cancellationToken);
+    }
+#nullable restore
+}";
+            await AssertGeneratedAsExpected<GenerateHandlerMethodsGenerator>(source, expected);
+        }
+
         [Fact]
         public async Task Supports_Allows_Nullable_Responses()
         {

--- a/test/Generation.Tests/LspFeatureTests.cs
+++ b/test/Generation.Tests/LspFeatureTests.cs
@@ -168,7 +168,8 @@ namespace Lsp.Tests.Integration.Fixtures
 }
 #nullable restore";
 
-            var expectedOptions = @"using MediatR;
+            var expectedOptions = @"
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Generation;
 using OmniSharp.Extensions.LanguageServer.Protocol;
@@ -183,6 +184,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
 #nullable enable
 namespace Lsp.Tests.Integration.Fixtures
 {
+    [RegistrationOptionsKey(""unitTestDiscovery"")]
     [RegistrationOptionsConverterAttribute(typeof(UnitTestRegistrationOptionsConverter))]
     public partial class UnitTestRegistrationOptions : OmniSharp.Extensions.LanguageServer.Protocol.IRegistrationOptions
     {
@@ -195,7 +197,7 @@ namespace Lsp.Tests.Integration.Fixtures
 
         class UnitTestRegistrationOptionsConverter : RegistrationOptionsConverterBase<UnitTestRegistrationOptions, StaticOptions>
         {
-            public UnitTestRegistrationOptionsConverter(): base(""unitTestDiscovery"")
+            public UnitTestRegistrationOptionsConverter()
             {
             }
 
@@ -205,6 +207,7 @@ namespace Lsp.Tests.Integration.Fixtures
             }
         }
 
+        [RegistrationOptionsKey(""unitTestDiscovery"")]
         public partial class StaticOptions : IWorkDoneProgressOptions
         {
             [Optional]

--- a/test/JsonRpc.Tests/HandlerResolverTests.cs
+++ b/test/JsonRpc.Tests/HandlerResolverTests.cs
@@ -45,7 +45,7 @@ namespace JsonRpc.Tests
         [InlineData(typeof(IJsonRpcNotificationDataHandler), "notificationdata")]
         public void Should_Contain_AllDefinedMethods(Type requestHandler, string key)
         {
-            var handler = new HandlerCollection(Substitute.For<IResolverContext>(), new HandlerTypeDescriptorProvider(new [] { typeof(HandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly })) {
+            var handler = new HandlerCollection(Substitute.For<IResolverContext>(), new AssemblyScanningHandlerTypeDescriptorProvider(new [] { typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly })) {
                 (IJsonRpcHandler) Substitute.For(new[] { requestHandler }, new object[0])
             };
             handler.Should().Contain(x => x.Method == key);
@@ -57,7 +57,7 @@ namespace JsonRpc.Tests
         [InlineData(typeof(IJsonRpcNotificationDataHandler), "notificationdata", null)]
         public void Should_Have_CorrectParams(Type requestHandler, string key, Type expected)
         {
-            var handler = new HandlerCollection(Substitute.For<IResolverContext>(), new HandlerTypeDescriptorProvider(new [] { typeof(HandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly })) {
+            var handler = new HandlerCollection(Substitute.For<IResolverContext>(), new AssemblyScanningHandlerTypeDescriptorProvider(new [] { typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly })) {
                 (IJsonRpcHandler) Substitute.For(new[] { requestHandler }, new object[0])
             };
             handler.First(x => x.Method == key).Params.Should().IsSameOrEqualTo(expected);

--- a/test/JsonRpc.Tests/MediatorTestsNotificationHandler.cs
+++ b/test/JsonRpc.Tests/MediatorTestsNotificationHandler.cs
@@ -30,7 +30,7 @@ namespace JsonRpc.Tests
         {
             var exitHandler = Substitute.For<IExitHandler>();
 
-            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new HandlerTypeDescriptorProvider(new [] { typeof(HandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly })) { exitHandler };
+            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new AssemblyScanningHandlerTypeDescriptorProvider(new [] { typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly })) { exitHandler };
             AutoSubstitute.Provide<IHandlersManager>(collection);
             var router = AutoSubstitute.Resolve<RequestRouter>();
 

--- a/test/JsonRpc.Tests/MediatorTestsNotificationHandlerOfT.cs
+++ b/test/JsonRpc.Tests/MediatorTestsNotificationHandlerOfT.cs
@@ -33,7 +33,7 @@ namespace JsonRpc.Tests
         {
             var cancelRequestHandler = Substitute.For<ICancelRequestHandler>();
 
-            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new HandlerTypeDescriptorProvider(new [] { typeof(HandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly })) { cancelRequestHandler };
+            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new AssemblyScanningHandlerTypeDescriptorProvider(new [] { typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly })) { cancelRequestHandler };
             AutoSubstitute.Provide<IHandlersManager>(collection);
             var router = AutoSubstitute.Resolve<RequestRouter>();
 

--- a/test/JsonRpc.Tests/MediatorTestsRequestHandlerOfTRequest.cs
+++ b/test/JsonRpc.Tests/MediatorTestsRequestHandlerOfTRequest.cs
@@ -33,7 +33,7 @@ namespace JsonRpc.Tests
         {
             var executeCommandHandler = Substitute.For<IExecuteCommandHandler>();
 
-            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new HandlerTypeDescriptorProvider(new [] { typeof(HandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly })) { executeCommandHandler };
+            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new AssemblyScanningHandlerTypeDescriptorProvider(new [] { typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly })) { executeCommandHandler };
             AutoSubstitute.Provide<IHandlersManager>(collection);
             var router = AutoSubstitute.Resolve<RequestRouter>();
 

--- a/test/JsonRpc.Tests/MediatorTestsRequestHandlerOfTRequestTResponse.cs
+++ b/test/JsonRpc.Tests/MediatorTestsRequestHandlerOfTRequestTResponse.cs
@@ -43,7 +43,7 @@ namespace JsonRpc.Tests
         {
             var codeActionHandler = Substitute.For<ICodeActionHandler>();
 
-            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new HandlerTypeDescriptorProvider(new [] { typeof(HandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly })) { codeActionHandler };
+            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new AssemblyScanningHandlerTypeDescriptorProvider(new [] { typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly })) { codeActionHandler };
             AutoSubstitute.Provide<IHandlersManager>(collection);
             var router = AutoSubstitute.Resolve<RequestRouter>();
 

--- a/test/JsonRpc.Tests/RequestRouterTests.cs
+++ b/test/JsonRpc.Tests/RequestRouterTests.cs
@@ -20,7 +20,7 @@ namespace JsonRpc.Tests
         [Fact]
         public async Task ShouldRoute_CustomRequestResponse()
         {
-            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new HandlerTypeDescriptorProvider(new [] { typeof(HandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
+            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new AssemblyScanningHandlerTypeDescriptorProvider(new [] { typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
             var registry = new TestLanguageServerRegistry();
             AutoSubstitute.Provide<IHandlersManager>(collection);
             AutoSubstitute.Provide<IEnumerable<IHandlerDescriptor>>(collection);
@@ -40,7 +40,7 @@ namespace JsonRpc.Tests
         [Fact]
         public async Task ShouldRoute_CustomRequest()
         {
-            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new HandlerTypeDescriptorProvider(new [] { typeof(HandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
+            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new AssemblyScanningHandlerTypeDescriptorProvider(new [] { typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
             var registry = new TestLanguageServerRegistry();
             AutoSubstitute.Provide<IHandlersManager>(collection);
             AutoSubstitute.Provide<IEnumerable<IHandlerDescriptor>>(collection);
@@ -60,7 +60,7 @@ namespace JsonRpc.Tests
         [Fact]
         public async Task ShouldRoute_CustomNotification()
         {
-            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new HandlerTypeDescriptorProvider(new [] { typeof(HandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
+            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new AssemblyScanningHandlerTypeDescriptorProvider(new [] { typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
             var registry = new TestLanguageServerRegistry();
             AutoSubstitute.Provide<IHandlersManager>(collection);
             AutoSubstitute.Provide<IEnumerable<IHandlerDescriptor>>(collection);
@@ -79,7 +79,7 @@ namespace JsonRpc.Tests
         [Fact]
         public async Task ShouldRoute_CustomEmptyNotification()
         {
-            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new HandlerTypeDescriptorProvider(new [] { typeof(HandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
+            var collection = new HandlerCollection(Substitute.For<IResolverContext>(), new AssemblyScanningHandlerTypeDescriptorProvider(new [] { typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
             var registry = new TestLanguageServerRegistry();
             AutoSubstitute.Provide<IHandlersManager>(collection);
             AutoSubstitute.Provide<IEnumerable<IHandlerDescriptor>>(collection);

--- a/test/JsonRpc.Tests/ResponseRouterTests.cs
+++ b/test/JsonRpc.Tests/ResponseRouterTests.cs
@@ -19,7 +19,7 @@ namespace JsonRpc.Tests
         public async Task WorksWithResultType()
         {
             var outputHandler = Substitute.For<IOutputHandler>();
-            var router = new ResponseRouter(new Lazy<IOutputHandler>(() => outputHandler), new JsonRpcSerializer(), new HandlerTypeDescriptorProvider(new [] { typeof(HandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
+            var router = new ResponseRouter(new Lazy<IOutputHandler>(() => outputHandler), new JsonRpcSerializer(), new AssemblyScanningHandlerTypeDescriptorProvider(new [] { typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
 
             outputHandler
                .When(x => x.Send(Arg.Is<object>(z => z.GetType() == typeof(OutgoingRequest))))
@@ -43,7 +43,7 @@ namespace JsonRpc.Tests
         public async Task WorksWithUnitType()
         {
             var outputHandler = Substitute.For<IOutputHandler>();
-            var router = new ResponseRouter(new Lazy<IOutputHandler>(() => outputHandler), new JsonRpcSerializer(), new HandlerTypeDescriptorProvider(new [] { typeof(HandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
+            var router = new ResponseRouter(new Lazy<IOutputHandler>(() => outputHandler), new JsonRpcSerializer(), new AssemblyScanningHandlerTypeDescriptorProvider(new [] { typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
 
             outputHandler
                .When(x => x.Send(Arg.Is<object>(z => z.GetType() == typeof(OutgoingRequest))))
@@ -64,7 +64,7 @@ namespace JsonRpc.Tests
         public async Task WorksWithNotification()
         {
             var outputHandler = Substitute.For<IOutputHandler>();
-            var router = new ResponseRouter(new Lazy<IOutputHandler>(() => outputHandler), new JsonRpcSerializer(), new HandlerTypeDescriptorProvider(new [] { typeof(HandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
+            var router = new ResponseRouter(new Lazy<IOutputHandler>(() => outputHandler), new JsonRpcSerializer(), new AssemblyScanningHandlerTypeDescriptorProvider(new [] { typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly, typeof(HandlerResolverTests).Assembly }));
 
             router.SendNotification(new NotificationParams());
 

--- a/test/Lsp.Tests/FoundationTests.cs
+++ b/test/Lsp.Tests/FoundationTests.cs
@@ -661,7 +661,7 @@ namespace Lsp.Tests
                 var handlerTypeDescriptorProvider =
                     new LspHandlerTypeDescriptorProvider(
                         new[] {
-                            typeof(HandlerTypeDescriptorProvider).Assembly,
+                            typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly,
                             typeof(LspHandlerTypeDescriptorProvider).Assembly,
                             typeof(LanguageServer).Assembly,
                             typeof(LanguageClient).Assembly,
@@ -694,7 +694,7 @@ namespace Lsp.Tests
                 var handlerTypeDescriptorProvider =
                     new LspHandlerTypeDescriptorProvider(
                         new[] {
-                            typeof(HandlerTypeDescriptorProvider).Assembly,
+                            typeof(AssemblyScanningHandlerTypeDescriptorProvider).Assembly,
                             typeof(LspHandlerTypeDescriptorProvider).Assembly,
                             typeof(LanguageServer).Assembly,
                             typeof(LanguageClient).Assembly,


### PR DESCRIPTION
This adds a few generators that emit assembly attributes so that getting access to all the registration converters, and capability keys is working as expected.