### PR TITLE
Add token permissions for sync-labels.yml

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -9,8 +9,14 @@ on:
   schedule:
     - cron: '0 0 * * 4'
 
+permissions:
+  contents: read
+
 jobs:
   sync_labels:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      issues: write  # for crazy-max/ghaction-github-labeler to create, rename, update and delete label
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
GitHub asks users to define workflow permissions, see https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token for securing GitHub workflows against supply-chain attacks.

StepSecurity is working on securing GitHub workflows and [OSSF Scorecards](https://github.com/ossf/scorecard) recommends using StepSecurity's secure-workflows online tool [app.stepsecurity.io](https://github.com/cosmos/cosmos-sdk/pull/app.stepsecurity.io) to improve the security of GitHub workflows.


We have fixed one of the repo's workflows for you by adding permissions for the involved jobs. You can secure the rest of the workflows for improved security by using the StepSecurity online tool at [app.stepsecurity.io](https://app.stepsecurity.io/).