### PR TITLE
Fix ProcessScheduler memleak

### DIFF
--- a/src/JsonRpc/ProcessScheduler.cs
+++ b/src/JsonRpc/ProcessScheduler.cs
@@ -34,7 +34,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
                     var observableQueue =
                         new BehaviorSubject<(RequestProcessType type, ReplaySubject<IObservable<Unit>> observer, Subject<Unit>? contentModifiedSource)>(
-                            ( RequestProcessType.Serial, new ReplaySubject<IObservable<Unit>>(int.MaxValue, Scheduler.Immediate), supportContentModified ? new Subject<Unit>() : null )
+                            ( RequestProcessType.Serial, new ReplaySubject<IObservable<Unit>>(10, Scheduler.Immediate), supportContentModified ? new Subject<Unit>() : null )
                         );
 
                     cd.Add(
@@ -52,7 +52,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
                                     logger.LogDebug("Completing existing request process type {Type}", observableQueue.Value.type);
                                     observableQueue.Value.observer.OnCompleted();
-                                    observableQueue.OnNext(( item.type, new ReplaySubject<IObservable<Unit>>(int.MaxValue, Scheduler.Immediate), supportContentModified ? new Subject<Unit>() : null ));
+                                    observableQueue.OnNext(( item.type, new ReplaySubject<IObservable<Unit>>(10, Scheduler.Immediate), supportContentModified ? new Subject<Unit>() : null ));
                                 }
 
                                 logger.LogDebug("Queueing {Type}:{Name} request for processing", item.type, item.name);


### PR DESCRIPTION
Reducing the int.MaxValue here to an arbitrary low int value seems to alleviate the suspected memory leak described in https://github.com/OmniSharp/csharp-language-server-protocol/issues/1037 

Hoping this PR can serve as the start of a conversation about what might be a more proper solution.