### PR TITLE
Limit mediatr version range to [8.1.0,9.0.0)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -40,7 +40,7 @@
         <PackageReference Update="System.Collections.Immutable" Version="1.7.1"/>
         <PackageReference Update="System.Threading.Channels" Version="4.7.1"/>
         <PackageReference Update="Microsoft.Reactive.Testing" Version="4.4.1"/>
-        <PackageReference Update="MediatR" Version="8.*"/>
+        <PackageReference Update="MediatR" Version="[8.1.0,9.0.0)"/>
         <PackageReference Update="Bogus" Version="33.0.2"/>
         <PackageReference Update="Snapper" Version="2.3.0"/>
         <PackageReference Update="Xunit.SkippableFact" Version="1.4.13"/>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -40,7 +40,7 @@
         <PackageReference Update="System.Collections.Immutable" Version="1.7.1"/>
         <PackageReference Update="System.Threading.Channels" Version="4.7.1"/>
         <PackageReference Update="Microsoft.Reactive.Testing" Version="4.4.1"/>
-        <PackageReference Update="MediatR" Version="8.1.0"/>
+        <PackageReference Update="MediatR" Version="8.*"/>
         <PackageReference Update="Bogus" Version="33.0.2"/>
         <PackageReference Update="Snapper" Version="2.3.0"/>
         <PackageReference Update="Xunit.SkippableFact" Version="1.4.13"/>


### PR DESCRIPTION
A possible fix for #676 

Sets the MediatR version using the version range syntax.

Have done a local build and all tests pass.  Results in a .nuspec file with:

```
   <dependency id="MediatR" version="[8.1.0, 9.0.0)" exclude="Build,Analyzers" />
```

Still need to test what happens when paket adds this dependency - will confirm when have done so, just creating this for review/thoughts.