### PR TITLE
Upgrade MediatR version to 12.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,9 +136,9 @@ jobs:
           working-directory: 'vscode-testextension'
       - name: 🏺 Publish coverage data
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: 'coverage'
+          name: 'coverage-${{ matrix.os }}'
           path: 'coverage/'
       - name: 🐿 Publish Coverage
         if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.user.login != 'renovate[bot]' && github.event.pull_request.user.login != 'dependabot[bot]')
@@ -147,26 +147,26 @@ jobs:
           name: 'actions-${{ matrix.os }}'
       - name: 🏺 Publish logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: 'logs'
+          name: 'logs-${{ matrix.os }}'
           path: 'artifacts/logs/'
       - name: 🏺 Publish test data
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: 'test data'
+          name: 'test data-${{ matrix.os }}'
           path: 'artifacts/test/'
       - name: 🏺 Publish NuGet Packages
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: 'nuget'
+          name: 'nuget-${{ matrix.os }}'
           path: 'artifacts/nuget/'
       - name: 🏺 Publish Documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: 'docs'
+          name: 'docs-${{ matrix.os }}'
           path: 'artifacts/docs/'
   Publish:
     needs:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -23,9 +23,11 @@ jobs:
         with:
           nuget-version: '5.x'
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: nuget
+          path: nuget
+          pattern: nuget-*
+          merge-multiple: true
 
       - name: nuget.org
         # continue-on-error: true

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,7 @@
     <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageVersion Include="System.Threading.Channels" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.1" />
-    <PackageVersion Include="MediatR" Version="9.0.0" />
+    <PackageVersion Include="MediatR" Version="12.4.1" />
     <PackageVersion Include="Bogus" Version="35.6.1" />
     <PackageVersion Include="Snapper" Version="2.4.1" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/src/Dap.Protocol/AbstractHandlers.cs
+++ b/src/Dap.Protocol/AbstractHandlers.cs
@@ -15,7 +15,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
         }
 
         public abstract class Notification<TParams> : IJsonRpcRequestHandler<TParams>
-            where TParams : IRequest
+            where TParams : IRequest<Unit>
         {
             public abstract Task<Unit> Handle(TParams request, CancellationToken cancellationToken);
         }

--- a/src/Dap.Protocol/Feature/Events/BreakpointFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/BreakpointFeature.cs
@@ -83,7 +83,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
         [GenerateHandler]
         [GenerateHandlerMethods]
         [GenerateRequestMethods]
-        public record BreakpointEvent : IRequest
+        public record BreakpointEvent : IRequest<Unit>
         {
             /// <summary>
             /// The reason for the event.

--- a/src/Dap.Protocol/Feature/Events/CapabilitiesFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/CapabilitiesFeature.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
 using OmniSharp.Extensions.JsonRpc;
@@ -238,7 +238,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
         [GenerateHandler]
         [GenerateHandlerMethods]
         [GenerateRequestMethods]
-        public record CapabilitiesEvent : IRequest
+        public record CapabilitiesEvent : IRequest<Unit>
         {
             /// <summary>
             /// The set of updated capabilities.

--- a/src/Dap.Protocol/Feature/Events/ContinuedFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/ContinuedFeature.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Generation;
@@ -15,7 +15,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
             GenerateHandlerMethods,
             GenerateRequestMethods
         ]
-        public record ContinuedEvent : IRequest
+        public record ContinuedEvent : IRequest<Unit>
         {
             /// <summary>
             /// The thread which was continued.

--- a/src/Dap.Protocol/Feature/Events/ExitedFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/ExitedFeature.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Generation;
 
@@ -14,7 +14,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
             GenerateHandlerMethods,
             GenerateRequestMethods
         ]
-        public record ExitedEvent : IRequest
+        public record ExitedEvent : IRequest<Unit>
         {
             /// <summary>
             /// The exit code returned from the debuggee.

--- a/src/Dap.Protocol/Feature/Events/InitializedFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/InitializedFeature.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Generation;
 
@@ -12,6 +12,6 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
         [GenerateHandler(Name = "DebugAdapterInitialized")]
         [GenerateHandlerMethods]
         [GenerateRequestMethods]
-        public record InitializedEvent : IRequest;
+        public record InitializedEvent : IRequest<Unit>;
     }
 }

--- a/src/Dap.Protocol/Feature/Events/InvalidatedFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/InvalidatedFeature.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
 using OmniSharp.Extensions.JsonRpc;
@@ -16,7 +16,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
             GenerateHandlerMethods,
             GenerateRequestMethods
         ]
-        public record InvalidatedEvent : IRequest
+        public record InvalidatedEvent : IRequest<Unit>
         {
             /// <summary>
             /// Optional set of logical areas that got invalidated. This property has a

--- a/src/Dap.Protocol/Feature/Events/LoadedSourceFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/LoadedSourceFeature.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Generation;
@@ -13,7 +13,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
         [GenerateHandler]
         [GenerateHandlerMethods]
         [GenerateRequestMethods]
-        public record LoadedSourceEvent : IRequest
+        public record LoadedSourceEvent : IRequest<Unit>
         {
             /// <summary>
             /// The reason for the event.

--- a/src/Dap.Protocol/Feature/Events/ModuleFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/ModuleFeature.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Generation;
@@ -13,7 +13,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
         [GenerateHandler]
         [GenerateHandlerMethods]
         [GenerateRequestMethods]
-        public record ModuleEvent : IRequest
+        public record ModuleEvent : IRequest<Unit>
         {
             /// <summary>
             /// The reason for the event.

--- a/src/Dap.Protocol/Feature/Events/OutputFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/OutputFeature.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
@@ -15,7 +15,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
         [GenerateHandler]
         [GenerateHandlerMethods]
         [GenerateRequestMethods]
-        public record OutputEvent : IRequest
+        public record OutputEvent : IRequest<Unit>
         {
             /// <summary>
             /// The output category. If not specified, 'console' is assumed.

--- a/src/Dap.Protocol/Feature/Events/ProcessFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/ProcessFeature.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Generation;
@@ -13,7 +13,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
         [GenerateHandler]
         [GenerateHandlerMethods]
         [GenerateRequestMethods]
-        public record ProcessEvent : IRequest
+        public record ProcessEvent : IRequest<Unit>
         {
             /// <summary>
             /// The logical name of the process. This is usually the full path to process's executable file. Example: /home/example/myproj/program.js.

--- a/src/Dap.Protocol/Feature/Events/ProgressFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/ProgressFeature.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
 using OmniSharp.Extensions.JsonRpc;
@@ -28,7 +28,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
         [GenerateHandler]
         [GenerateHandlerMethods]
         [GenerateRequestMethods]
-        public record ProgressStartEvent : ProgressEvent, IRequest
+        public record ProgressStartEvent : ProgressEvent, IRequest<Unit>
         {
             /// <summary>
             /// Mandatory (short) title of the progress reporting. Shown in the UI to describe the long running operation.
@@ -63,7 +63,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
         [GenerateHandler]
         [GenerateHandlerMethods]
         [GenerateRequestMethods]
-        public record ProgressUpdateEvent : ProgressEvent, IRequest
+        public record ProgressUpdateEvent : ProgressEvent, IRequest<Unit>
         {
             /// <summary>
             /// Optional progress percentage to display (value range: 0 to 100). If omitted no percentage will be shown.
@@ -77,6 +77,6 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
         [GenerateHandler]
         [GenerateHandlerMethods]
         [GenerateRequestMethods]
-        public record ProgressEndEvent : ProgressEvent, IRequest;
+        public record ProgressEndEvent : ProgressEvent, IRequest<Unit>;
     }
 }

--- a/src/Dap.Protocol/Feature/Events/StoppedFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/StoppedFeature.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Generation;
@@ -15,7 +15,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
             GenerateHandlerMethods,
             GenerateRequestMethods
         ]
-        public record StoppedEvent : IRequest
+        public record StoppedEvent : IRequest<Unit>
         {
             /// <summary>
             /// The reason for the event.

--- a/src/Dap.Protocol/Feature/Events/TerminatedFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/TerminatedFeature.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Serialization;
@@ -17,7 +17,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
             GenerateHandlerMethods,
             GenerateRequestMethods
         ]
-        public record TerminatedEvent : IRequest
+        public record TerminatedEvent : IRequest<Unit>
         {
             /// <summary>
             /// A debug adapter may set 'restart' to true (or to an arbitrary object) to request that the front end restarts the session.

--- a/src/Dap.Protocol/Feature/Events/ThreadFeature.cs
+++ b/src/Dap.Protocol/Feature/Events/ThreadFeature.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.JsonRpc.Generation;
 
@@ -14,7 +14,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
             GenerateHandlerMethods,
             GenerateRequestMethods
         ]
-        public record ThreadEvent : IRequest
+        public record ThreadEvent : IRequest<Unit>
         {
             /// <summary>
             /// The reason for the event.

--- a/src/Dap.Protocol/IDebugAdapterProtocolProxy.cs
+++ b/src/Dap.Protocol/IDebugAdapterProtocolProxy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,7 +39,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Protocol
             _responseRouter.SendNotification(method, @params);
         }
 
-        public void SendNotification(IRequest request)
+        public void SendNotification(IRequest<Unit> request)
         {
             _responseRouter.SendNotification(request);
         }

--- a/src/Dap.Shared/DapResponseRouter.cs
+++ b/src/Dap.Shared/DapResponseRouter.cs
@@ -49,7 +49,7 @@ namespace OmniSharp.Extensions.DebugAdapter.Shared
             );
         }
 
-        public void SendNotification(IRequest @params)
+        public void SendNotification(IRequest<Unit> @params)
         {
             SendNotification(GetMethodName(@params.GetType()), @params);
         }

--- a/src/JsonRpc.Testing/SettlePipeline.cs
+++ b/src/JsonRpc.Testing/SettlePipeline.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 
@@ -11,7 +11,7 @@ namespace OmniSharp.Extensions.JsonRpc.Testing
 
         public SettlePipeline(IRequestSettler settler) => _settler = settler;
 
-        async Task<TR> IPipelineBehavior<T, TR>.Handle(T request, CancellationToken cancellationToken, RequestHandlerDelegate<TR> next)
+        async Task<TR> IPipelineBehavior<T, TR>.Handle(T request, RequestHandlerDelegate<TR> next, CancellationToken cancellationToken)
         {
             _settler.OnStartRequest();
             try

--- a/src/JsonRpc/CancelParams.cs
+++ b/src/JsonRpc/CancelParams.cs
@@ -3,7 +3,7 @@ using MediatR;
 namespace OmniSharp.Extensions.JsonRpc
 {
     [Method(JsonRpcNames.CancelRequest)]
-    public partial class CancelParams : IRequest
+    public partial class CancelParams : IRequest<Unit>
     {
         /// <summary>
         /// The request id to cancel.

--- a/src/JsonRpc/DefaultJsonRpcServerFacade.cs
+++ b/src/JsonRpc/DefaultJsonRpcServerFacade.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,7 +30,7 @@ namespace OmniSharp.Extensions.JsonRpc
             _responseRouter.SendNotification(method, @params);
         }
 
-        public void SendNotification(IRequest request)
+        public void SendNotification(IRequest<Unit> request)
         {
             _responseRouter.SendNotification(request);
         }

--- a/src/JsonRpc/DelegatingHandlers.cs
+++ b/src/JsonRpc/DelegatingHandlers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -22,7 +22,7 @@ namespace OmniSharp.Extensions.JsonRpc
 
         public class Request<TParams> :
             IJsonRpcRequestHandler<TParams>
-            where TParams : IRequest
+            where TParams : IRequest<Unit>
         {
             private readonly Func<TParams, CancellationToken, Task> _handler;
 
@@ -37,7 +37,7 @@ namespace OmniSharp.Extensions.JsonRpc
         }
 
         public class Notification<TParams> : IJsonRpcRequestHandler<TParams>
-            where TParams : IRequest
+            where TParams : IRequest<Unit>
         {
             private readonly Func<TParams, CancellationToken, Task> _handler;
 

--- a/src/JsonRpc/DelegatingNotification.cs
+++ b/src/JsonRpc/DelegatingNotification.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json.Linq;
 
 namespace OmniSharp.Extensions.JsonRpc
 {
-    public class DelegatingNotification<T> : IRequest
+    public class DelegatingNotification<T> : IRequest<Unit>
     {
         public DelegatingNotification(object value) => Value = typeof(T) == typeof(Unit) || value is Unit ? new JObject() : JToken.FromObject(value);
 

--- a/src/JsonRpc/IJsonRpcHandler.cs
+++ b/src/JsonRpc/IJsonRpcHandler.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 
 namespace OmniSharp.Extensions.JsonRpc
 {
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.JsonRpc
     /// <summary>
     ///  Marker interface for source generation to properly know that this IRequest is a real request and not a notification
     /// </summary>
-    public interface IJsonRpcRequest : IRequest
+    public interface IJsonRpcRequest : IRequest<Unit>
     {
 
     }

--- a/src/JsonRpc/IJsonRpcNotificationHandler.cs
+++ b/src/JsonRpc/IJsonRpcNotificationHandler.cs
@@ -2,8 +2,8 @@ using MediatR;
 
 namespace OmniSharp.Extensions.JsonRpc
 {
-    public interface IJsonRpcNotificationHandler<in TNotification> : IRequestHandler<TNotification>, IJsonRpcHandler
-        where TNotification : IRequest
+    public interface IJsonRpcNotificationHandler<in TNotification> : IRequestHandler<TNotification, Unit>, IJsonRpcHandler
+        where TNotification : IRequest<Unit>
     {
     }
 }

--- a/src/JsonRpc/IJsonRpcRequestHandler.cs
+++ b/src/JsonRpc/IJsonRpcRequestHandler.cs
@@ -24,8 +24,8 @@ namespace OmniSharp.Extensions.JsonRpc
     ///
     /// </summary>
     /// <typeparam name="TRequest"></typeparam>
-    public interface IJsonRpcRequestHandler<in TRequest> : IRequestHandler<TRequest>, IJsonRpcHandler
-        where TRequest : IRequest
+    public interface IJsonRpcRequestHandler<in TRequest> : IRequestHandler<TRequest, Unit>, IJsonRpcHandler
+        where TRequest : IRequest<Unit>
     {
     }
 }

--- a/src/JsonRpc/IResponseRouter.cs
+++ b/src/JsonRpc/IResponseRouter.cs
@@ -10,7 +10,7 @@ namespace OmniSharp.Extensions.JsonRpc
     {
         void SendNotification(string method);
         void SendNotification<T>(string method, T @params);
-        void SendNotification(IRequest request);
+        void SendNotification(IRequest<Unit> request);
         IResponseRouterReturns SendRequest<T>(string method, T @params);
         IResponseRouterReturns SendRequest(string method);
         Task<TResponse> SendRequest<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken);

--- a/src/JsonRpc/JsonRpcServerBase.cs
+++ b/src/JsonRpc/JsonRpcServerBase.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -27,7 +27,7 @@ namespace OmniSharp.Extensions.JsonRpc
             ResponseRouter.SendNotification(method, @params);
         }
 
-        public void SendNotification(IRequest @params)
+        public void SendNotification(IRequest<Unit> @params)
         {
             ResponseRouter.SendNotification(@params);
         }

--- a/src/JsonRpc/JsonRpcServerServiceCollectionExtensions.cs
+++ b/src/JsonRpc/JsonRpcServerServiceCollectionExtensions.cs
@@ -100,7 +100,8 @@ namespace OmniSharp.Extensions.JsonRpc
         {
             container.RegisterMany(new[] { typeof(IMediator).GetAssembly() }, Registrator.Interfaces, Reuse.ScopedOrSingleton);
             container.RegisterMany<RequestContext>(Reuse.Scoped);
-            container.RegisterDelegate<ServiceFactory>(context => context.Resolve, Reuse.ScopedOrSingleton);
+            // Select the desired constructor
+            container.Register<IMediator, Mediator>(made: Made.Of(() => new Mediator(Arg.Of<IServiceProvider>())));
             container.Register(typeof(IRequestHandler<,>), typeof(RequestHandler<,>));
             container.Register(typeof(IRequestHandler<,>), typeof(RequestHandlerDecorator<,>), setup: Setup.Decorator);
 

--- a/src/JsonRpc/NoopResponseRouter.cs
+++ b/src/JsonRpc/NoopResponseRouter.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -25,7 +25,7 @@ namespace OmniSharp.Extensions.JsonRpc
         {
         }
 
-        public void SendNotification(IRequest request)
+        public void SendNotification(IRequest<Unit> request)
         {
         }
 

--- a/src/JsonRpc/NotificationHandler.cs
+++ b/src/JsonRpc/NotificationHandler.cs
@@ -8,15 +8,15 @@ namespace OmniSharp.Extensions.JsonRpc
     public static class NotificationHandler
     {
         public static DelegatingHandlers.Notification<TParams> For<TParams>(Action<TParams, CancellationToken> handler)
-            where TParams : IRequest => new(HandlerAdapter.Adapt(handler));
+            where TParams : IRequest<Unit> => new(HandlerAdapter.Adapt(handler));
 
         public static DelegatingHandlers.Notification<TParams> For<TParams>(Func<TParams, CancellationToken, Task> handler)
-            where TParams : IRequest => new(HandlerAdapter.Adapt(handler));
+            where TParams : IRequest<Unit> => new(HandlerAdapter.Adapt(handler));
 
         public static DelegatingHandlers.Notification<TParams> For<TParams>(Action<TParams> handler)
-            where TParams : IRequest => new(HandlerAdapter.Adapt(handler));
+            where TParams : IRequest<Unit> => new(HandlerAdapter.Adapt(handler));
 
         public static DelegatingHandlers.Notification<TParams> For<TParams>(Func<TParams, Task> handler)
-            where TParams : IRequest => new(HandlerAdapter.Adapt(handler));
+            where TParams : IRequest<Unit> => new(HandlerAdapter.Adapt(handler));
     }
 }

--- a/src/JsonRpc/RequestHandler.cs
+++ b/src/JsonRpc/RequestHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -14,9 +14,9 @@ namespace OmniSharp.Extensions.JsonRpc
             where TParams : IRequest<TResult> => new(HandlerAdapter.Adapt(handler));
 
         public static DelegatingHandlers.Request<TParams> For<TParams>(Func<TParams, CancellationToken, Task> handler)
-            where TParams : IRequest => new(HandlerAdapter.Adapt(handler));
+            where TParams : IRequest<Unit> => new(HandlerAdapter.Adapt(handler));
 
         public static DelegatingHandlers.Request<TParams> For<TParams>(Func<TParams, Task> handler)
-            where TParams : IRequest => new(HandlerAdapter.Adapt(handler));
+            where TParams : IRequest<Unit> => new(HandlerAdapter.Adapt(handler));
     }
 }

--- a/src/JsonRpc/RequestRouterBase.cs
+++ b/src/JsonRpc/RequestRouterBase.cs
@@ -216,7 +216,7 @@ namespace OmniSharp.Extensions.JsonRpc
         }
 
         private static Task SendRequest<T>(IMediator mediator, T request, CancellationToken token)
-            where T : IRequest =>
+            where T : IRequest<Unit> =>
             mediator.Send(request, token);
 
         private static Task<TResponse> SendRequest<T, TResponse>(IMediator mediator, T request, CancellationToken token)

--- a/src/JsonRpc/ResponseRouter.cs
+++ b/src/JsonRpc/ResponseRouter.cs
@@ -48,7 +48,7 @@ namespace OmniSharp.Extensions.JsonRpc
             );
         }
 
-        public void SendNotification(IRequest @params)
+        public void SendNotification(IRequest<Unit> @params)
         {
             SendNotification(GetMethodName(@params.GetType()), @params);
         }

--- a/src/Protocol/AbstractHandlers.Notification.cs
+++ b/src/Protocol/AbstractHandlers.Notification.cs
@@ -17,7 +17,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
     public static partial class AbstractHandlers
     {
         public abstract class Notification<TParams> : IJsonRpcRequestHandler<TParams>
-            where TParams : IRequest
+            where TParams : IRequest<Unit>
         {
             public abstract Task<Unit> Handle(TParams request, CancellationToken cancellationToken);
         }
@@ -25,7 +25,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         public abstract class Notification<TParams, TRegistrationOptions, TCapability> :
             Base<TRegistrationOptions, TCapability>,
             IJsonRpcRequestHandler<TParams>
-            where TParams : IRequest
+            where TParams : IRequest<Unit>
             where TRegistrationOptions : class, new()
             where TCapability : ICapability
         {
@@ -35,7 +35,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         public abstract class Notification<TParams, TRegistrationOptions> :
             Base<TRegistrationOptions>,
             IJsonRpcRequestHandler<TParams>
-            where TParams : IRequest
+            where TParams : IRequest<Unit>
             where TRegistrationOptions : class, new()
         {
             public abstract Task<Unit> Handle(TParams request, CancellationToken cancellationToken);
@@ -44,7 +44,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         public abstract class NotificationCapability<TParams, TCapability> :
             BaseCapability<TCapability>,
             IJsonRpcRequestHandler<TParams>
-            where TParams : IRequest
+            where TParams : IRequest<Unit>
             where TCapability : ICapability
         {
             public abstract Task<Unit> Handle(TParams request, CancellationToken cancellationToken);

--- a/src/Protocol/Client/WorkDone/LanguageClientWorkDoneManager.cs
+++ b/src/Protocol/Client/WorkDone/LanguageClientWorkDoneManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Reactive.Disposables;
 using System.Threading;

--- a/src/Protocol/Features/Client/LogTraceFeature.cs
+++ b/src/Protocol/Features/Client/LogTraceFeature.cs
@@ -14,7 +14,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.Client")]
         [GenerateHandlerMethods]
         [GenerateRequestMethods(typeof(IClientLanguageServer), typeof(ILanguageServer))]
-        public record LogTraceParams : IRequest
+        public record LogTraceParams : IRequest<Unit>
         {
             /// <summary>
             /// The message to be logged.

--- a/src/Protocol/Features/Document/CodeLensFeature.cs
+++ b/src/Protocol/Features/Document/CodeLensFeature.cs
@@ -118,7 +118,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateHandlerMethods]
         [GenerateRequestMethods(typeof(IWorkspaceLanguageServer), typeof(ILanguageServer))]
         [Capability(typeof(CodeLensWorkspaceClientCapabilities))]
-        public partial record CodeLensRefreshParams : IRequest;
+        public partial record CodeLensRefreshParams : IRequest<Unit>;
     }
 
     namespace Client.Capabilities

--- a/src/Protocol/Features/Document/DiagnosticsFeature.cs
+++ b/src/Protocol/Features/Document/DiagnosticsFeature.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using MediatR;
 using Newtonsoft.Json;
 using OmniSharp.Extensions.JsonRpc;
@@ -73,7 +73,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateHandlerMethods]
         [GenerateRequestMethods(typeof(IWorkspaceLanguageServer), typeof(ILanguageServer))]
         [Capability(typeof(CodeLensWorkspaceClientCapabilities))]
-        public partial record DiagnosticRefreshParams : IRequest;
+        public partial record DiagnosticRefreshParams : IRequest<Unit>;
 
         public interface IDiagnosticReport
         {

--- a/src/Protocol/Features/Document/InlayHintFeature.cs
+++ b/src/Protocol/Features/Document/InlayHintFeature.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using MediatR;
 using Newtonsoft.Json;
@@ -272,7 +272,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateHandlerMethods]
         [GenerateRequestMethods(typeof(IWorkspaceLanguageServer), typeof(ILanguageServer))]
         [Capability(typeof(InlayHintWorkspaceClientCapabilities))]
-        public partial record InlayHintRefreshParams : IRequest;
+        public partial record InlayHintRefreshParams : IRequest<Unit>;
 
         [GenerateRegistrationOptions(nameof(ServerCapabilities.InlayHintProvider))]
         [RegistrationOptionsConverter(typeof(InlayHintRegistrationOptionsConverter))]

--- a/src/Protocol/Features/Document/InlineValueFeature.cs
+++ b/src/Protocol/Features/Document/InlineValueFeature.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using MediatR;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -70,7 +70,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateHandlerMethods]
         [GenerateRequestMethods(typeof(IWorkspaceLanguageServer), typeof(ILanguageServer))]
         [Capability(typeof(InlineValueWorkspaceClientCapabilities))]
-        public partial record InlineValueRefreshParams : IRequest;
+        public partial record InlineValueRefreshParams : IRequest<Unit>;
 
         [JsonConverter(typeof(Converter))]
         public abstract partial record InlineValueBase

--- a/src/Protocol/Features/Document/NotebookDocumentSyncFeature.cs
+++ b/src/Protocol/Features/Document/NotebookDocumentSyncFeature.cs
@@ -37,7 +37,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateRequestMethods(typeof(INotebookDocumentLanguageClient), typeof(ILanguageClient))]
         [RegistrationOptions(typeof(NotebookDocumentSyncOptions))]
         [Capability(typeof(NotebookDocumentSyncClientCapabilities))]
-        public partial class DidOpenNotebookDocumentParams : IRequest
+        public partial class DidOpenNotebookDocumentParams : IRequest<Unit>
         {
             /// <summary>
             /// The notebook document that got opened.
@@ -63,7 +63,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateRequestMethods(typeof(INotebookDocumentLanguageClient), typeof(ILanguageClient))]
         [RegistrationOptions(typeof(NotebookDocumentSyncOptions))]
         [Capability(typeof(NotebookDocumentSyncClientCapabilities))]
-        public partial record DidChangeNotebookDocumentParams : IRequest
+        public partial record DidChangeNotebookDocumentParams : IRequest<Unit>
         {
             /// <summary>
             /// The notebook document that did change. The version number points
@@ -94,7 +94,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateRequestMethods(typeof(INotebookDocumentLanguageClient), typeof(ILanguageClient))]
         [RegistrationOptions(typeof(NotebookDocumentSyncOptions))]
         [Capability(typeof(NotebookDocumentSyncClientCapabilities))]
-        public partial class DidSaveNotebookDocumentParams : INotebookDocumentIdentifierParams, IRequest
+        public partial class DidSaveNotebookDocumentParams : INotebookDocumentIdentifierParams, IRequest<Unit>
         {
             /// <summary>
             /// The notebook document that got saved.
@@ -109,7 +109,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateRequestMethods(typeof(INotebookDocumentLanguageClient), typeof(ILanguageClient))]
         [RegistrationOptions(typeof(NotebookDocumentSyncOptions))]
         [Capability(typeof(NotebookDocumentSyncClientCapabilities))]
-        public partial class DidCloseNotebookDocumentParams : INotebookDocumentIdentifierParams, IRequest
+        public partial class DidCloseNotebookDocumentParams : INotebookDocumentIdentifierParams, IRequest<Unit>
         {
             /// <summary>
             /// The notebook document that got closed.

--- a/src/Protocol/Features/Document/PublishDiagnosticsFeature.cs
+++ b/src/Protocol/Features/Document/PublishDiagnosticsFeature.cs
@@ -20,7 +20,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             GenerateRequestMethods(typeof(ITextDocumentLanguageServer), typeof(ILanguageServer))
         ]
         [Capability(typeof(PublishDiagnosticsCapability))]
-        public record PublishDiagnosticsParams : IRequest
+        public record PublishDiagnosticsParams : IRequest<Unit>
         {
             /// <summary>
             /// The URI for which diagnostic information is reported.

--- a/src/Protocol/Features/Document/SemanticTokensFeature.cs
+++ b/src/Protocol/Features/Document/SemanticTokensFeature.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -99,7 +99,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateHandlerMethods]
         [GenerateRequestMethods(typeof(IWorkspaceLanguageServer), typeof(ILanguageServer))]
         [Capability(typeof(SemanticTokensWorkspaceCapability))]
-        public partial record SemanticTokensRefreshParams : IRequest;
+        public partial record SemanticTokensRefreshParams : IRequest<Unit>;
 
         public interface ISemanticTokenResult
         {

--- a/src/Protocol/Features/Document/TextDocumentSyncFeature.cs
+++ b/src/Protocol/Features/Document/TextDocumentSyncFeature.cs
@@ -30,7 +30,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateRequestMethods(typeof(ITextDocumentLanguageClient), typeof(ILanguageClient))]
         [RegistrationOptions(typeof(TextDocumentChangeRegistrationOptions))]
         [Capability(typeof(TextSynchronizationCapability))]
-        public partial record DidChangeTextDocumentParams : IRequest
+        public partial record DidChangeTextDocumentParams : IRequest<Unit>
         {
             /// <summary>
             /// The document that did change. The version number points
@@ -111,7 +111,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateRequestMethods(typeof(ITextDocumentLanguageClient), typeof(ILanguageClient))]
         [RegistrationOptions(typeof(TextDocumentOpenRegistrationOptions))]
         [Capability(typeof(TextSynchronizationCapability))]
-        public partial class DidOpenTextDocumentParams : IRequest
+        public partial class DidOpenTextDocumentParams : IRequest<Unit>
         {
             /// <summary>
             /// The document that was opened.
@@ -131,7 +131,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateRequestMethods(typeof(ITextDocumentLanguageClient), typeof(ILanguageClient))]
         [RegistrationOptions(typeof(TextDocumentCloseRegistrationOptions))]
         [Capability(typeof(TextSynchronizationCapability))]
-        public partial class DidCloseTextDocumentParams : ITextDocumentIdentifierParams, IRequest
+        public partial class DidCloseTextDocumentParams : ITextDocumentIdentifierParams, IRequest<Unit>
         {
             /// <summary>
             /// The document that was closed.
@@ -151,7 +151,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateRequestMethods(typeof(ITextDocumentLanguageClient), typeof(ILanguageClient))]
         [RegistrationOptions(typeof(TextDocumentSaveRegistrationOptions))]
         [Capability(typeof(TextSynchronizationCapability))]
-        public partial class DidSaveTextDocumentParams : ITextDocumentIdentifierParams, IRequest
+        public partial class DidSaveTextDocumentParams : ITextDocumentIdentifierParams, IRequest<Unit>
         {
             /// <summary>
             /// The document that was saved.
@@ -515,7 +515,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateRequestMethods(typeof(ITextDocumentLanguageClient), typeof(ILanguageClient))]
         [RegistrationOptions(typeof(TextDocumenWillSaveRegistrationOptions))]
         [Capability(typeof(TextSynchronizationCapability))]
-        public partial class WillSaveTextDocumentParams : IRequest
+        public partial class WillSaveTextDocumentParams : IRequest<Unit>
         {
             /// <summary>
             /// The document that will be saved.

--- a/src/Protocol/Features/FileOperationsFeature.cs
+++ b/src/Protocol/Features/FileOperationsFeature.cs
@@ -48,7 +48,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateRequestMethods(typeof(IWorkspaceLanguageClient), typeof(ILanguageClient))]
         [RegistrationOptions(typeof(DidCreateFilesRegistrationOptions))]
         [Capability(typeof(FileOperationsWorkspaceClientCapabilities))]
-        public partial record DidCreateFilesParams : FileOperationsParams<FileCreate>, IRequest
+        public partial record DidCreateFilesParams : FileOperationsParams<FileCreate>, IRequest<Unit>
         {
             public static implicit operator WillCreateFilesParams(DidCreateFilesParams @params)
             {
@@ -83,7 +83,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateRequestMethods(typeof(IWorkspaceLanguageClient), typeof(ILanguageClient))]
         [RegistrationOptions(typeof(DidRenameFilesRegistrationOptions))]
         [Capability(typeof(FileOperationsWorkspaceClientCapabilities))]
-        public partial record DidRenameFilesParams : RenameFilesOperationParams, IRequest
+        public partial record DidRenameFilesParams : RenameFilesOperationParams, IRequest<Unit>
         {
             public static implicit operator WillRenameFilesParams(DidRenameFilesParams @params)
             {
@@ -146,7 +146,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateRequestMethods(typeof(IWorkspaceLanguageClient), typeof(ILanguageClient))]
         [RegistrationOptions(typeof(DidDeleteFilesRegistrationOptions))]
         [Capability(typeof(FileOperationsWorkspaceClientCapabilities))]
-        public partial record DidDeleteFilesParams : FileOperationsParams<FileDelete>, IRequest
+        public partial record DidDeleteFilesParams : FileOperationsParams<FileDelete>, IRequest<Unit>
         {
             public static implicit operator WillDeleteFilesParams(DidDeleteFilesParams @params)
             {

--- a/src/Protocol/Features/General/ExitFeature.cs
+++ b/src/Protocol/Features/General/ExitFeature.cs
@@ -12,7 +12,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [Serial]
         [Method(GeneralNames.Exit, Direction.ClientToServer)]
         [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.General"), GenerateHandlerMethods, GenerateRequestMethods(typeof(ILanguageClient))]
-        public partial record ExitParams : IRequest
+        public partial record ExitParams : IRequest<Unit>
         {
             public static ExitParams Instance { get; } = new ExitParams();
         }

--- a/src/Protocol/Features/General/InitializedFeature.cs
+++ b/src/Protocol/Features/General/InitializedFeature.cs
@@ -14,6 +14,6 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.General", Name = "LanguageProtocolInitialized")]
         [GenerateHandlerMethods(typeof(ILanguageServerRegistry))]
         [GenerateRequestMethods(typeof(ILanguageClient))]
-        public partial record InitializedParams : IRequest;
+        public partial record InitializedParams : IRequest<Unit>;
     }
 }

--- a/src/Protocol/Features/General/ShutdownFeature.cs
+++ b/src/Protocol/Features/General/ShutdownFeature.cs
@@ -14,7 +14,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [Serial]
         [Method(GeneralNames.Shutdown, Direction.ClientToServer)]
         [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.General"), GenerateHandlerMethods, GenerateRequestMethods(typeof(ILanguageClient))]
-        public partial record ShutdownParams : IRequest
+        public partial record ShutdownParams : IRequest<Unit>
         {
             public static ShutdownParams Instance { get; } = new();
         }

--- a/src/Protocol/Features/ProgressFeature.cs
+++ b/src/Protocol/Features/ProgressFeature.cs
@@ -24,7 +24,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol")]
         [GenerateHandlerMethods]
         [GenerateRequestMethods(typeof(IGeneralLanguageClient), typeof(ILanguageClient), typeof(IGeneralLanguageServer), typeof(ILanguageServer))]
-        public record ProgressParams : IRequest
+        public record ProgressParams : IRequest<Unit>
         {
             public static ProgressParams Create<T>(ProgressToken token, T value, JsonSerializer jsonSerializer)
             {

--- a/src/Protocol/Features/Server/SetTraceFeature.cs
+++ b/src/Protocol/Features/Server/SetTraceFeature.cs
@@ -11,7 +11,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [Parallel]
         [Method(GeneralNames.SetTrace, Direction.ClientToServer)]
         [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.Server"), GenerateHandlerMethods, GenerateRequestMethods(typeof(IClientLanguageClient), typeof(ILanguageClient))]
-        public record SetTraceParams : IRequest
+        public record SetTraceParams : IRequest<Unit>
         {
             /// <summary>
             /// The new value that should be assigned to the trace setting.

--- a/src/Protocol/Features/Window/LogMessageFeature.cs
+++ b/src/Protocol/Features/Window/LogMessageFeature.cs
@@ -14,7 +14,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.Window")]
         [GenerateHandlerMethods]
         [GenerateRequestMethods(typeof(IWindowLanguageServer), typeof(ILanguageServer))]
-        public record LogMessageParams : IRequest
+        public record LogMessageParams : IRequest<Unit>
         {
             /// <summary>
             /// The message type. See {@link MessageType}

--- a/src/Protocol/Features/Window/ShowMessageFeature.cs
+++ b/src/Protocol/Features/Window/ShowMessageFeature.cs
@@ -17,7 +17,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.Window")]
         [GenerateHandlerMethods]
         [GenerateRequestMethods(typeof(IWindowLanguageServer), typeof(ILanguageServer))]
-        public record ShowMessageParams : IRequest
+        public record ShowMessageParams : IRequest<Unit>
         {
             /// <summary>
             /// The message type. See {@link MessageType}.

--- a/src/Protocol/Features/Window/TelemetryEventFeature.cs
+++ b/src/Protocol/Features/Window/TelemetryEventFeature.cs
@@ -17,7 +17,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             GenerateHandlerMethods,
             GenerateRequestMethods(typeof(IWindowLanguageServer), typeof(ILanguageServer))
         ]
-        public record TelemetryEventParams : IRequest
+        public record TelemetryEventParams : IRequest<Unit>
         {
             [JsonExtensionData] public IDictionary<string, object> ExtensionData { get; init; } = new Dictionary<string, object>();
         }

--- a/src/Protocol/Features/Window/WorkDoneProgressFeature.cs
+++ b/src/Protocol/Features/Window/WorkDoneProgressFeature.cs
@@ -15,7 +15,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [Method(WindowNames.WorkDoneProgressCreate, Direction.ServerToClient)]
         [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.Window"), GenerateHandlerMethods,
          GenerateRequestMethods(typeof(IWindowLanguageServer), typeof(ILanguageServer))]
-        public partial record WorkDoneProgressCreateParams : IRequest
+        public partial record WorkDoneProgressCreateParams : IRequest<Unit>
         {
             /// <summary>
             /// The token to be used to report progress.
@@ -27,7 +27,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [Method(WindowNames.WorkDoneProgressCancel, Direction.ClientToServer)]
         [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.Window"), GenerateHandlerMethods,
          GenerateRequestMethods(typeof(IWindowLanguageClient), typeof(ILanguageClient))]
-        public partial record WorkDoneProgressCancelParams : IRequest
+        public partial record WorkDoneProgressCancelParams : IRequest<Unit>
         {
             /// <summary>
             /// The token to be used to report progress.

--- a/src/Protocol/Features/Workspace/DidChangeConfigurationFeature.cs
+++ b/src/Protocol/Features/Workspace/DidChangeConfigurationFeature.cs
@@ -15,7 +15,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [Method(WorkspaceNames.DidChangeConfiguration, Direction.ClientToServer)]
         [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.Workspace"), GenerateHandlerMethods, GenerateRequestMethods(typeof(IWorkspaceLanguageClient), typeof(ILanguageClient))]
         [Capability(typeof(DidChangeConfigurationCapability))]
-        public partial record DidChangeConfigurationParams : IRequest
+        public partial record DidChangeConfigurationParams : IRequest<Unit>
         {
             /// <summary>
             /// The actual changed settings

--- a/src/Protocol/Features/Workspace/DidChangeWatchedFilesFeature.cs
+++ b/src/Protocol/Features/Workspace/DidChangeWatchedFilesFeature.cs
@@ -15,7 +15,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
         [Method(WorkspaceNames.DidChangeWatchedFiles, Direction.ClientToServer)]
         [GenerateHandler("OmniSharp.Extensions.LanguageServer.Protocol.Workspace"), GenerateHandlerMethods, GenerateRequestMethods(typeof(IWorkspaceLanguageClient), typeof(ILanguageClient))]
         [RegistrationOptions(typeof(DidChangeWatchedFilesRegistrationOptions)), Capability(typeof(DidChangeWatchedFilesCapability))]
-        public partial record DidChangeWatchedFilesParams : IRequest
+        public partial record DidChangeWatchedFilesParams : IRequest<Unit>
         {
             /// <summary>
             /// The actual file events.

--- a/src/Protocol/Features/Workspace/WorkspaceFoldersFeature.cs
+++ b/src/Protocol/Features/Workspace/WorkspaceFoldersFeature.cs
@@ -21,7 +21,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             GenerateRequestMethods(typeof(IWorkspaceLanguageClient), typeof(ILanguageClient))
         ]
         [RegistrationOptions(typeof(DidChangeWorkspaceFolderRegistrationOptions))]
-        public partial record DidChangeWorkspaceFoldersParams : IRequest
+        public partial record DidChangeWorkspaceFoldersParams : IRequest<Unit>
         {
             /// <summary>
             /// The actual workspace folder change event.

--- a/src/Protocol/LanguageProtocolDelegatingHandlers.Notification.cs
+++ b/src/Protocol/LanguageProtocolDelegatingHandlers.Notification.cs
@@ -20,7 +20,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             AbstractHandlers.Base<TRegistrationOptions, TCapability>,
             IJsonRpcNotificationHandler<TParams>,
             ICanBeIdentifiedHandler
-            where TParams : IRequest
+            where TParams : IRequest<Unit>
             where TRegistrationOptions : class, new()
             where TCapability : ICapability
         {
@@ -59,7 +59,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             AbstractHandlers.Base<TRegistrationOptions>,
             IJsonRpcNotificationHandler<TParams>,
             ICanBeIdentifiedHandler
-            where TParams : IRequest
+            where TParams : IRequest<Unit>
             where TRegistrationOptions : class, new()
         {
             private readonly Func<TParams, CancellationToken, Task> _handler;
@@ -92,7 +92,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             AbstractHandlers.BaseCapability<TCapability>,
             IJsonRpcNotificationHandler<TParams>,
             ICanBeIdentifiedHandler
-            where TParams : IRequest
+            where TParams : IRequest<Unit>
             where TCapability : ICapability
         {
             private readonly Func<TParams, TCapability, CancellationToken, Task> _handler;

--- a/src/Protocol/LanguageProtocolDelegatingHandlers.Request.cs
+++ b/src/Protocol/LanguageProtocolDelegatingHandlers.Request.cs
@@ -58,7 +58,7 @@ public static partial class LanguageProtocolDelegatingHandlers
         AbstractHandlers.Base<TRegistrationOptions, TCapability>,
         IJsonRpcRequestHandler<TParams>,
         ICanBeIdentifiedHandler
-        where TParams : IRequest
+        where TParams : IRequest<Unit>
         where TRegistrationOptions : class, new()
         where TCapability : ICapability
     {
@@ -136,7 +136,7 @@ public static partial class LanguageProtocolDelegatingHandlers
         AbstractHandlers.Base<TRegistrationOptions>,
         IJsonRpcRequestHandler<TParams>,
         ICanBeIdentifiedHandler
-        where TParams : IRequest
+        where TParams : IRequest<Unit>
         where TRegistrationOptions : class, new()
     {
         private readonly Func<TParams, CancellationToken, Task> _handler;
@@ -202,7 +202,7 @@ public static partial class LanguageProtocolDelegatingHandlers
         AbstractHandlers.BaseCapability<TCapability>,
         IJsonRpcRequestHandler<TParams>,
         ICanBeIdentifiedHandler
-        where TParams : IRequest
+        where TParams : IRequest<Unit>
         where TCapability : ICapability
     {
         private readonly Func<TParams, TCapability, CancellationToken, Task> _handler;

--- a/src/Protocol/LanguageProtocolProxy.cs
+++ b/src/Protocol/LanguageProtocolProxy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,7 +43,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol
             _responseRouter.SendNotification(method, @params);
         }
 
-        public void SendNotification(IRequest request)
+        public void SendNotification(IRequest<Unit> request)
         {
             _responseRouter.SendNotification(request);
         }

--- a/src/Server/Pipelines/ResolveCommandPipeline.cs
+++ b/src/Server/Pipelines/ResolveCommandPipeline.cs
@@ -24,7 +24,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Pipelines
             _descriptor = ( context.Descriptor as ILspHandlerDescriptor )!;
         }
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
         {
             var response = await next().ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Server/Pipelines/SemanticTokensDeltaPipeline.cs
+++ b/src/Server/Pipelines/SemanticTokensDeltaPipeline.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,7 +10,7 @@ namespace OmniSharp.Extensions.LanguageServer.Server.Pipelines
     internal class SemanticTokensDeltaPipeline<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse?>
         where TRequest : notnull
     {
-        public async Task<TResponse?> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse?> next)
+        public async Task<TResponse?> Handle(TRequest request, RequestHandlerDelegate<TResponse?> next, CancellationToken cancellationToken)
         {
             if (request is SemanticTokensParams semanticTokensParams)
             {

--- a/test/Dap.Tests/Integration/RecursiveResolutionTests.cs
+++ b/test/Dap.Tests/Integration/RecursiveResolutionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using DryIoc;
@@ -185,7 +185,7 @@ namespace Dap.Tests.Integration
         }
 
         [Method(nameof(ClassRequest))]
-        public class ClassRequest : IRequest
+        public class ClassRequest : IRequest<Unit>
         {
         }
 
@@ -204,7 +204,7 @@ namespace Dap.Tests.Integration
         }
 
         [Method(nameof(InterfaceRequest))]
-        public class InterfaceRequest : IRequest
+        public class InterfaceRequest : IRequest<Unit>
         {
         }
 

--- a/test/Generation.Tests/LspFeatureTests.cs
+++ b/test/Generation.Tests/LspFeatureTests.cs
@@ -39,7 +39,7 @@ namespace Lsp.Tests.Integration.Fixtures
         GenerateRequestMethods(typeof(ILanguageClient))
     ]
     [RegistrationOptions(typeof(UnitTestRegistrationOptions)), Capability(typeof(UnitTestCapability))]
-    public partial class UnitTest : IRequest
+    public partial class UnitTest : IRequest<Unit>
     {
         public string Name { get; set; } = null!;
     }
@@ -587,7 +587,7 @@ namespace OmniSharp.Extensions.LanguageServer.Protocol.Test
         [GenerateHandlerMethods]
         [GenerateRequestMethods(typeof(IWorkspaceLanguageServer), typeof(ILanguageServer))]
         [Capability(typeof(SubLensWorkspaceClientCapabilities))]
-        public partial record SubLensRefreshParams : IRequest;
+        public partial record SubLensRefreshParams : IRequest<Unit>;
     }
 
     namespace Client.Capabilities

--- a/test/JsonRpc.Tests/HandlerResolverTests.cs
+++ b/test/JsonRpc.Tests/HandlerResolverTests.cs
@@ -11,7 +11,7 @@ namespace JsonRpc.Tests
 {
     public class HandlerResolverTests
     {
-        public class Request : IRequest, IRequest<Response>
+        public class Request : IRequest<Unit>, IRequest<Response>
         {
         }
 
@@ -19,7 +19,7 @@ namespace JsonRpc.Tests
         {
         }
 
-        public class Notification : IRequest
+        public class Notification : IRequest<Unit>
         {
         }
 

--- a/test/JsonRpc.Tests/MediatorTestsNotificationHandler.cs
+++ b/test/JsonRpc.Tests/MediatorTestsNotificationHandler.cs
@@ -14,7 +14,7 @@ namespace JsonRpc.Tests
     public class MediatorTestsNotificationHandler : AutoTestBase
     {
         [Method("exit")]
-        public class ExitParams : IRequest
+        public class ExitParams : IRequest<Unit>
         {
         }
 

--- a/test/JsonRpc.Tests/MediatorTestsNotificationHandlerOfT.cs
+++ b/test/JsonRpc.Tests/MediatorTestsNotificationHandlerOfT.cs
@@ -21,7 +21,7 @@ namespace JsonRpc.Tests
         {
         }
 
-        public class CancelParams : IRequest
+        public class CancelParams : IRequest<Unit>
         {
             public object Id { get; set; } = null!;
         }

--- a/test/JsonRpc.Tests/MediatorTestsRequestHandlerOfTRequest.cs
+++ b/test/JsonRpc.Tests/MediatorTestsRequestHandlerOfTRequest.cs
@@ -21,7 +21,7 @@ namespace JsonRpc.Tests
         {
         }
 
-        public class ExecuteCommandParams : IRequest
+        public class ExecuteCommandParams : IRequest<Unit>
         {
             public string Command { get; set; } = null!;
         }

--- a/test/JsonRpc.Tests/RecursiveResolutionTests.cs
+++ b/test/JsonRpc.Tests/RecursiveResolutionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using DryIoc;
@@ -110,7 +110,7 @@ namespace JsonRpc.Tests
         }
 
         [Method(nameof(ClassRequest))]
-        public class ClassRequest : IRequest
+        public class ClassRequest : IRequest<Unit>
         {
         }
 
@@ -132,7 +132,7 @@ namespace JsonRpc.Tests
         }
 
         [Method(nameof(InterfaceRequest))]
-        public class InterfaceRequest : IRequest
+        public class InterfaceRequest : IRequest<Unit>
         {
         }
 

--- a/test/JsonRpc.Tests/ResponseRouterTests.cs
+++ b/test/JsonRpc.Tests/ResponseRouterTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -82,12 +82,12 @@ namespace JsonRpc.Tests
         }
 
         [Method("unit")]
-        public class UnitParams : IRequest
+        public class UnitParams : IRequest<Unit>
         {
         }
 
         [Method("notification")]
-        public class NotificationParams : IRequest
+        public class NotificationParams : IRequest<Unit>
         {
         }
     }

--- a/test/Lsp.Integration.Tests/RecursiveResolutionTests.cs
+++ b/test/Lsp.Integration.Tests/RecursiveResolutionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -348,7 +348,7 @@ namespace Lsp.Integration.Tests
         }
 
         [Method(nameof(ClassRequest))]
-        public class ClassRequest : IRequest
+        public class ClassRequest : IRequest<Unit>
         {
         }
 
@@ -370,7 +370,7 @@ namespace Lsp.Integration.Tests
         }
 
         [Method(nameof(InterfaceRequest))]
-        public class InterfaceRequest : IRequest
+        public class InterfaceRequest : IRequest<Unit>
         {
         }
 
@@ -392,7 +392,7 @@ namespace Lsp.Integration.Tests
         }
 
         [Method(nameof(NestedRequest))]
-        public class NestedRequest : IRequest
+        public class NestedRequest : IRequest<Unit>
         {
         }
 

--- a/test/Lsp.Tests/Matchers/ResolveCommandMatcherTests.cs
+++ b/test/Lsp.Tests/Matchers/ResolveCommandMatcherTests.cs
@@ -83,7 +83,7 @@ namespace Lsp.Tests.Matchers
             );
 
             // When
-            Func<Task> a = async () => await handlerMatcher.Handle(new CodeLensParams(), CancellationToken.None, () => Task.FromResult(new CodeLensContainer()));
+            Func<Task> a = async () => await handlerMatcher.Handle(new CodeLensParams(), () => Task.FromResult(new CodeLensContainer()), CancellationToken.None);
             await a.Should().NotThrowAsync();
         }
 
@@ -272,7 +272,7 @@ namespace Lsp.Tests.Matchers
             ( list is IEnumerable<ICanBeResolved> ).Should().BeTrue();
 
             // When
-            var response = await handlerMatcher.Handle(new CompletionParams(), CancellationToken.None, () => Task.FromResult(list));
+            var response = await handlerMatcher.Handle(new CompletionParams(), () => Task.FromResult(list), CancellationToken.None);
 
             // Then
             response.Should().BeEquivalentTo(list, x => x.UsingStructuralRecordEquality());
@@ -323,7 +323,7 @@ namespace Lsp.Tests.Matchers
             ( list is IEnumerable<ICanBeResolved> ).Should().BeTrue();
 
             // When
-            var response = await handlerMatcher.Handle(new CodeLensParams(), CancellationToken.None, () => Task.FromResult(list));
+            var response = await handlerMatcher.Handle(new CodeLensParams(), () => Task.FromResult(list), CancellationToken.None);
 
             // Then
             response.Should().BeEquivalentTo(list, x => x.UsingStructuralRecordEquality());
@@ -370,7 +370,7 @@ namespace Lsp.Tests.Matchers
             };
 
             // When
-            var response = await handlerMatcher.Handle(item, CancellationToken.None, () => Task.FromResult(item));
+            var response = await handlerMatcher.Handle(item, () => Task.FromResult(item), CancellationToken.None);
 
             // Then
             response.Should().BeEquivalentTo(item, x => x.UsingStructuralRecordEquality());


### PR DESCRIPTION
- Change all MediatR IRequest usages to IRequest{Unit}. MediatR doesn't use the Unit return type by default anymore. To keep similar signatures I updated all usages to IRequest{Unit}