### PR TITLE
Fix NotebookSelector type

### DIFF
--- a/src/Protocol/Features/Document/NotebookDocumentSyncFeature.cs
+++ b/src/Protocol/Features/Document/NotebookDocumentSyncFeature.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
@@ -734,7 +734,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             /// <summary>
             /// The notebooks to be synced
             /// </summary>
-            NotebookSelector NotebookSelector { get; set; }
+            Container<NotebookSelector> NotebookSelector { get; set; }
         }
 
         /// <summary>
@@ -761,7 +761,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             /// value is provided it matches against the
             /// notebook type. '*' matches every notebook.
             /// </summary>
-            public NotebookSelector NotebookSelector { get; set; }
+            public Container<NotebookSelector> NotebookSelector { get; set; }
 
             /// <summary>
             /// Whether save notification should be forwarded to

--- a/src/Server/Matchers/NotebookDocumentMatcher.cs
+++ b/src/Server/Matchers/NotebookDocumentMatcher.cs
@@ -101,14 +101,15 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Matchers
                 var registrationOptions = descriptor.RegistrationOptions as INotebookDocumentRegistrationOptions;
 
                 _logger.LogTrace("Registration options {OptionsName}", registrationOptions?.GetType().FullName);
-                _logger.LogTrace("Document Selector {NotebookDocumentSelector}", registrationOptions?.NotebookSelector?.ToString() ?? string.Empty);
-                if (registrationOptions?.NotebookSelector is null || registrationOptions.NotebookSelector.IsMatch(attributes))
+                var selector = registrationOptions?.NotebookSelector?.FirstOrDefault(s => s.IsMatch(attributes));
+                _logger.LogTrace("Document Selector {NotebookDocumentSelector}", selector?.ToString());
+                if (registrationOptions?.NotebookSelector is null || selector is not null)
                 {
                     _logger.LogTrace(
                         "Handler Selected: {Handler} {Id} via {NotebookDocumentSelector} (targeting {HandlerInterface})",
                         descriptor.ImplementationType.FullName,
                         descriptor.Handler is ICanBeIdentifiedHandler h ? h.Id.ToString() : string.Empty,
-                        registrationOptions?.NotebookSelector?.ToString(),
+                        selector?.ToString(),
                         descriptor.HandlerType.FullName
                     );
                     yield return descriptor;


### PR DESCRIPTION
Fixes #1066

The `NotebookSelector` type is an array type.
See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notebookDocumentSyncOptions