### PR TITLE
Set max depth for JSON serializer to mitigate known DOS vulnerability

### DIFF
--- a/src/JsonRpc/Serialization/SerializerBase.cs
+++ b/src/JsonRpc/Serialization/SerializerBase.cs
@@ -19,7 +19,7 @@ namespace OmniSharp.Extensions.JsonRpc.Serialization
 
         protected virtual JsonSerializerSettings CreateSerializerSettings()
         {
-            var settings = JsonConvert.DefaultSettings != null ? JsonConvert.DefaultSettings() : new JsonSerializerSettings();
+            var settings = JsonConvert.DefaultSettings != null ? JsonConvert.DefaultSettings() : new JsonSerializerSettings { MaxDepth = 128 };
             AddOrReplaceConverters(settings.Converters);
             return _settings = settings;
         }


### PR DESCRIPTION
The other option is to update Newtonsoft.Json, which now also sets the maximum depth by default, but this mitigates without having to update.