### PR TITLE
Don't log critical message when client disconnect

### DIFF
--- a/src/JsonRpc/InputHandler.cs
+++ b/src/JsonRpc/InputHandler.cs
@@ -144,9 +144,17 @@ namespace OmniSharp.Extensions.JsonRpc
                         {
                             await ProcessInputStream(_stopProcessing.Token).ConfigureAwait(false);
                         }
+                        catch (IOException e)
+                        {
+                            if (e.InnerException is SocketException se && se.SocketErrorCode == SocketError.ConnectionReset)
+                                _logger.LogInformation(e, "Connection reset by client.");
+                            else
+                                throw;
+
+                        }
                         catch (Exception e)
                         {
-                            _logger.LogCritical(e, "unhandled exception");
+                            _logger.LogCritical(e, "Unhandled exception");
                         }
                     }
                 ).Subscribe(_inputActive)


### PR DESCRIPTION
We are showing warnings/errors in our UI and this would pop up every time a client disconnects (usually by the user). This error should not result in a critical message in the log IMO. What do you think?  
  
Not 100% about the wording of the message to show in this case though.
