### PR TITLE
Fix version conflicts caused by PR#626

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
         <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
@@ -44,8 +44,8 @@
         <PackageReference Update="Bogus" Version="33.0.2"/>
         <PackageReference Update="Snapper" Version="2.3.0"/>
         <PackageReference Update="Xunit.SkippableFact" Version="1.4.13"/>
-        <PackageReference Update="System.IO.Pipelines" Version="4.7.3"/>
-        <PackageReference Update="Nerdbank.Streams" Version="2.6.81"/>
+        <PackageReference Update="System.IO.Pipelines" Version="5.0.1"/>
+        <PackageReference Update="Nerdbank.Streams" Version="2.8.46"/>
         <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2"/>
         <PackageReference Update="DryIoc.Internal" Version="4.7.6"/>

--- a/sample/SampleServer/SampleServer.csproj
+++ b/sample/SampleServer/SampleServer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -20,8 +20,8 @@
         <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
         <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
         <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
-        <PackageReference Include="System.IO.Pipelines" Version="4.7.3" />
-        <PackageReference Include="Nerdbank.Streams" Version="2.6.81" />
+        <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
+        <PackageReference Include="Nerdbank.Streams" Version="2.8.46" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Nerdbank.Streams from 2.6.81 to 2.8.46. [(PR#626)](https://github.com/OmniSharp/csharp-language-server-protocol/pull/626).
Hope this fix can help you.

Best regards,
sucrose