### PR TITLE
Update Mediatr to 9.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,17 +9,17 @@
     <PackageVersion Include="Rocket.Surgery.MSBuild.SourceLink" Version="1.1.2" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
-    <!-- Samples -->
-    <ItemGroup>
-        <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
-        <PackageVersion Include="Serilog.Sinks.Debug" Version="2.0.0" />
-        <PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-        <PackageVersion Include="System.IO" Version="4.3.0" />
-        <PackageVersion Include="System.Runtime.Handles" Version="4.3.0" />
-        <PackageVersion Include="System.Text.Encoding" Version="4.3.0" />
-        <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-        <PackageVersion Include="System.Threading.Tasks" Version="4.3.0" />
-    </ItemGroup>
+  <!-- Samples -->
+  <ItemGroup>
+    <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Debug" Version="2.0.0" />
+    <PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageVersion Include="System.IO" Version="4.3.0" />
+    <PackageVersion Include="System.Runtime.Handles" Version="4.3.0" />
+    <PackageVersion Include="System.Text.Encoding" Version="4.3.0" />
+    <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+    <PackageVersion Include="System.Threading.Tasks" Version="4.3.0" />
+  </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="GitVersion.Tool" Version="5.12.0" />
     <PackageVersion Include="JetBrains.ReSharper.CommandLineTools" Version="2023.2.2" />
@@ -53,7 +53,7 @@
     <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageVersion Include="System.Threading.Channels" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.0" />
-    <PackageVersion Include="MediatR" Version="8.1.0" />
+    <PackageVersion Include="MediatR" Version="9.0.0" />
     <PackageVersion Include="Bogus" Version="34.0.2" />
     <PackageVersion Include="Snapper" Version="2.4.0" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/Directory.Packages.supports.props
+++ b/Directory.Packages.supports.props
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project>
-    <ItemGroup
-        Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' or '$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net472'"
-    >
-        <!-- Lower bound for most target frameworks -->
-        <PackageVersion Update="Microsoft.Extensions.Logging" Version="2.2.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
+    <!-- Lower bound for most target frameworks -->
+    <PackageVersion Update="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageVersion Update="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
     <PackageVersion Update="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageVersion Update="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
     <PackageVersion Update="Microsoft.Extensions.Options" Version="2.2.0" />
     <PackageVersion Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
-        <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    </ItemGroup>
+    <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Versions 10.x-11.x dropped netstandard2.0 support. Version 12.x requries some deep changes due to how IRequest was redefined.