### PR TITLE
Fix RegistrationOptions and Capabilities

### DIFF
--- a/src/Protocol/Client/Capabilities/ITextDocumentClientCapabilities.cs
+++ b/src/Protocol/Client/Capabilities/ITextDocumentClientCapabilities.cs
@@ -159,20 +159,20 @@
         ///
         /// @since 3.17.0
         /// </summary>
-        Supports<InlineValueWorkspaceClientCapabilities?> InlineValue { get; set; }
+        Supports<InlineValueClientCapabilities?> InlineValue { get; set; }
 
         /// <summary>
         /// Capability specific to the `textDocument/inlayHint` request.
         ///
         /// @since 3.17.0
         /// </summary>
-        Supports<InlayHintWorkspaceClientCapabilities?> InlayHint { get; set; }
+        Supports<InlayHintClientCapabilities?> InlayHint { get; set; }
 
         /// <summary>
         /// Capability specific to the diagnostic pull model.
         ///
         /// @since 3.17.0
         /// </summary>
-        Supports<DiagnosticWorkspaceClientCapabilities?> Diagnostic { get; set; }
+        Supports<DiagnosticClientCapabilities?> Diagnostic { get; set; }
     }
 }

--- a/src/Protocol/Client/Capabilities/TextDocumentClientCapabilities.cs
+++ b/src/Protocol/Client/Capabilities/TextDocumentClientCapabilities.cs
@@ -159,20 +159,20 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities
         ///
         /// @since 3.17.0
         /// </summary>
-        public Supports<InlineValueWorkspaceClientCapabilities?> InlineValue { get; set; }
+        public Supports<InlineValueClientCapabilities?> InlineValue { get; set; }
 
         /// <summary>
         /// Capability specific to the `textDocument/inlayHint` request.
         ///
         /// @since 3.17.0
         /// </summary>
-        public Supports<InlayHintWorkspaceClientCapabilities?> InlayHint { get; set; }
+        public Supports<InlayHintClientCapabilities?> InlayHint { get; set; }
 
         /// <summary>
         /// Capability specific to the diagnostic pull model.
         ///
         /// @since 3.17.0
         /// </summary>
-        public Supports<DiagnosticWorkspaceClientCapabilities?> Diagnostic { get; set; }
+        public Supports<DiagnosticClientCapabilities?> Diagnostic { get; set; }
     }
 }

--- a/src/Protocol/Client/Capabilities/WorkspaceEditCapability.cs
+++ b/src/Protocol/Client/Capabilities/WorkspaceEditCapability.cs
@@ -3,7 +3,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities
 {
-    [CapabilityKey(nameof(ClientCapabilities.TextDocument), nameof(WorkspaceClientCapabilities.WorkspaceEdit))]
+    [CapabilityKey(nameof(ClientCapabilities.Workspace), nameof(WorkspaceClientCapabilities.WorkspaceEdit))]
     public class WorkspaceEditCapability : ICapability
     {
         /// <summary>

--- a/src/Protocol/Features/Document/CompletionFeature.cs
+++ b/src/Protocol/Features/Document/CompletionFeature.cs
@@ -509,7 +509,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
                     var items = result["items"].ToObject<IEnumerable<CompletionItem>>(serializer);
                     return new CompletionList(items, result["isIncomplete"]?.Value<bool>() ?? false)
                     {
-                        ItemDefaults = result["itemDefaults"]?.ToObject<CompletionListItemDefaults>()
+                        ItemDefaults = result["itemDefaults"]?.ToObject<CompletionListItemDefaults>(serializer)
                     };
                 }
 

--- a/src/Protocol/Features/Document/DiagnosticsFeature.cs
+++ b/src/Protocol/Features/Document/DiagnosticsFeature.cs
@@ -467,7 +467,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
         [GenerateRegistrationOptions(nameof(ServerCapabilities.DiagnosticProvider))]
         [RegistrationName(TextDocumentNames.Diagnostics)]
-        public partial class DiagnosticsRegistrationOptions : ITextDocumentRegistrationOptions, IWorkDoneProgressOptions
+        public partial class DiagnosticsRegistrationOptions : ITextDocumentRegistrationOptions, IWorkDoneProgressOptions, IStaticRegistrationOptions
         {
             /// <summary>
             /// An optional identifier under which the diagnostics are

--- a/src/Protocol/Features/Document/InlayHintFeature.cs
+++ b/src/Protocol/Features/Document/InlayHintFeature.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using MediatR;
 using Newtonsoft.Json;
@@ -231,7 +231,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
                     if (reader.TokenType == JsonToken.StartArray)
                     {
                         var result = JArray.Load(reader);
-                        return new StringOrInlayHintLabelParts(result.ToObject<Container<InlayHintLabelPart>>());
+                        return new StringOrInlayHintLabelParts(result.ToObject<Container<InlayHintLabelPart>>(serializer));
                     }
 
                     if (reader.TokenType == JsonToken.String)

--- a/src/Protocol/Features/Document/InlineValueFeature.cs
+++ b/src/Protocol/Features/Document/InlineValueFeature.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -98,7 +98,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
                     {
                         return new InlineValueText()
                         {
-                            Range = result["range"]!.ToObject<Range?>()!,
+                            Range = result["range"]!.ToObject<Range?>(serializer)!,
                             Text = result["text"]!.Value<string>()!
                         };
                     }
@@ -107,7 +107,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
                     {
                         return new InlineValueVariableLookup()
                         {
-                            Range = result["range"].ToObject<Range>()!,
+                            Range = result["range"].ToObject<Range>(serializer)!,
                             VariableName = result["variableName"]!.Value<string>()!,
                             CaseSensitiveLookup = result["caseSensitiveLookup"]?.Value<bool?>() ?? false,
                         };
@@ -115,7 +115,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
                     return new InlineValueEvaluatableExpression()
                     {
-                        Range = result["range"].ToObject<Range>()!,
+                        Range = result["range"].ToObject<Range>(serializer)!,
                         Expression = result["expression"]?.Value<string>()
                     };
                 }

--- a/src/Protocol/Features/Document/InlineValueFeature.cs
+++ b/src/Protocol/Features/Document/InlineValueFeature.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -25,7 +25,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             GenerateHandlerMethods,
             GenerateRequestMethods(typeof(ITextDocumentLanguageClient), typeof(ILanguageClient))
         ]
-        [RegistrationOptions(typeof(InlineValueRegistrationOptions)), Capability(typeof(InlineValueWorkspaceClientCapabilities))]
+        [RegistrationOptions(typeof(InlineValueRegistrationOptions)), Capability(typeof(InlineValueClientCapabilities))]
         public partial record InlineValueParams : ITextDocumentIdentifierParams, IWorkDoneProgressParams,
                                                   IRequest<Container<InlineValueBase>?>
         {
@@ -69,7 +69,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.Workspace")]
         [GenerateHandlerMethods]
         [GenerateRequestMethods(typeof(IWorkspaceLanguageServer), typeof(ILanguageServer))]
-        [Capability(typeof(CodeLensWorkspaceClientCapabilities))]
+        [Capability(typeof(InlineValueWorkspaceClientCapabilities))]
         public partial record InlineValueRefreshParams : IRequest;
 
         [JsonConverter(typeof(Converter))]
@@ -179,7 +179,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
         [GenerateRegistrationOptions(nameof(ServerCapabilities.InlineValueProvider))]
         [RegistrationName(TextDocumentNames.InlineValue)]
-        public partial class InlineValueRegistrationOptions : ITextDocumentRegistrationOptions, IWorkDoneProgressOptions
+        public partial class InlineValueRegistrationOptions : ITextDocumentRegistrationOptions, IWorkDoneProgressOptions, IStaticRegistrationOptions
         {
         }
     }
@@ -190,12 +190,17 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
     namespace Client.Capabilities
     {
+        [CapabilityKey(nameof(ClientCapabilities.TextDocument), nameof(TextDocumentClientCapabilities.InlineValue))]
+        public partial class InlineValueClientCapabilities : DynamicCapability
+        {
+        }
+
         /// <summary>
         /// Client workspace capabilities specific to inline values.
         ///
         /// @since 3.17.0
         /// </summary>
-        [CapabilityKey(nameof(ClientCapabilities.TextDocument), nameof(TextDocumentClientCapabilities.InlineValue))]
+        [CapabilityKey(nameof(ClientCapabilities.Workspace), nameof(WorkspaceClientCapabilities.InlineValue))]
         public partial class InlineValueWorkspaceClientCapabilities : ICapability
         {
             /// <summary>

--- a/src/Protocol/Features/Document/SemanticTokensFeature.cs
+++ b/src/Protocol/Features/Document/SemanticTokensFeature.cs
@@ -790,14 +790,17 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         ///
         /// @since 3.16.0.
         /// </summary>
-        [CapabilityKey(nameof(ClientCapabilities.TextDocument), nameof(WorkspaceClientCapabilities.SemanticTokens))]
+        [CapabilityKey(nameof(ClientCapabilities.Workspace), nameof(WorkspaceClientCapabilities.SemanticTokens))]
         public class SemanticTokensWorkspaceCapability : ICapability
         {
             /// <summary>
-            /// Whether the client implementation supports a refresh request send from
-            /// the server to the client. This is useful if a server detects a project
-            /// wide configuration change which requires a re-calculation of all semantic
-            /// tokens provided by the server issuing the request.
+            /// Whether the client implementation supports a refresh request sent from
+            /// the server to the client.
+            /// 
+            /// Note that this event is global and will force the client to refresh all
+            /// semantic tokens currently shown. It should be used with absolute care
+            /// and is useful for situation where a server for example detect a project
+            /// wide change that requires such a calculation.
             /// </summary>
             [Optional]
             public bool RefreshSupport { get; set; }

--- a/src/Protocol/Features/Workspace/DidChangeConfigurationFeature.cs
+++ b/src/Protocol/Features/Workspace/DidChangeConfigurationFeature.cs
@@ -26,7 +26,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
     namespace Client.Capabilities
     {
-        [CapabilityKey(nameof(ClientCapabilities.TextDocument), nameof(WorkspaceClientCapabilities.Configuration))]
+        [CapabilityKey(nameof(ClientCapabilities.Workspace), nameof(WorkspaceClientCapabilities.Configuration))]
         public partial class DidChangeConfigurationCapability : DynamicCapability
         {
         }

--- a/src/Protocol/Features/Workspace/DidChangeWatchedFilesFeature.cs
+++ b/src/Protocol/Features/Workspace/DidChangeWatchedFilesFeature.cs
@@ -36,7 +36,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
     namespace Client.Capabilities
     {
-        [CapabilityKey(nameof(ClientCapabilities.TextDocument), nameof(WorkspaceClientCapabilities.DidChangeWatchedFiles))]
+        [CapabilityKey(nameof(ClientCapabilities.Workspace), nameof(WorkspaceClientCapabilities.DidChangeWatchedFiles))]
         public partial class DidChangeWatchedFilesCapability : DynamicCapability
         {
             /// <summary>

--- a/src/Protocol/Features/Workspace/ExecuteCommandFeature.cs
+++ b/src/Protocol/Features/Workspace/ExecuteCommandFeature.cs
@@ -107,7 +107,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
     namespace Client.Capabilities
     {
-        [CapabilityKey(nameof(ClientCapabilities.TextDocument), nameof(WorkspaceClientCapabilities.ExecuteCommand))]
+        [CapabilityKey(nameof(ClientCapabilities.Workspace), nameof(WorkspaceClientCapabilities.ExecuteCommand))]
         public class ExecuteCommandCapability : DynamicCapability
         {
         }

--- a/src/Protocol/Features/Workspace/WorkspaceSymbolsFeature.cs
+++ b/src/Protocol/Features/Workspace/WorkspaceSymbolsFeature.cs
@@ -187,7 +187,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
 
     namespace Client.Capabilities
     {
-        [CapabilityKey(nameof(ClientCapabilities.TextDocument), nameof(WorkspaceClientCapabilities.Symbol))]
+        [CapabilityKey(nameof(ClientCapabilities.Workspace), nameof(WorkspaceClientCapabilities.Symbol))]
         public partial class WorkspaceSymbolCapability : DynamicCapability //
         {
             /// <summary>

--- a/src/Protocol/Models/RangeOrEditRange.cs
+++ b/src/Protocol/Models/RangeOrEditRange.cs
@@ -46,10 +46,10 @@ public partial record RangeOrEditRange
             var obj = JObject.Load(reader);
             if (obj.ContainsKey("insert"))
             {
-                return new RangeOrEditRange(obj.ToObject<EditRange>());
+                return new RangeOrEditRange(obj.ToObject<EditRange>(serializer));
             }
 
-            return new RangeOrEditRange(obj.ToObject<Range>());
+            return new RangeOrEditRange(obj.ToObject<Range>(serializer));
         }
 
         public override bool CanRead => true;

--- a/src/Protocol/Serialization/Converters/CommandOrCodeActionConverter.cs
+++ b/src/Protocol/Serialization/Converters/CommandOrCodeActionConverter.cs
@@ -31,10 +31,10 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
             var command = result["command"];
             if (command?.Type == JTokenType.String)
             {
-                return new CommandOrCodeAction(result.ToObject<Command>());
+                return new CommandOrCodeAction(result.ToObject<Command>(serializer));
             }
 
-            return new CommandOrCodeAction(result.ToObject<CodeAction>());
+            return new CommandOrCodeAction(result.ToObject<CodeAction>(serializer));
         }
 
         public override bool CanRead => true;

--- a/src/Protocol/Serialization/Converters/GlobPatternConverter.cs
+++ b/src/Protocol/Serialization/Converters/GlobPatternConverter.cs
@@ -29,7 +29,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
 
             if (reader.TokenType == JsonToken.StartObject)
             {
-                return new GlobPattern(JObject.Load(reader).ToObject<RelativePattern>());
+                return new GlobPattern(JObject.Load(reader).ToObject<RelativePattern>(serializer));
             }
 
             return new GlobPattern("");

--- a/src/Protocol/Serialization/Converters/LocationOrFileLocationConverter.cs
+++ b/src/Protocol/Serialization/Converters/LocationOrFileLocationConverter.cs
@@ -19,10 +19,10 @@ public class LocationOrFileLocationConverter : JsonConverter<LocationOrFileLocat
         var obj = JObject.Load(reader);
         if (obj.ContainsKey("range"))
         {
-            return new LocationOrFileLocation(obj.ToObject<Location>());
+            return new LocationOrFileLocation(obj.ToObject<Location>(serializer));
         }
 
-        return new LocationOrFileLocation(obj.ToObject<FileLocation>());
+        return new LocationOrFileLocation(obj.ToObject<FileLocation>(serializer));
     }
 
     public override bool CanRead => true;

--- a/src/Protocol/Serialization/Converters/LocationOrLocationLinkConverter.cs
+++ b/src/Protocol/Serialization/Converters/LocationOrLocationLinkConverter.cs
@@ -20,10 +20,10 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
             var obj = JObject.Load(reader);
             if (obj.ContainsKey("uri"))
             {
-                return new LocationOrLocationLink(obj.ToObject<Location>());
+                return new LocationOrLocationLink(obj.ToObject<Location>(serializer));
             }
 
-            return new LocationOrLocationLink(obj.ToObject<LocationLink>());
+            return new LocationOrLocationLink(obj.ToObject<LocationLink>(serializer));
         }
 
         public override bool CanRead => true;

--- a/src/Protocol/Serialization/Converters/RangeOrPlaceholderRangeConverter.cs
+++ b/src/Protocol/Serialization/Converters/RangeOrPlaceholderRangeConverter.cs
@@ -36,13 +36,13 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
             {
                 var obj = (JToken.ReadFrom(reader) as JObject)!;
                 return obj.ContainsKey("placeholder")
-                    ? new RangeOrPlaceholderRange(obj.ToObject<PlaceholderRange>())
+                    ? new RangeOrPlaceholderRange(obj.ToObject<PlaceholderRange>(serializer))
                     : obj.ContainsKey("defaultBehavior")
                         ? new RangeOrPlaceholderRange(
-                            obj.ToObject<RenameDefaultBehavior>()
+                            obj.ToObject<RenameDefaultBehavior>(serializer)
                         )
                         : new RangeOrPlaceholderRange(
-                            obj.ToObject<Range>()
+                            obj.ToObject<Range>(serializer)
                         );
             }
 

--- a/src/Protocol/Serialization/Converters/SemanticTokensFullOrDeltaConverter.cs
+++ b/src/Protocol/Serialization/Converters/SemanticTokensFullOrDeltaConverter.cs
@@ -30,10 +30,10 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
             var obj = JObject.Load(reader);
             if (obj.ContainsKey("data"))
             {
-                return new SemanticTokensFullOrDelta(obj.ToObject<SemanticTokens>());
+                return new SemanticTokensFullOrDelta(obj.ToObject<SemanticTokens>(serializer));
             }
 
-            return new SemanticTokensFullOrDelta(obj.ToObject<SemanticTokensDelta>());
+            return new SemanticTokensFullOrDelta(obj.ToObject<SemanticTokensDelta>(serializer));
         }
 
         public override bool CanRead => true;

--- a/src/Protocol/Serialization/Converters/SemanticTokensFullOrDeltaPartialResultConverter.cs
+++ b/src/Protocol/Serialization/Converters/SemanticTokensFullOrDeltaPartialResultConverter.cs
@@ -30,10 +30,10 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
             var obj = JObject.Load(reader);
             if (obj.ContainsKey("data"))
             {
-                return new SemanticTokensFullOrDeltaPartialResult(obj.ToObject<SemanticTokensPartialResult>());
+                return new SemanticTokensFullOrDeltaPartialResult(obj.ToObject<SemanticTokensPartialResult>(serializer));
             }
 
-            return new SemanticTokensFullOrDeltaPartialResult(obj.ToObject<SemanticTokensDeltaPartialResult>());
+            return new SemanticTokensFullOrDeltaPartialResult(obj.ToObject<SemanticTokensDeltaPartialResult>(serializer));
         }
 
         public override bool CanRead => true;

--- a/src/Protocol/Serialization/Converters/SymbolInformationOrDocumentSymbolConverter.cs
+++ b/src/Protocol/Serialization/Converters/SymbolInformationOrDocumentSymbolConverter.cs
@@ -32,10 +32,10 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
             // SymbolInformation has property location, DocumentSymbol does not.
             if (result["location"] != null)
             {
-                return new SymbolInformationOrDocumentSymbol(result.ToObject<SymbolInformation>());
+                return new SymbolInformationOrDocumentSymbol(result.ToObject<SymbolInformation>(serializer));
             }
 
-            return new SymbolInformationOrDocumentSymbol(result.ToObject<DocumentSymbol>());
+            return new SymbolInformationOrDocumentSymbol(result.ToObject<DocumentSymbol>(serializer));
         }
 
         public override bool CanRead => true;

--- a/src/Protocol/Serialization/Converters/TextEditConverter.cs
+++ b/src/Protocol/Serialization/Converters/TextEditConverter.cs
@@ -31,7 +31,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
             if (result["annotationId"] is { Type: JTokenType.String } annotation)
             {
                 edit = new AnnotatedTextEdit() {
-                    AnnotationId = annotation.ToObject<ChangeAnnotationIdentifier>()
+                    AnnotationId = annotation.ToObject<ChangeAnnotationIdentifier>(serializer)
                 };
             }
             else
@@ -41,7 +41,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
 
             if (result["range"] is { Type: JTokenType.Object } range)
             {
-                edit = edit with { Range = range.ToObject<Range>()};
+                edit = edit with { Range = range.ToObject<Range>(serializer)};
             }
 
             if (result["newText"] is { Type: JTokenType.String } newText)

--- a/src/Protocol/Serialization/Converters/TextEditOrInsertReplaceEditConverter.cs
+++ b/src/Protocol/Serialization/Converters/TextEditOrInsertReplaceEditConverter.cs
@@ -31,10 +31,10 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
             var command = result["insert"];
             if (command?.Type == JTokenType.String)
             {
-                return new TextEditOrInsertReplaceEdit(result.ToObject<InsertReplaceEdit>());
+                return new TextEditOrInsertReplaceEdit(result.ToObject<InsertReplaceEdit>(serializer));
             }
 
-            return new TextEditOrInsertReplaceEdit(result.ToObject<TextEdit>());
+            return new TextEditOrInsertReplaceEdit(result.ToObject<TextEdit>(serializer));
         }
 
         public override bool CanRead => true;

--- a/src/Protocol/Serialization/Converters/ValueTupleContractResolver.cs
+++ b/src/Protocol/Serialization/Converters/ValueTupleContractResolver.cs
@@ -11,7 +11,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
         public override (T1, T2) ReadJson(JsonReader reader, Type objectType, (T1, T2) existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
             var a = JArray.Load(reader);
-            return ( a.ToObject<T1>(), a.ToObject<T2>() );
+            return ( a.ToObject<T1>(serializer), a.ToObject<T2>(serializer) );
         }
     }
 }

--- a/src/Protocol/Serialization/Converters/WorkspaceEditDocumentChangeConverter.cs
+++ b/src/Protocol/Serialization/Converters/WorkspaceEditDocumentChangeConverter.cs
@@ -26,17 +26,17 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
                 switch (kind)
                 {
                     case "create":
-                        return new WorkspaceEditDocumentChange(obj.ToObject<CreateFile>());
+                        return new WorkspaceEditDocumentChange(obj.ToObject<CreateFile>(serializer));
                     case "rename":
-                        return new WorkspaceEditDocumentChange(obj.ToObject<RenameFile>());
+                        return new WorkspaceEditDocumentChange(obj.ToObject<RenameFile>(serializer));
                     case "delete":
-                        return new WorkspaceEditDocumentChange(obj.ToObject<DeleteFile>());
+                        return new WorkspaceEditDocumentChange(obj.ToObject<DeleteFile>(serializer));
                     default:
                         throw new NotSupportedException("Object with " + kind + " is not supported");
                 }
             }
 
-            return new WorkspaceEditDocumentChange(obj.ToObject<TextDocumentEdit>());
+            return new WorkspaceEditDocumentChange(obj.ToObject<TextDocumentEdit>(serializer));
         }
 
         public override bool CanRead => true;

--- a/src/Protocol/Serialization/Converters/WorkspaceFolderOrUriConverter.cs
+++ b/src/Protocol/Serialization/Converters/WorkspaceFolderOrUriConverter.cs
@@ -32,10 +32,10 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Serialization.Converters
                 var obj = JObject.Load(reader);
                 if (obj.ContainsKey("name"))
                 {
-                    return new WorkspaceFolderOrUri(obj.ToObject<WorkspaceFolder>());
+                    return new WorkspaceFolderOrUri(obj.ToObject<WorkspaceFolder>(serializer));
                 }
 
-                return new WorkspaceFolderOrUri(obj.ToObject<DocumentUri>());
+                return new WorkspaceFolderOrUri(obj.ToObject<DocumentUri>(serializer));
             }
 
             return new WorkspaceFolderOrUri("");

--- a/src/Protocol/WorkspaceNames.cs
+++ b/src/Protocol/WorkspaceNames.cs
@@ -22,5 +22,6 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         public const string InlineValueRefresh = "workspace/inlineValue/refresh";
         public const string DiagnosticRefresh = "workspace/diagnostic/refresh";
         public const string Diagnostics = "workspace/diagnostic";
+        public const string InlayHintRefresh = "workspace/inlayHint/refresh";
     }
 }

--- a/src/Server/LanguageServer.cs
+++ b/src/Server/LanguageServer.cs
@@ -419,7 +419,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server
                 {
                     if (request.Capabilities.SelectToken(group.Key) is JObject capabilityData)
                     {
-                        var capability = capabilityData.ToObject(capabilityType) as ICapability;
+                        var capability = capabilityData.ToObject(capabilityType, _serializer.JsonSerializer) as ICapability;
                         _supportedCapabilities.Add(capability!);
                     }
                 }

--- a/test/Generation.Tests/LspFeatureTests.cs
+++ b/test/Generation.Tests/LspFeatureTests.cs
@@ -358,7 +358,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Test
                     if (reader.TokenType == JsonToken.StartArray)
                     {
                         var result = JArray.Load(reader);
-                        return new StringOrOutlayHintLabelParts(result.ToObject<Container<OutlayHintLabelPart>>());
+                        return new StringOrOutlayHintLabelParts(result.ToObject<Container<OutlayHintLabelPart>>(serializer));
                     }
 
                     if (reader.TokenType == JsonToken.String)

--- a/test/Generation.Tests/snapshots/LspFeatureTests.Supports_Params_Type_As_Source.00AssemblyCapabilityKeys.verified.cs
+++ b/test/Generation.Tests/snapshots/LspFeatureTests.Supports_Params_Type_As_Source.00AssemblyCapabilityKeys.verified.cs
@@ -13,4 +13,4 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 using System.Diagnostics;
 
-[assembly: AssemblyCapabilityKey(typeof(OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities.WorkspaceSymbolCapability), nameof(ClientCapabilities.TextDocument), nameof(WorkspaceClientCapabilities.Symbol))]
+[assembly: AssemblyCapabilityKey(typeof(OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities.WorkspaceSymbolCapability), nameof(ClientCapabilities.Workspace), nameof(WorkspaceClientCapabilities.Symbol))]

--- a/test/Lsp.Integration.Tests/ExtensionTests.cs
+++ b/test/Lsp.Integration.Tests/ExtensionTests.cs
@@ -7,6 +7,7 @@ using Lsp.Integration.Tests.Fixtures;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Testing;
 using OmniSharp.Extensions.LanguageProtocol.Testing;
 using OmniSharp.Extensions.LanguageServer.Client;
@@ -67,12 +68,14 @@ namespace Lsp.Integration.Tests
             );
 
             {
-                var capability = client.ClientSettings.Capabilities!.Workspace!.ExtensionData["unitTests"].ToObject<UnitTestCapability>();
+                var capability = client.ClientSettings.Capabilities!.Workspace!.ExtensionData["unitTests"]
+                    .ToObject<UnitTestCapability>(client.Services.GetRequiredService<ISerializer>().JsonSerializer);
                 capability.Property.Should().Be("Abcd");
             }
 
             {
-                var capability = server.ClientSettings.Capabilities!.Workspace!.ExtensionData["unitTests"].ToObject<UnitTestCapability>();
+                var capability = server.ClientSettings.Capabilities!.Workspace!.ExtensionData["unitTests"]
+                    .ToObject<UnitTestCapability>(server.Services.GetRequiredService<ISerializer>().JsonSerializer);
                 capability.Property.Should().Be("Abcd");
             }
 
@@ -127,7 +130,8 @@ namespace Lsp.Integration.Tests
             );
 
             {
-                var capability = server.ClientSettings.Capabilities!.Workspace!.ExtensionData["unitTests"].ToObject<UnitTestCapability>();
+                var capability = server.ClientSettings.Capabilities!.Workspace!.ExtensionData["unitTests"]
+                    .ToObject<UnitTestCapability>(server.Services.GetRequiredService<ISerializer>().JsonSerializer);
                 capability.Property.Should().Be("Abcd");
             }
 
@@ -175,14 +179,16 @@ namespace Lsp.Integration.Tests
             );
 
             {
-                var capability = server.ClientSettings.Capabilities!.Workspace!.ExtensionData["unitTests"].ToObject<UnitTestCapability>();
+                var capability = server.ClientSettings.Capabilities!.Workspace!.ExtensionData["unitTests"]
+                    .ToObject<UnitTestCapability>(server.Services.GetRequiredService<ISerializer>().JsonSerializer);
                 capability.Property.Should().Be("Abcd");
             }
 
             {
                 server.ServerSettings.Capabilities.ExtensionData["unitTestDiscovery"].Should().NotBeNull();
                 server.ServerSettings.Capabilities.ExtensionData["unitTestDiscovery"]
-                      .ToObject<UnitTestRegistrationOptions.StaticOptions>().SupportsDebugging.Should().BeTrue();
+                      .ToObject<UnitTestRegistrationOptions.StaticOptions>(server.Services.GetRequiredService<ISerializer>().JsonSerializer)
+                      .SupportsDebugging.Should().BeTrue();
             }
 
             {


### PR DESCRIPTION
Fixes some issue found while trying to implement the InlayHint handler (https://github.com/OmniSharp/omnisharp-roslyn/pull/2566). Verified with these changes that the O# LSP will connect to VS Code and InlayHints are provided.

- Pass serializer when calling JObject.ToObject

The various custom converters are not available unless we pass along the LSPSerializer.JsonSerializer. This was causing deserialization issues when reading the client capabilities.

- Fix up registration options and capabilities

InlayHint client capability was missing. Workspace capabilities were incorrectly attached to TextDocumentClientCapabilities. Several Workspace capabilities were keyed off TextDocument.