### PR TITLE
Add ICapability to ShowMessageRequestClientCapabilities. Fixes #1117

### DIFF
--- a/src/Protocol/Features/Window/ShowMessageRequestFeature.cs
+++ b/src/Protocol/Features/Window/ShowMessageRequestFeature.cs
@@ -75,7 +75,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         /// @since 3.16.0
         /// </summary>
         [CapabilityKey(nameof(ClientCapabilities.Window), nameof(WindowClientCapabilities.ShowMessage))]
-        public class ShowMessageRequestClientCapabilities
+        public class ShowMessageRequestClientCapabilities : ICapability
         {
             /// <summary>
             /// Capabilities specific to the `MessageActionItem` type.


### PR DESCRIPTION
Fixes #1117 by adding the interface `ICapability` which should allow it to be used by the `LanguageClientOptions.WithCapability` method.