### PR TITLE
Clean System.IO.Pipelines explicit dependency

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
         <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
@@ -44,7 +44,6 @@
         <PackageReference Update="Bogus" Version="33.0.2"/>
         <PackageReference Update="Snapper" Version="2.3.0"/>
         <PackageReference Update="Xunit.SkippableFact" Version="1.4.13"/>
-        <PackageReference Update="System.IO.Pipelines" Version="4.7.3"/>
         <PackageReference Update="Nerdbank.Streams" Version="2.6.81"/>
         <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2"/>

--- a/src/JsonRpc/JsonRpc.csproj
+++ b/src/JsonRpc/JsonRpc.csproj
@@ -14,7 +14,6 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Newtonsoft.Json" />
         <PackageReference Include="MediatR" />
-        <PackageReference Include="System.IO.Pipelines" />
         <PackageReference Include="Nerdbank.Streams" />
         <PackageReference Include="System.Threading.Channels" />
         <PackageReference Include="DryIoc.Internal" PrivateAssets="All" />


### PR DESCRIPTION
I got that exception during the startup of my application:

```    
System.MissingMethodException: Method not found: 'System.Threading.Tasks.ValueTask System.IO.Pipelines.PipeWriter.CompleteAsync(System.Exception)'.

```

With stack trace:
```
   at Nerdbank.Streams.PipeExtensions.<>c__DisplayClass19_0.<<UsePipeReader>b__2>d.MoveNext() in D:\a\1\s\src\Nerdbank.Streams\PipeExtensions.cs:line 546
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine) in f:\dd\ndp\clr\src\BCL\system\runtime\compilerservices\AsyncMethodBuilder.cs:line 322
   at Nerdbank.Streams.PipeExtensions.<>c__DisplayClass19_0.<UsePipeReader>b__2()
   at System.Threading.Tasks.Task`1.InnerInvoke() in f:\dd\ndp\clr\src\BCL\system\threading\Tasks\Future.cs:line 680
   at System.Threading.Tasks.Task.Execute() in f:\dd\ndp\clr\src\BCL\system\threading\Tasks\Task.cs:line 2498
```

I don't completely understand why I get this but the dependency tree is a bit complex so I feel like simplifying would improve the situation. `System.IO.Pipelines` is inherited by dependency to `NerdBank.Streams` so we should not explictely reference it.