### PR TITLE
Update dotnet tools

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,42 +1,48 @@
 {
-    "version": 1,
-    "isRoot": true,
-    "tools": {
-        "dotnet-outdated": {
-            "version": "2.11.0",
-            "commands": [
-                "dotnet-outdated"
-            ]
-        },
-        "dotnet-reportgenerator-globaltool": {
-            "version": "5.4.4",
-            "commands": [
-                "reportgenerator"
-            ]
-        },
-        "nuke.globaltool": {
-            "version": "9.0.4",
-            "commands": [
-                "nuke"
-            ]
-        },
-        "codecov.tool": {
-            "version": "1.13.0",
-            "commands": [
-                "codecov"
-            ]
-        },
-        "jetbrains.resharper.globaltools": {
-            "version": "2024.3.5",
-            "commands": [
-                "jb"
-            ]
-        },
-        "nukeeper": {
-            "version": "0.35.0",
-            "commands": [
-                "nukeeper"
-            ]
-        }
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-outdated-tool": {
+      "version": "4.6.7",
+      "commands": [
+        "dotnet-outdated"
+      ],
+      "rollForward": false
+    },
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.4.4",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": false
+    },
+    "nuke.globaltool": {
+      "version": "9.0.4",
+      "commands": [
+        "nuke"
+      ],
+      "rollForward": false
+    },
+    "codecov.tool": {
+      "version": "1.13.0",
+      "commands": [
+        "codecov"
+      ],
+      "rollForward": false
+    },
+    "jetbrains.resharper.globaltools": {
+      "version": "2024.3.5",
+      "commands": [
+        "jb"
+      ],
+      "rollForward": false
+    },
+    "nukeeper": {
+      "version": "0.35.0",
+      "commands": [
+        "nukeeper"
+      ],
+      "rollForward": false
     }
+  }
 }

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -23,13 +23,6 @@
       ],
       "rollForward": false
     },
-    "codecov.tool": {
-      "version": "1.13.0",
-      "commands": [
-        "codecov"
-      ],
-      "rollForward": false
-    },
     "jetbrains.resharper.globaltools": {
       "version": "2024.3.5",
       "commands": [

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -29,13 +29,6 @@
         "jb"
       ],
       "rollForward": false
-    },
-    "nukeeper": {
-      "version": "0.35.0",
-      "commands": [
-        "nukeeper"
-      ],
-      "rollForward": false
     }
   }
 }


### PR DESCRIPTION
Move to `dotnet-outdated-tool` as `dotnet-outdated` is obsolete and generates now some signature issues on the macos build.