### PR TITLE
Update MediatR to 9.0.0

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -40,7 +40,7 @@
         <PackageReference Update="System.Collections.Immutable" Version="1.7.1"/>
         <PackageReference Update="System.Threading.Channels" Version="4.7.1"/>
         <PackageReference Update="Microsoft.Reactive.Testing" Version="4.4.1"/>
-        <PackageReference Update="MediatR" Version="8.1.0"/>
+        <PackageReference Update="MediatR" Version="[9.0.0,10.0.0)"/>
         <PackageReference Update="Bogus" Version="33.0.2"/>
         <PackageReference Update="Snapper" Version="2.3.0"/>
         <PackageReference Update="Xunit.SkippableFact" Version="1.4.13"/>


### PR DESCRIPTION
A possible fix for #676

Sets the MediatR version using the version range syntax to `[9.0.0,10.0.0)` (as a precaution for future breaking changes in MediatR v10.

Have done a local build and all tests pass without any changes.  It seems that just building against the explicit 9.0.0 dependency is sufficient to ensure the correct mediator interface method is invoked.