### PR TITLE
Added AllowDerivedRequest support for lsp telemetry event

### DIFF
--- a/src/JsonRpc.Generators/DelegateHelpers.cs
+++ b/src/JsonRpc.Generators/DelegateHelpers.cs
@@ -89,10 +89,6 @@ namespace OmniSharp.Extensions.JsonRpc.Generators
                .WithTypeArgumentList(TypeArgumentList(SeparatedList(typeArguments)));
         }
 
-        public static GenericNameSyntax CreateAction(params TypeSyntax[] arguments) => CreateAction(true, arguments);
-
-        public static GenericNameSyntax CreateAsyncAction(params TypeSyntax[] arguments) => CreateAsyncFunc(null, true, arguments);
-
         public static GenericNameSyntax CreateAsyncAction(bool withCancellationToken, params TypeSyntax[] arguments) => CreateAsyncFunc(null, withCancellationToken, arguments);
 
         public static GenericNameSyntax CreateAsyncFunc(TypeSyntax? returnType, bool withCancellationToken, params TypeSyntax[] arguments)

--- a/src/JsonRpc.Generators/Strategies/OnNotificationMethodGeneratorWithRegistrationOptionsStrategy.cs
+++ b/src/JsonRpc.Generators/Strategies/OnNotificationMethodGeneratorWithRegistrationOptionsStrategy.cs
@@ -46,9 +46,9 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Strategies
             if (allowDerivedRequests)
             {
                 var genericFactory = MakeGenericFactory(factory, notification.Request.Syntax);
-                yield return genericFactory(CreateAction(IdentifierName("T")));
-                yield return genericFactory(CreateAsyncAction(false, IdentifierName("T")));
+                yield return genericFactory(CreateAction(false, IdentifierName("T")));
                 yield return genericFactory(CreateAction(true, IdentifierName("T")));
+                yield return genericFactory(CreateAsyncAction(false, IdentifierName("T")));
                 yield return genericFactory(CreateAsyncAction(true, IdentifierName("T")));
             }
 

--- a/src/JsonRpc.Generators/Strategies/OnNotificationMethodGeneratorWithoutRegistrationOptionsStrategy.cs
+++ b/src/JsonRpc.Generators/Strategies/OnNotificationMethodGeneratorWithoutRegistrationOptionsStrategy.cs
@@ -12,21 +12,21 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Strategies
     {
         public IEnumerable<MemberDeclarationSyntax> Apply(ExtensionMethodContext extensionMethodContext, GeneratorData item)
         {
-            if (item is { RegistrationOptions: {} }) yield break;
+            if (item is { RegistrationOptions: { } }) yield break;
             if (item is not NotificationItem notification) yield break;
             if (extensionMethodContext is not { IsRegistry: true }) yield break;
 
             var allowDerivedRequests = item.JsonRpcAttributes.AllowDerivedRequests;
 
             var method = MethodDeclaration(extensionMethodContext.Item, item.JsonRpcAttributes.HandlerMethodName)
-                                      .WithModifiers(
-                                           TokenList(
-                                               Token(SyntaxKind.PublicKeyword),
-                                               Token(SyntaxKind.StaticKeyword)
-                                           )
-                                       )
-                                      .WithExpressionBody(GetNotificationHandlerExpression(GetJsonRpcMethodName(extensionMethodContext.TypeDeclaration)))
-                                      .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
+                        .WithModifiers(
+                             TokenList(
+                                 Token(SyntaxKind.PublicKeyword),
+                                 Token(SyntaxKind.StaticKeyword)
+                             )
+                         )
+                        .WithExpressionBody(GetNotificationHandlerExpression(GetJsonRpcMethodName(extensionMethodContext.TypeDeclaration)))
+                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
 
             var factory = MakeMethodFactory(method, extensionMethodContext.GetRegistryParameterList());
             yield return factory(CreateAction(false, item.Request.Syntax));
@@ -37,9 +37,9 @@ namespace OmniSharp.Extensions.JsonRpc.Generators.Strategies
             if (allowDerivedRequests)
             {
                 var genericFactory = MakeGenericFactory(factory, notification.Request.Syntax);
-                yield return genericFactory(CreateAction(IdentifierName("T")));
-                yield return genericFactory(CreateAsyncAction(false, IdentifierName("T")));
+                yield return genericFactory(CreateAction(false, IdentifierName("T")));
                 yield return genericFactory(CreateAction(true, IdentifierName("T")));
+                yield return genericFactory(CreateAsyncAction(false, IdentifierName("T")));
                 yield return genericFactory(CreateAsyncAction(true, IdentifierName("T")));
             }
 

--- a/src/Protocol/Features/Window/TelemetryEventFeature.cs
+++ b/src/Protocol/Features/Window/TelemetryEventFeature.cs
@@ -9,15 +9,18 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 // ReSharper disable once CheckNamespace
 namespace OmniSharp.Extensions.LanguageServer.Protocol
 {
-
     namespace Models
     {
         [Parallel]
         [Method(WindowNames.TelemetryEvent, Direction.ServerToClient)]
-        [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.Window"), GenerateHandlerMethods, GenerateRequestMethods(typeof(IWindowLanguageServer), typeof(ILanguageServer))]
+        [
+            GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.Window", AllowDerivedRequests = true),
+            GenerateHandlerMethods,
+            GenerateRequestMethods(typeof(IWindowLanguageServer), typeof(ILanguageServer))
+        ]
         public record TelemetryEventParams : IRequest
         {
-            [JsonExtensionData] public IDictionary<string, JToken> Data { get; init; } = new Dictionary<string, JToken>();
+            [JsonExtensionData] public IDictionary<string, object> ExtensionData { get; init; } = new Dictionary<string, object>();
         }
     }
 

--- a/test/Lsp.Tests/Integration/CustomRequestsTests.cs
+++ b/test/Lsp.Tests/Integration/CustomRequestsTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using OmniSharp.Extensions.JsonRpc.Testing;
+using OmniSharp.Extensions.LanguageProtocol.Testing;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
+using TestingUtils;
+using Xunit.Abstractions;
+
+namespace Lsp.Tests.Integration
+{
+    public class CustomRequestsTests : LanguageProtocolTestBase
+    {
+        public CustomRequestsTests(ITestOutputHelper outputHelper) : base(new JsonRpcTestOptions().ConfigureForXUnit(outputHelper))
+        {
+        }
+
+        [RetryFact]
+        public async Task Should_Support_Custom_Telemetry_Using_Base_Class()
+        {
+            var fake = Substitute.For<TelemetryEventHandlerBase<CustomTelemetryEventParams>>();
+            var (_, server) = await Initialize(options => { }, options => { options.AddHandler(fake); });
+
+            var @event = new CustomTelemetryEventParams {
+                CodeFolding = true,
+                ProfileLoading = false,
+                ScriptAnalysis = true,
+                Pester5CodeLens = true,
+                PromptToUpdatePackageManagement = false
+            };
+            server.SendTelemetryEvent(@event);
+            await SettleNext();
+
+            var call = fake.ReceivedCalls().Single();
+            var args = call.GetArguments();
+
+            args[0].Should().BeOfType<CustomTelemetryEventParams>()
+                   .And
+                   .Should().BeEquivalentTo(@event);
+        }
+
+        [RetryFact]
+        public async Task Should_Support_Custom_Telemetry_Receiving_Regular_Telemetry_Using_Base_Class()
+        {
+            var fake = Substitute.For<TelemetryEventHandlerBase>();
+            var (_, server) = await Initialize(options => { }, options => { options.AddHandler(fake); });
+
+            var @event = new CustomTelemetryEventParams {
+                CodeFolding = true,
+                ProfileLoading = false,
+                ScriptAnalysis = true,
+                Pester5CodeLens = true,
+                PromptToUpdatePackageManagement = false
+            };
+            server.SendTelemetryEvent(@event);
+            await SettleNext();
+
+            var call = fake.ReceivedCalls().Single();
+            var args = call.GetArguments();
+            var request = args[0].Should().BeOfType<TelemetryEventParams>().Which;
+            request.ExtensionData.Should().ContainKey("codeFolding").And.Subject["codeFolding"].Should().Be(true);
+            request.ExtensionData.Should().ContainKey("profileLoading").And.Subject["profileLoading"].Should().Be(false);
+            request.ExtensionData.Should().ContainKey("scriptAnalysis").And.Subject["scriptAnalysis"].Should().Be(true);
+            request.ExtensionData.Should().ContainKey("pester5CodeLens").And.Subject["pester5CodeLens"].Should().Be(true);
+            request.ExtensionData.Should().ContainKey("promptToUpdatePackageManagement").And.Subject["promptToUpdatePackageManagement"].Should().Be(false);
+        }
+
+        [RetryFact]
+        public async Task Should_Support_Custom_Telemetry_Using_Extension_Data_Using_Base_Class()
+        {
+            var fake = Substitute.For<TelemetryEventHandlerBase<CustomTelemetryEventParams>>();
+            var (_, server) = await Initialize(options => { }, options => { options.AddHandler(fake); });
+
+            server.SendTelemetryEvent(
+                new TelemetryEventParams {
+                    ExtensionData = new Dictionary<string, object> {
+                        ["CodeFolding"] = true,
+                        ["ProfileLoading"] = false,
+                        ["ScriptAnalysis"] = true,
+                        ["Pester5CodeLens"] = true,
+                        ["PromptToUpdatePackageManagement"] = false
+                    }
+                }
+            );
+
+            var call = fake.ReceivedCalls().Single();
+            var args = call.GetArguments();
+            var request = args[0].Should().BeOfType<CustomTelemetryEventParams>().Which;
+            request.CodeFolding.Should().Be(true);
+            request.ProfileLoading.Should().Be(false);
+            request.ScriptAnalysis.Should().Be(true);
+            request.Pester5CodeLens.Should().Be(true);
+            request.PromptToUpdatePackageManagement.Should().Be(false);
+        }
+
+        [RetryFact]
+        public async Task Should_Support_Custom_Telemetry_Using_Delegate()
+        {
+            var fake = Substitute.For<Func<CustomTelemetryEventParams, CancellationToken, Task>>();
+            var (_, server) = await Initialize(options => { options.OnTelemetryEvent(fake); }, options => {  });
+
+            var @event = new CustomTelemetryEventParams {
+                CodeFolding = true,
+                ProfileLoading = false,
+                ScriptAnalysis = true,
+                Pester5CodeLens = true,
+                PromptToUpdatePackageManagement = false
+            };
+            server.SendTelemetryEvent(@event);
+            await SettleNext();
+
+            var call = fake.ReceivedCalls().Single();
+            var args = call.GetArguments();
+            args[0]
+                         .Should().BeOfType<CustomTelemetryEventParams>()
+                         .And
+                         .Should().BeEquivalentTo(@event);
+        }
+
+        [RetryFact]
+        public async Task Should_Support_Custom_Telemetry_Receiving_Regular_Telemetry_Using_Delegate()
+        {
+            var fake = Substitute.For<Func<TelemetryEventParams, CancellationToken, Task>>();
+            var (_, server) = await Initialize(options => { options.OnTelemetryEvent(fake); }, options => {  });
+
+            var @event = new CustomTelemetryEventParams {
+                CodeFolding = true,
+                ProfileLoading = false,
+                ScriptAnalysis = true,
+                Pester5CodeLens = true,
+                PromptToUpdatePackageManagement = false
+            };
+            server.SendTelemetryEvent(@event);
+            await SettleNext();
+
+            var call = fake.ReceivedCalls().Single();
+            var args = call.GetArguments();
+            var request = args[0].Should().BeOfType<TelemetryEventParams>().Which;
+            request.ExtensionData.Should().ContainKey("codeFolding").And.Subject["codeFolding"].Should().Be(true);
+            request.ExtensionData.Should().ContainKey("profileLoading").And.Subject["profileLoading"].Should().Be(false);
+            request.ExtensionData.Should().ContainKey("scriptAnalysis").And.Subject["scriptAnalysis"].Should().Be(true);
+            request.ExtensionData.Should().ContainKey("pester5CodeLens").And.Subject["pester5CodeLens"].Should().Be(true);
+            request.ExtensionData.Should().ContainKey("promptToUpdatePackageManagement").And.Subject["promptToUpdatePackageManagement"].Should().Be(false);
+        }
+
+        [RetryFact]
+        public async Task Should_Support_Custom_Telemetry_Using_Extension_Data_Using_Delegate()
+        {
+            var fake = Substitute.For<Func<CustomTelemetryEventParams, CancellationToken, Task>>();
+            var (_, server) = await Initialize(options => { options.OnTelemetryEvent(fake); }, options => {  });
+
+            server.SendTelemetryEvent(
+                new TelemetryEventParams {
+                    ExtensionData = new Dictionary<string, object> {
+                        ["CodeFolding"] = true,
+                        ["ProfileLoading"] = false,
+                        ["ScriptAnalysis"] = true,
+                        ["Pester5CodeLens"] = true,
+                        ["PromptToUpdatePackageManagement"] = false
+                    }
+                }
+            );
+
+            var call = fake.ReceivedCalls().Single();
+            var args = call.GetArguments();
+            var request = args[0].Should().BeOfType<CustomTelemetryEventParams>().Which;
+            request.CodeFolding.Should().Be(true);
+            request.ProfileLoading.Should().Be(false);
+            request.ScriptAnalysis.Should().Be(true);
+            request.Pester5CodeLens.Should().Be(true);
+            request.PromptToUpdatePackageManagement.Should().Be(false);
+        }
+
+        public record CustomTelemetryEventParams : TelemetryEventParams
+        {
+            public bool ScriptAnalysis { get; init; }
+            public bool CodeFolding { get; init; }
+            public bool PromptToUpdatePackageManagement { get; init; }
+            public bool ProfileLoading { get; init; }
+            public bool Pester5CodeLens { get; init; }
+        }
+    }
+}


### PR DESCRIPTION
### TelemetryEvent Change
The property `TelemetryEvent.Data` has been renamed to `ExtensionData` and the type has been changed as well.