### PR TITLE
Fix invalid cast issue in omnisharp-roslyn by fixing LspHandlerDescriptor ctor

### DIFF
--- a/src/Protocol/Shared/LspHandlerDescriptor.cs
+++ b/src/Protocol/Shared/LspHandlerDescriptor.cs
@@ -69,8 +69,11 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Shared
             CapabilityType = capabilityType;
 
             Response = @params?.GetInterfaces()
-                               .FirstOrDefault(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IRequest<>))
-                              ?.GetGenericArguments()[0] ?? typeDescriptor?.ResponseType ?? typeof(Unit);
+                               .Where(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IRequest<>))
+                               .Select(x => x.GetGenericArguments()[0])
+                               .OrderBy(x => x == typeof(Unit))
+                               .FirstOrDefault()
+                              ?? typeDescriptor?.ResponseType ?? typeof(Unit);
 
             // If multiple are implemented this behavior is unknown
             CanBeResolvedHandlerType = handler.GetType().GetTypeInfo()


### PR DESCRIPTION
See:
 - https://github.com/OmniSharp/omnisharp-roslyn/issues/1995

The issue (apparently) is that `LspHandlerDescriptor` is constructed for `DelegatingRequest` that is registered in `LanguageServerHost.cs` (in omnisharp-roslyn) via `r.OnRequest()` here:

https://github.com/OmniSharp/omnisharp-roslyn/blob/b68f146a649bd6b0294894831e08bbd3b802110c/src/OmniSharp.LanguageServerProtocol/LanguageServerHost.cs#L310

The constructor attempts to resolve RPC return type based on what generic type is set on `IRequest<T>` that is inherited by `DelegatingRequest`. However `DelegatingRequest` implements both `IRequest` and `IRequest<TResponse>` and LINQ code selects `IRequest<MediatR.Unit>` type as the return value -- while it should be `IRequest<JToken>` for LSP requests (apparently?).

The issue was fixed by ordering implemented `IRequest<>` interfaces by generic param type and taking the first that is not `MediatR.Unit` -- only then use the `MediatR.Unit` version.

---

I am not 100% sure this is the proper/correct fix for my issue (https://github.com/OmniSharp/omnisharp-roslyn/issues/1995) but it seems to do the job.

I can try to write tests or change this you feel that is the wrong approach to fix the issue.