### PR TITLE
Fix bug caused by `System.Threading.Tasks` v4.7.1

### DIFF
--- a/.build/.build.csproj
+++ b/.build/.build.csproj
@@ -14,7 +14,6 @@
         <PackageReference Include="JetBrains.ReSharper.CommandLineTools" ExcludeAssets="All" />
         <PackageReference Include="GitVersion.Tool" ExcludeAssets="All" />
         <PackageReference Include="ReportGenerator" ExcludeAssets="All" />
-        <PackageReference Include="JetBrains.ReSharper.CommandLineTools" ExcludeAssets="All" />
         <PackageReference Include="Rocket.Surgery.Nuke" />
     </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,7 @@
     <PackageVersion Include="coverlet.msbuild" Version="3.1.2" />
     <PackageVersion Include="System.Reactive" Version="5.0.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageVersion Include="System.Threading.Channels" Version="4.7.1" />
+    <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="5.0.0" />
     <PackageVersion Include="MediatR" Version="8.1.0" />
     <PackageVersion Include="Bogus" Version="34.0.2" />

--- a/sample/SampleServer/SampleServer.csproj
+++ b/sample/SampleServer/SampleServer.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <ProjectReference Include="../../src/Server/Server.csproj" />
-        <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="6.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" VersionOverride="3.1.0" />
         <PackageReference Include="Serilog.Sinks.File" VersionOverride="5.0.0" />
         <PackageReference Include="Serilog.Sinks.Debug" VersionOverride="2.0.0" />


### PR DESCRIPTION
Unfortunately `System.Threading.Tasks` v4.7.1 is broken. Its package manifest states that it depends on `System.Threading.Tasks.Extensions` >= v4.5.4 (assembly version v4.2.0.1); however, for some reason it actually requests v4.2.0.0. While neither OmniSharp nor PowerShell Editor Services, the downstream library where this bug appeared, ship that version of the library, it can sometimes be found in the Global Assembly Cache on Windows. When present (due to an installation by some other program), it gets loaded, and then other dependencies (correctly) request v4.2.0.1 which also gets loaded. When both are loaded, a `System.MissingMethodException` is thrown! Specifically the method `ChannelReader.ReadAsync` (from `System.Threading.Tasks`) on the type `Tasks.ValueTask` (provided by `System.Threading.Tasks.Extensions`) can no longer be resolved. I do not know enough about the intricacies of method/type resolution in the full .NET Framework as to explain precisely why the presence of v4.2.0.0 causes this resolution to fail, but it certainly does. Upgrading `System.Threading.Tasks` to v6.0.0 is confirmed to solve the problem, since the newer package correctly requests `System.Threading.Tasks.Extensions` v4.2.0.1.

I tested this and it sure seems to fix https://github.com/PowerShell/vscode-powershell/issues/4175.