### PR TITLE
Add npm to CI build

### DIFF
--- a/.build/Build.cs
+++ b/.build/Build.cs
@@ -49,8 +49,7 @@ public sealed partial class Solution : NukeBuild,
                                   .DependsOn(Restore)
                                   .DependsOn(Build)
                                   .DependsOn(Test)
-                                  .DependsOn(Pack)
-                                  .DependsOn(TestVscodeTestExtension);
+                                  .DependsOn(Pack);
 
     public Target Build => _ => _.Inherit<ICanBuildWithDotNetCore>(x => x.CoreBuild);
 
@@ -69,7 +68,7 @@ public sealed partial class Solution : NukeBuild,
             NpmTasks.NpmCi(s => s
                 .SetProcessWorkingDirectory(VscodeTestExtensionProjectDirectory)));
 
-    public Target TestVscodeTestExtension => _ => _
+    public Target TestVscodeExtension => _ => _
         .DependsOn(NpmInstall)
         .Executes(() =>
             NpmTasks.NpmRun(s => s

--- a/.build/Solution.cs
+++ b/.build/Solution.cs
@@ -102,10 +102,32 @@ public partial class Solution
             .ConfigureStep<CheckoutStep>(step => step.FetchDepth = 0)
             .UseDotNetSdks("3.1", "7.0")
             .AddNuGetCache()
+            .AddVscodeExtensionTests()
             .PublishLogs<Solution>()
             .PublishArtifacts<Solution>()
             .FailFast = false;
 
         return configuration;
+    }
+}
+
+public static class Extensions
+{
+    public static RocketSurgeonsGithubActionsJob AddVscodeExtensionTests(this RocketSurgeonsGithubActionsJob job)
+    {
+        return job
+            .AddStep(new RunStep("Npm install") {
+                Run = string.Join(Environment.NewLine, [
+                    "cd vscode-testextension",
+                    "npm ci",
+                    "cd .."
+                ])
+            })
+            .AddStep(new UsingStep("Vscode extension tests") {
+                Uses = "coactions/setup-xvfb@v1",
+                With = {
+                    ["run"] = "npm run test",
+                    ["working-directory"] = "vscode-testextension"
+            }});
     }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,14 @@ jobs:
         id: test
         run: |
           dotnet nuke Test TriggerCodeCoverageReports GenerateCodeCoverageReportCobertura GenerateCodeCoverageBadges GenerateCodeCoverageSummary GenerateCodeCoverageReport --skip
+      - name: Npm Install
+        id: npmInstall
+        run: |
+          dotnet nuke NpmInstall --skip
+      - name: 🚦 Test Vscode Test Extension
+        id: testVscodeTestExtension
+        run: |
+          dotnet nuke TestVscodeTestExtension --skip
       - name: 📦 Pack
         id: pack
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,18 +113,20 @@ jobs:
         id: test
         run: |
           dotnet nuke Test TriggerCodeCoverageReports GenerateCodeCoverageReportCobertura GenerateCodeCoverageBadges GenerateCodeCoverageSummary GenerateCodeCoverageReport --skip
-      - name: Npm Install
-        id: npmInstall
-        run: |
-          dotnet nuke NpmInstall --skip
-      - name: 🚦 Test Vscode Test Extension
-        id: testVscodeTestExtension
-        run: |
-          dotnet nuke TestVscodeTestExtension --skip
       - name: 📦 Pack
         id: pack
         run: |
           dotnet nuke Pack --skip
+      - name: Npm install
+        run: |
+          cd vscode-testextension
+          npm ci
+          cd ..
+      - name: 🚦 Vscode extension tests
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: 'npm run test'
+          working-directory: 'vscode-testextension'
       - name: 🏺 Publish coverage data
         if: always()
         uses: actions/upload-artifact@v3

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -103,9 +103,11 @@
               "GenerateCodeCoverageReportCobertura",
               "GenerateCodeCoverageSummary",
               "GenerateReadme",
+              "NpmInstall",
               "Pack",
               "Restore",
               "Test",
+              "TestVscodeTestExtension",
               "Trigger_Code_Coverage_Reports",
               "TriggerCodeCoverageReports"
             ]
@@ -140,9 +142,11 @@
               "GenerateCodeCoverageReportCobertura",
               "GenerateCodeCoverageSummary",
               "GenerateReadme",
+              "NpmInstall",
               "Pack",
               "Restore",
               "Test",
+              "TestVscodeTestExtension",
               "Trigger_Code_Coverage_Reports",
               "TriggerCodeCoverageReports"
             ]

--- a/vscode-testextension/package-lock.json
+++ b/vscode-testextension/package-lock.json
@@ -21,6 +21,7 @@
                 "glob": "^10.3.10",
                 "mocha": "^10.2.0",
                 "source-map-support": "^0.5.21",
+                "tmp-promise": "^3.0.3",
                 "typescript": "^5.2.2"
             },
             "engines": {
@@ -1194,6 +1195,53 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rimraf/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rimraf/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -1369,6 +1417,27 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/tmp": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+            "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+            "dev": true,
+            "dependencies": {
+                "rimraf": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8.17.0"
+            }
+        },
+        "node_modules/tmp-promise": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+            "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+            "dev": true,
+            "dependencies": {
+                "tmp": "^0.2.0"
             }
         },
         "node_modules/to-regex-range": {

--- a/vscode-testextension/package.json
+++ b/vscode-testextension/package.json
@@ -55,6 +55,7 @@
         "glob": "^10.3.10",
         "mocha": "^10.2.0",
         "source-map-support": "^0.5.21",
+        "tmp-promise": "^3.0.3",
         "typescript": "^5.2.2"
     },
     "dependencies": {


### PR DESCRIPTION
Should avoid introducing breaking changes in the `vscode-testextension` project and int its `npm` dependencies in particular.